### PR TITLE
feat(web-shell): add continuous history and compact turn navigation

### DIFF
--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
@@ -6,6 +6,10 @@ Phase 2A merged in [#11054](https://github.com/QwenLM/qwen-code/pull/11054);
 Phase 2B implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208),
 following the
 [historical viewport integration design](web-shell-global-turn-navigation-phase2b.md).
+The same open PR also implements the agreed Phase 3 rail and scoped frontend
+verification. See the [parent design](web-shell-global-turn-navigation.md) for
+the current delivery scope and remaining real-daemon acceptance; Phase 3 is no
+longer an unimplemented UI dependency.
 Original proposal: 2026-09-04. Builds on
 `web-shell-global-turn-navigation.md` (Phase 1 merged as #10751) and the
 page-table model of `web-shell-bounded-transcript-and-subagent-details.md`.
@@ -26,7 +30,8 @@ The [implementation plan](../../plans/2026-09-04-web-shell-global-turn-navigatio
 supersedes the proposed API names and migration sequence below. Phase 2A adds
 the headless index, isolated historical page table, reconciliation, and hooks.
 The Phase 2B design supersedes the earlier prepend-compatibility migration and
-defers only the global rail, not the minimal historical viewport, to Phase 3.
+assigns only the global rail, not the minimal historical viewport, to Phase 3;
+both are now implemented in #11208.
 The problem analysis below describes `origin/main` at `80497a74d0`, before Phase 2A.
 
 ## Problem
@@ -658,7 +663,9 @@ Provider/store unit tests (vitest + jsdom, extending the existing
 - fallback: capability-absent and ceiling-exceeded paths keep the existing
   rail behavior.
 
-Real-browser random-jump E2E remains Phase 3 with the rail UI.
+Real-browser random-jump checks have since passed with the Phase 3 rail in
+#11208 using the built frontend and deterministic daemon responses. Integrated
+browser-to-real-daemon acceptance remains a separate verification follow-up.
 
 ## Open questions
 

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
@@ -2,8 +2,10 @@
 
 ## Status
 
-Phase 2A implemented in [#11054](https://github.com/QwenLM/qwen-code/pull/11054)
-(under review); Phase 2B pending. Original proposal: 2026-09-04. Builds on
+Phase 2A merged in [#11054](https://github.com/QwenLM/qwen-code/pull/11054);
+Phase 2B proposed in the
+[historical viewport integration design](web-shell-global-turn-navigation-phase2b.md).
+Original proposal: 2026-09-04. Builds on
 `web-shell-global-turn-navigation.md` (Phase 1 merged as #10751) and the
 page-table model of `web-shell-bounded-transcript-and-subagent-details.md`.
 
@@ -21,9 +23,10 @@ same PR so the two documents stop contradicting each other.
 
 The [implementation plan](../../plans/2026-09-04-web-shell-global-turn-navigation-phase2.md)
 supersedes the proposed API names and migration sequence below. Phase 2A adds
-the headless index, isolated historical page table, reconciliation, and hooks;
-Phase 2B migrates legacy sequential pagination. The problem analysis below
-describes `origin/main` at `80497a74d0`, before Phase 2A.
+the headless index, isolated historical page table, reconciliation, and hooks.
+The Phase 2B design supersedes the earlier prepend-compatibility migration and
+defers only the global rail, not the minimal historical viewport, to Phase 3.
+The problem analysis below describes `origin/main` at `80497a74d0`, before Phase 2A.
 
 ## Problem
 

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2.md
@@ -3,7 +3,8 @@
 ## Status
 
 Phase 2A merged in [#11054](https://github.com/QwenLM/qwen-code/pull/11054);
-Phase 2B proposed in the
+Phase 2B implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208),
+following the
 [historical viewport integration design](web-shell-global-turn-navigation-phase2b.md).
 Original proposal: 2026-09-04. Builds on
 `web-shell-global-turn-navigation.md` (Phase 1 merged as #10751) and the
@@ -50,8 +51,9 @@ today:
   its completeness is coupled to transcript retention.
 
 Phase 2A builds the two stores and headless random-read API without changing
-the visible transcript. Phase 2B migrates existing sequential pagination;
-Phase 3 wires the visible random-jump UI.
+the visible transcript. Phase 2B adds a historical viewport over the same page
+table while preserving the legacy sequential path. Phase 3 wires the visible
+random-jump rail.
 
 ## Consumed contract (Phase 1, shipped)
 
@@ -197,7 +199,7 @@ as a generic transient index failure.
 ## Non-goals (Phase 3 and later)
 
 - Rail virtualization, rail selection UX, keyboard navigation, jump-to-latest
-  visual integration, and real-browser E2E.
+  visual integration, and real-browser random-jump E2E.
 - Server or SDK protocol changes. (Two known non-blocking Phase 1 follow-ups —
   ACP-path `atRecordId` length parity with the route's 200-char cap, and a
   pinning test for the two-record anchored-expansion case — are tracked

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
@@ -4,6 +4,13 @@
 
 Implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208),
 2026-09-07. Review and verification status are tracked on that PR.
+The same open PR now includes the agreed Phase 3 global rail, implemented at
+`02e975e9fa`. Its final interaction preserves ordinary upward pagination and
+adds compact ticks with hover/focus previews and distant on-demand selection;
+there is no historical snapshot toolbar. The original integration rationale
+below is superseded where it describes explicit sequential-entry controls.
+See the [parent design](web-shell-global-turn-navigation.md) for current scope
+and the distinction between completed frontend tests and real-daemon acceptance.
 Implementation started on `1a86cd6c5`. User approved the compatibility variant:
 keep `HistoricalTranscriptRange` and the legacy navigation snapshot unchanged;
 expose sequential ranges through an additional viewport snapshot/command surface
@@ -25,8 +32,9 @@ This supersedes the **Phase 2B migration and UI deferral** portions of the
 That plan proposed an atomic-prepend compatibility projection and deferred the
 historical viewport to Phase 3. Here, Phase 2B includes the minimum viewport,
 boundary controls, and scroll preservation needed to make sequential browsing
-use the bounded history cache. Phase 3 still owns the global virtualized rail,
-ordinal navigation controls, previews, and rail keyboard interaction.
+use the bounded history cache. Phase 3 owns the global virtualized rail,
+ordinal navigation controls, previews, and rail keyboard interaction; that work
+has now been delivered in the same PR with the final scrolling interaction above.
 
 ## Outcome and non-goals
 
@@ -35,7 +43,8 @@ cap, and return to the live tail. Pages and missing ranges remain distinguishabl
 background output and current approvals continue while history is visible.
 The existing loaded-only path remains available for unsupported daemons.
 
-This phase does not add a global turn rail, search, browser persistence, a new
+The Phase 2B data/viewport scope excludes the rail delivered as Phase 3 in the
+same PR. Neither phase adds search, browser persistence, a new
 daemon route, an SDK reducer rewrite, or a second navigation/ledger store.
 It does not migrate subagent detail pagination or the public read-only
 `WebShellTranscript` component. It does not promise a low-latency recovery of an
@@ -438,8 +447,12 @@ offset positioning instead of leaving a long-lived index target behind.
 The native review runner captured all 26 changed files, including five new files,
 but its ten-minute unattended run returned `completed: false`, `timedOut: true`
 and no verdict. This is not an approval. Integrated browser-to-real-HTTP-daemon
-coverage, comprehensive grouped-row/media cases and browser lifecycle races also
-remain unverified; the separate UI and signed-reader results do not cover them.
+coverage and comprehensive grouped-row/media cases remain unverified; the
+separate UI and signed-reader results do not cover them. Subsequent verification
+at `02e975e9fa` passed eight browser lifecycle scenarios for reconnect, rewind,
+branch, and late-request isolation using deterministic HTTP/SSE fixtures, plus
+105 targeted unit tests. These unit runs overlap previous totals. See the parent
+design for the tested behavior and remaining real-daemon acceptance boundary.
 
 ## Review gates and tradeoffs
 
@@ -449,10 +462,11 @@ confirm the main/split consumer map against the implementation base. If that
 requires a breaking public API or a cross-package protocol change, stop and
 re-scope rather than silently expanding this phase.
 
-The visible tradeoff is an explicit transition into a historical window instead
-of a single infinite scrollback containing both all cached ranges and the live
-tail. This limits cross-gap grouping and mutation risk. Smooth simultaneous
-multi-range rendering would require a separate gap-aware projection design.
+The final UI preserves ordinary upward scrolling and opens an isolated historical
+window when a distant rail target is selected. That window does not concatenate
+all cached ranges with the live tail. This limits cross-gap grouping and mutation
+risk. Smooth simultaneous multi-range rendering would require a separate
+gap-aware projection design.
 Long-gap recovery is memory-bounded but can require many reads; record request
 counts and latency, allow logical cancellation, and do not advertise constant-time
 recovery. Protocol optimization belongs in a separate measured follow-up.

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
@@ -1,0 +1,459 @@
+# Web Shell turn navigation Phase 2B: historical viewport integration
+
+## Status and decision
+
+Implemented locally, 2026-09-07; build and focused verification passed.
+Independent native review remains incomplete: its unattended run timed out
+after ten minutes without a verdict. Independent review is still required.
+Implementation started on `1a86cd6c5`. User approved the compatibility variant:
+keep `HistoricalTranscriptRange` and the legacy navigation snapshot unchanged;
+expose sequential ranges through an additional viewport snapshot/command surface
+over the same page table. Never synthesize turn IDs for before-record origins.
+Global baseline evidence is recorded in
+`.qwen/e2e-tests/phase2b-baseline-result.md`.
+Tracks [#10750](https://github.com/QwenLM/qwen-code/issues/10750), building on
+[#11054](https://github.com/QwenLM/qwen-code/pull/11054).
+Code observations below are pinned to `ec572f68e16c954927d20fee57a0507411c72702`.
+Implementation is based on main `1a86cd6c5`; the listed consumers were rechecked.
+
+Use **one visible contiguous historical range**, backed by the existing bounded
+page table, while the live transcript continues independently. A daemon-aware
+presentation adapter selects the visible source. Do not replace the live SDK
+store, merge historical pages into it, or concatenate unrelated cached ranges.
+
+This supersedes the **Phase 2B migration and UI deferral** portions of the
+[Phase 2 implementation plan](../../plans/2026-09-04-web-shell-global-turn-navigation-phase2.md).
+That plan proposed an atomic-prepend compatibility projection and deferred the
+historical viewport to Phase 3. Here, Phase 2B includes the minimum viewport,
+boundary controls, and scroll preservation needed to make sequential browsing
+use the bounded history cache. Phase 3 still owns the global virtualized rail,
+ordinal navigation controls, previews, and rail keyboard interaction.
+
+## Outcome and non-goals
+
+A user can load earlier history, continue in either direction beyond the cache
+cap, and return to the live tail. Pages and missing ranges remain distinguishable;
+background output and current approvals continue while history is visible.
+The existing loaded-only path remains available for unsupported daemons.
+
+This phase does not add a global turn rail, search, browser persistence, a new
+daemon route, an SDK reducer rewrite, or a second navigation/ledger store.
+It does not migrate subagent detail pagination or the public read-only
+`WebShellTranscript` component. It does not promise a low-latency recovery of an
+arbitrarily long backward-only gap.
+
+## Current code and integration constraints
+
+Paths below are relative to `packages/web-shell/client/`.
+
+| Area                                                                                | Verified behavior                                                                                       | Design consequence                                                                                   |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `App.tsx:894`, `:3188`, `:3814`                                                     | Structural live snapshots feed the outer App; `LiveMessageList` projects streaming updates separately.  | Preserve this split and live update throttling.                                                      |
+| `App.tsx:935`                                                                       | The live wrapper updates `messagesRef` and calls the host transcript callback.                          | Historical visibility must not change host callback semantics.                                       |
+| `App.tsx:4073`, `:6455`, `:6488`, `:6603`                                           | Messages/blocks also drive output associations, permissions, Todo, workflow, and task activity.         | Keep business/control consumers on live data.                                                        |
+| `hooks/useMessages.ts:70`, `:380`                                                   | Source block identity is already retained; the hook also reconciles background agents over the network. | Use the pure localized adapter for history, not a second live hook.                                  |
+| `components/MessageList.tsx:2887`, `:3263`                                          | Grouping, metrics, collapse, and the local timeline assume contiguous input.                            | Project one continuous range; do not use a synthetic message to hide a gap between unrelated ranges. |
+| `components/MessageList.tsx:3448`, `:4168`, `:4590`                                 | Session reset, virtual rows, and prepend restoration already exist.                                     | Extend their view identity and anchor contracts instead of replacing the virtualizer.                |
+| `components/MessageList.tsx:3820`, `:5130`                                          | Quiet-period reload and new-message events can enable bottom following.                                 | Historical mode must suppress both behaviors.                                                        |
+| `components/MessageList.tsx:2855`, `:5400`; `App.tsx:13094`                         | Edit/rewind uses a locally counted user-turn index.                                                     | Never enable these actions for a historical fragment.                                                |
+| `components/ChatPane.tsx:1354`                                                      | Split panes have a separate MessageList consumer and provider.                                          | Share the integration adapter, not viewport state.                                                   |
+| `components/SubagentDetail.tsx:204`; `WebShellTranscript.tsx:275`                   | Other consumers include a child session and a provider-free public renderer.                            | MessageList must remain usable without navigation context.                                           |
+| `daemon/session/DaemonSessionProvider.tsx:4277`                                     | Legacy history loads prepend into the live store and update repair checkpoints.                         | Leave this as the compatibility path; capable built-in views use page-table admission.               |
+| `daemon/session/transcript-page-table.ts:176`, `:833` in `turn-navigation-store.ts` | Page selection is available only through turn lookup; gap recovery rereads a turn anchor.               | Add viewport pinning and a non-turn bootstrap origin for sequential browsing.                        |
+
+The #11143 comparison identified useful interest in rendered identity, but the
+current `sourceBlockIds` projection already supports the first integration.
+Do not cherry-pick unused `Message.promptId` or `sourceRecordIds` fields merely
+for symmetry. Add a field only if a named consumer cannot use the existing map.
+
+## Ownership and visible source
+
+```mermaid
+flowchart LR
+    SSE[Session SSE] --> Live[Existing live transcript store]
+    Live --> Control[Permissions / Todo / tasks / host callbacks]
+    Live --> LiveProjection[Existing live message projection]
+    Reader[Current session transcript reader] --> Cache[Phase 2A page table]
+    Cache --> HistoryProjection[Pure projection of active range]
+    LiveProjection --> View[Daemon-aware viewport adapter]
+    HistoryProjection --> View
+    View --> List[Existing MessageList + boundary controls]
+```
+
+Add an internal `useTranscriptViewport` integration shared by the main live
+wrapper and `ChatPane`. It owns only presentation intent: live versus one
+historical range, a pending transition, and a scroll anchor. It must not copy
+blocks, cursor state, or page maps into another stateful cache.
+
+The live projection continues running while hidden. Historical projection is
+memoized by the active range's ordered page identities and locale; unrelated
+SSE changes must not rerun it. Project the entire contiguous range together so
+tool relationships can cross a page boundary, but never across a range boundary.
+Discard derived projections when their pages leave the cache.
+
+Historical tool projection must preserve recorded terminal status without a
+background-agent status poll. The current default pure adapter can force a
+completed background agent back to pending (`transcriptToMessages.ts:1258`).
+Add a narrow recorded-status option consumed by the historical projection while
+retaining normal tool payload/detail projection. Do not simply enable
+`safeToolProjection`: that also removes tool content and changes input/output
+projection. Other callers retain their current behavior. Recorded nonterminal
+tools are labelled as snapshot state, not as proof of a currently running task.
+
+Keep App/ChatPane live messages as the input to session-wide business logic.
+Only row-local display data, such as historical output cards, use the historical
+projection. Outputs must have an exact backing tool/record association; omit
+unmatched cards rather than associating them with a fragment's last user turn.
+Session latest-review, recap, copy-last-answer, and host callbacks stay live.
+
+The generic MessageList receives optional presentation props and callbacks.
+It must not call daemon navigation hooks. Reuse its renderer, virtualizer,
+expansion, and locate helpers. The daemon-aware wrapper renders the small
+history status/return controls; it is not a second MessageList implementation.
+
+## Entering history from the live window
+
+The current `locateOrdinal()` is insufficient for sequential pagination: it
+correctly returns a live location for an already loaded turn, and an older page
+may contain only assistant/tool records. Never invent a turn ID or fetch every
+metadata page to find a convenient navigation anchor.
+
+Add an `openBeforeLive()` command to the existing navigation store, backed by a
+provider-observed **live older boundary**. The provider supplies its exact
+persisted `beforeRecordId`, reachability, and owner-local boundary revision from
+the existing load/trim/replay events. An ID-less optimistic echo is not a boundary.
+Legacy cursor-only sessions remain on the existing history path.
+
+Reachability here means persisted records exist before the boundary. It must be
+captured before legacy capacity gating: legacy `hasMore=false` can mean the live
+window is full, not that history ended. A count/byte-saturated live window with a
+valid persisted boundary must still be able to enter the independent history
+cache. Provider repair completeness remains authoritative; an unresolved repair
+gap must be signalled explicitly, not treated as a proven contiguous live edge.
+
+The command performs this sequence:
+
+1. Capture the current client owner, chain, live boundary, and transition intent.
+2. Obtain a successful fresh index-head snapshot whose read starts after that
+   boundary capture. An older in-flight head request must be followed by a fresh
+   read. `refreshHead()` currently catches errors, so completion of its promise
+   alone is not evidence of a fresh usable snapshot.
+3. Read `{ beforeRecordId, snapshot, limit }` through that session client. Do not
+   pair a signed cursor with a snapshot or reinterpret it as a forward cursor.
+4. Validate owner, chain, response integrity, and the captured live boundary
+   revision. On trim/reload/rewind during the read, discard the result and offer
+   retry; do not silently retarget the reader to a different record.
+5. Admit the complete page under the existing historical budget. If no visible
+   block is produced but the response has more records, advance with the legal
+   backward continuation; retain cancellation/progress checks.
+6. Switch the viewport only after admission succeeds. Initially show the newer
+   edge of the preceding page with an explicit control back to the live view.
+   Existing live blocks remain unchanged.
+
+The first entry into history is an explicit view transition, not a prepend into
+the live array. The control must say that it opens earlier history. No blank
+intermediate view and no attempt to preserve the live array's scroll height
+across this source replacement. Returning to latest is always available.
+
+## Small extensions to the existing data layer
+
+### Sequential range origin and reversible gaps
+
+A sequentially opened range has a **frozen before-record origin**, whereas a
+randomly opened range has a frozen turn origin. Represent these as distinct
+origin cases, never synthetic ordinals or turn IDs. Keep turn-origin behavior
+unchanged. A before-record range has no selected navigation turn by default.
+
+Gap recovery must carry the origin plus the exact retained `afterRecordId`:
+reread either `{ atRecordId, snapshot }` or `{ beforeRecordId, snapshot }`, then
+walk backward until the retained edge is found, reusing Phase 2A's bounded
+current-response/immediate-newer-candidate algorithm. It admits the nearest
+missing page or the suffix following the exact retained record, without
+splitting a persisted record group. A before-record origin never yields a forward
+cursor by itself.
+Its newer terminal boundary is the captured live edge, not transcript end.
+
+Range origin, boundary recipes, and their strings count toward the same byte
+budget. There is no tombstone list of every evicted page. Update range types,
+request identity comparison, byte estimates, and all origin read sites together.
+`HistoricalTranscriptRange` is exported today: widening it is a public type
+change requiring maintainer/API review, not an undocumented compatibility claim.
+
+The approved compatibility implementation leaves that exported type and the old
+navigation snapshot intact. Sequential ranges are visible only through the
+additional viewport API. Both origin families share one page table and one byte/page
+budget, but overlap deduplication and cached-neighbor links stay within each
+family; the old API must never point at a hidden sequential range. Concurrent
+legacy and viewport callers can therefore retain an overlapping page twice,
+charged twice to the same budget. Viewport pins protect both families.
+
+The provider captures persisted reachability separately from legacy admission
+capacity, together with the exact before-record ID and an owner/generation guard.
+Cursor-only loads keep their existing loader. A pending legacy load or unresolved
+repair cannot supply a bootstrap boundary. If legacy loading extends live across
+a historical edge later, exact record overlap suppresses unnecessary gap recovery.
+
+### Viewport retention anchor
+
+Add a narrow `setViewportAnchor(viewportId, pageId | undefined)`
+command. Each mounted viewport has a stable local registration ID and releases
+its pin on unmount or return to live. Its caller supplies the representative
+page of the first visible content row, synchronously before starting a boundary
+load and when that row moves to another page. This extends page-table retention
+selection; it does not change the rail's logical selected turn, fetch metadata,
+or require a user prompt inside that page.
+
+Main/split providers naturally isolate pins. Multiple embedded views sharing
+one provider must not overwrite each other's pin: retain at most one reading
+anchor per mounted viewport, and exclude all registered anchor pages/ranges
+from eviction. Registration cleanup is mandatory; this is bounded by mounted
+views, not visited turns. If their pins exhaust the shared budget, report
+capacity pressure rather than evicting another visible view's reading anchor.
+
+Eviction protects the reading-anchor page and the incoming page, removes the
+opposite outer edge when possible, and restores that edge's recovery recipe.
+Do not pin every page ever seen or the entire range. A constrained window stays
+readable and reports capacity pressure; moving the reading anchor and retrying
+must make progress. An individually oversized page is terminal for that request,
+not a reason to disable navigation session-wide.
+
+### Historical view revision
+
+Expose a monotonic history revision derived from the existing reset/owner
+epochs. It changes on chain reset or owner replacement, not on normal append or
+page admission. Page/range IDs are currently reused after reset, so a session ID
+and range ID alone cannot identify the lifetime of a historical view.
+The presentation adapter uses this revision with the session and range identity
+to reset stale focus, expansion, and pending scroll operations.
+
+Viewport-originated fetches also carry that viewport's registration and current
+navigation-intent token into the store's request guard. Check it before further
+recovery reads and before cache admission, not only after the promise returns
+to React. Return-to-live, a different requested view, and unmount invalidate the
+token; ordinary scroll/pin movement does not. Existing headless callers retain
+their session/chain guards. Cancellation of one embedded viewport must not
+cancel another viewport's work or release its pin.
+
+## Boundaries and transitions
+
+| Boundary/state                              | Visible behavior                                                             | Command/ownership                                                         |
+| ------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Older/newer loadable                        | Explicit load control at that edge; no implied complete history.             | Existing `loadOlder` / `loadNewer` for the active range.                  |
+| Loading                                     | Keep current rows; disable repeated requests at that edge.                   | One in-flight request per boundary identity.                              |
+| Retryable error                             | Inline retry while keeping readable rows.                                    | Retry that boundary; do not clear unrelated metadata errors.              |
+| Page too large / partial / invalid response | Explain that the requested section is unavailable; retain the old view.      | No truncated-page success or automatic retry loop.                        |
+| Cached neighbor                             | Offer continuation into the named cached range.                              | Switch only after validating neighbor lifetime and pinning its near edge. |
+| Live boundary                               | Offer return to latest; do not append a live array to the range.             | Clear historical reading pin and resume existing live follow behavior.    |
+| End                                         | Show start/end of the frozen history where proven.                           | No more fetches in that direction.                                        |
+| Missing origin / expired snapshot           | Keep or explicitly retire the old frozen view; offer reload/retry or latest. | Never guess a new ordinal, workspace, or cursor.                          |
+
+A `live` boundary records overlap/adjacency at an earlier instant. Live trimming
+can remove that overlap. It must not be displayed as proof that current live
+rows immediately follow the historical range. To continue through that newly
+unloaded interval, capture the new live older boundary, obtain a fresh snapshot,
+and recover from that before-record origin back to the exact retained historical
+edge. Commit only if that edge still exists on the active chain; otherwise
+report invalidation. A plain "return to latest" remains an explicit jump that
+may skip the gap, not a claim that the gap was loaded.
+
+Do not auto-fetch both directions or chase a growing live tail indefinitely.
+Keep sequential edge loading coalesced; an error requires an explicit retry.
+The historical bottom is not the live bottom. Remote output updates the live
+status/return affordance without scrolling or switching the historical view.
+An explicit local send or existing "resume bottom follow" action returns to live
+before showing its optimistic prompt. Merely typing a draft does not switch.
+
+## Identity, fragments, and scrolling
+
+Use `turnId -> location.blockId -> message.sourceBlockIds -> display row` for
+future random targets. For sequential tool-only pages, use exact block/record
+identity. Persisted record identity is for lookup; message and virtual-row IDs
+remain presentation identities. One record can create several rows, so record ID
+alone is not a unique virtual key. Same-text prompts must remain distinct.
+
+For same-range continuation/eviction, capture the first visible content row and
+its pixel offset, pin its page, then restore that surviving row after layout.
+Extend the current row-source helper: it only exports source block IDs for plain
+message rows today. Every anchorable row needs a representative source, including
+compact/parallel-agent groups, collapsed turns and output rows. For an expanded
+group use the first actually visible child; for a collapsed group use its stable
+representative tool/block; output rows resolve through their exact owning turn
+or tool. A cross-page row pins that representative source's page, not every page
+in the group. Pure controls are not reading anchors. If a row has no exact source,
+use the nearest source-backed content row and make that limitation explicit.
+
+Reuse row-key restoration with this complete row-to-source/page map. If a projection
+regroups the row, resolve its exact source block to the new row. A full rematerialize
+may require record identity plus a block-role discriminator; if no exact target
+survives, report a source transition instead of jumping to similarly worded text.
+Do not rely only on scroll-height deltas: prepend and opposite-edge eviction can
+cancel each other's height changes.
+
+Separate view identity from data updates: changing source/range/revision resets
+transient scroll state, while appending within that range does not remount it.
+Carry session/view keys through split panes as well as the main view. Delay a
+target scroll until the target row exists; folded targets use the existing
+expand-then-locate path. Any later user navigation cancels pending scroll effects.
+
+Historical first/last fragments can be partial turns. They stay expanded by
+default and must not present incomplete totals as complete duration, usage, or
+final-answer summaries. A historical last row is never marked as the active live
+answer. Hide the local loaded-message timeline in historical mode for this phase;
+do not relabel a window-local count as the session-wide turn count.
+
+Historical mode disables new-user bottom-follow and the 500-block/15-second
+quiet reload. Live mode preserves them. Provider-driven repair remains enabled
+for live correctness; its owner/chain changes invalidate affected history work.
+Do not retain an extra full historical message array just to preserve a viewport
+whose pages have already been evicted or invalidated.
+
+## Interaction and lifecycle safety
+
+| Concern                              | Required behavior                                                                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Approvals / AskUser / Todo / tasks   | Remain connected to live state and reachable through the composer/current approval UI. Historical permission rows are display-only. |
+| Edit, rewind, retry-last             | Disabled on historical fragments; never pass a fragment-local turn index to session mutation.                                       |
+| Branch and turn-output mutations     | Remain disabled in the historical viewport in this phase. Stable-identity mutation UX is separate follow-up work.                   |
+| Copy, attachment, file/tool detail   | Read-only inspection remains available using exact identifiers and the same session/workspace owner. No "latest turn" fallback.     |
+| Historical background agents         | Pure projection only; do not start an extra status reconciliation loop for recorded pending tools.                                  |
+| Session/workspace/split change       | Clear viewport intent and pin; ignore old requests and scroll callbacks using owner guard, history revision, and view generation.   |
+| Same-session reconnect               | Freeze readable rows while disconnected; disable history I/O. Owner replacement or chain invalidation retires old view state.       |
+| Rewind / divergent head              | Invalidate before old rows or reused IDs can be treated as current and return to live.                                              |
+| Capability absent / indexing ceiling | Use existing live/legacy history behavior, without new navigation requests.                                                         |
+| Transient index error                | Preserve usable history; expose retry. Do not switch data sources on each temporary error.                                          |
+
+All reader commands remain **live-session-owner scoped** through the bound
+`DaemonSessionClient`. No new daemon route or workspace resolver is introduced.
+Provider, actions, normalization, attachment/detail readers, and error paths
+must preserve that owner; unknown or removed owners never fall back to primary.
+
+## Compatibility and delivery
+
+Keep public `useTranscriptHistory()` and raw transcript hooks unchanged. They
+continue to describe the legacy live-store path for existing consumers.
+Built-in main/split views use the new viewport adapter only when the navigation
+data layer and exact bootstrap boundary are ready; otherwise they use the old
+history props. Do not silently change what external hook consumers receive.
+
+Choose one pagination route when an action begins. Wait for an existing legacy
+load to settle before enabling the new route; never admit one response into both
+stores. Capability/error transitions do not reinterpret an in-flight request.
+The old provider boundary bookkeeping remains necessary for fallback and
+external consumers; removing it is not a Phase 2B acceptance criterion.
+
+Implementation is ordered in two reviewable slices, both required for Phase 2B:
+
+1. **Data-layer bridge:** sequential origin/bootstrap, viewport pinning, revision
+   visibility, live-edge gap recovery, and pure regression tests. Preserve
+   Phase 2A turn-origin tests and the legacy history contract.
+2. **Presentation integration:** shared adapter, main/split wiring, boundary
+   controls, safe historical interactions, scroll restoration, DOM and browser
+   tests. Enable the built-in capable path only when these tests pass.
+
+Do not revive #11143's flat-array ledger in parallel. Reuse a small identity
+change from that PR only when a test demonstrates a missing identity consumer.
+
+### Expected files
+
+| Files under `packages/web-shell/client/`                                     | Work                                                                                        |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `daemon/session/transcript-page-table.ts`, `turn-navigation-store.ts`, tests | Sequential origins, recovery, pinning and lifecycle revision.                               |
+| `daemon/session/DaemonSessionProvider.tsx`, tests                            | Feed exact live boundary and owner; keep normalization side-effect-free.                    |
+| Session/export barrels                                                       | Expose only the required navigation contract additions; verify generated declarations.      |
+| New `hooks/useTranscriptViewport.ts`, tests                                  | Source selection, commands, derived history projection and transition guards.               |
+| `App.tsx`, `components/ChatPane.tsx`, tests                                  | Integrate only at display boundary; preserve live business consumers.                       |
+| `components/MessageList.tsx`, tests; a small boundary component              | View mode/key, anchor reporting/restoration, edge controls and historical read-only policy. |
+| Existing locale resources                                                    | Boundary, retry, invalidation and return-to-latest labels.                                  |
+| `client/e2e/` (relative to package root)                                     | Focused browser regression spec using existing Playwright setup.                            |
+
+Also update `adapters/transcriptToMessages.ts` and its tests for recorded-status
+projection without changing live reconciliation or discarding historical tool details.
+
+No changes to `packages/core`, `packages/cli`, or `packages/sdk-typescript` are
+planned. No new library or global CSS rewrite. New controls reuse shared UI
+primitives; preserve React 18 refs, portal-root scoping, themes, and embedded use.
+
+## Acceptance and verification
+
+The execution test plan is
+`.qwen/e2e-tests/web-shell-global-turn-navigation-phase2b.md` (local artifact).
+The following requirements remain committed even when that local file is absent:
+
+- Capable live view opens the immediately preceding page, including a tool-only
+  page and a saturated live window; initial failure leaves the live view unchanged.
+- Read beyond five historical pages in both directions, move the viewport pin,
+  reverse direction, and recover exact record order without duplicates.
+- A live trim that removes the joining edge exposes and can recover the gap;
+  a frozen cursor never silently skips to the new live tail.
+- After same-range admission/eviction, the anchor row remains within 2 CSS pixels
+  of its previous offset once deterministic layout settles. Test virtual and
+  non-virtual lists, regrouping, and late media measurement separately.
+- First-visible parallel-agent, collapsed-turn and output rows resolve to an
+  exact retained page; multiple embedded viewports do not overwrite each other's
+  reading pin or leak pins after unmount.
+- Recorded completed/failed/cancelled background agents stay terminal even when
+  the selected window lacks their completion notification; details remain readable.
+- Stream, approve a live request, update Todo/tasks, and queue a prompt while
+  history is visible. Live callbacks continue; historical rows do not act live.
+- Reconnect, rewind, snapshot loss, source switch, and split-pane changes reject
+  late state/scroll updates, including reuse of the same numeric range ID.
+- Transient failures recover after retry; full/oversized windows have distinct
+  behavior. Tests must assert subsequent progress, not just an error enum.
+- No-capability, index ceiling, legacy cursor-only, subagent detail, and
+  provider-free `WebShellTranscript` remain usable.
+- Historical projections and retained page metadata remain bounded by the
+  current window, not total turns or number of previous navigation actions.
+- Only the legacy/live path schedules quiet-period transcript reload; browser
+  history does not disable provider repair or current approval handling.
+
+Before implementation, dry-run the planned baseline with the installed global
+CLI and record gaps rather than pretending the feature exists. Then verify the
+local build with focused package tests, root build/typecheck/bundle, and real
+browser runs. Mock-daemon browser tests prove UI behavior, not signed-cursor
+protocol correctness: retain separate real-reader/signed-cursor tests.
+
+The installed global CLI `0.22.2` baseline ran in an isolated daemon/browser and
+did not advertise turn navigation. Real-reader probes subsequently verified
+tool-only bootstrap, signed backward continuation, bounded bidirectional gap
+recovery, cancellation, multiple pins, and a fresh before-origin after live trim.
+Separate Chrome mock-daemon runs verified main/split viewport transitions,
+six older and two newer admissions (including equal-sized eviction windows),
+live background output, and composer approval during history. Ordinary-list
+anchor drift measured at most 0.125 CSS pixels; virtual-list drift was zero.
+Mock-browser checks do not prove signed-cursor behavior; real-reader probes do
+not prove React layout. Reports remain under `.qwen/e2e-tests/`.
+
+Final root build, typecheck and bundle passed. The broad focused run passed
+1,726 tests; after the virtual-transition fix, the affected renderer/viewport,
+store/table and build-artifact run passed 282 tests. These runs overlap and
+must not be added together. Two clean self-audit passes were completed.
+
+The committed-style Chrome regression uses 16 and 200 records per page. Both
+cases passed six older and two newer admissions with the exact source offset
+within 2 CSS pixels for four consecutive 100ms samples, followed by actual newer
+record assertions. The 200-record case caught and now covers ordinary-to-virtual
+anchor loss and delayed index recentering after subsequent user wheel input.
+Historical restoration ignores its own scroll events and uses immediate virtual
+offset positioning instead of leaving a long-lived index target behind.
+
+The native review runner captured all 26 changed files, including five new files,
+but its ten-minute unattended run returned `completed: false`, `timedOut: true`
+and no verdict. This is not an approval. Integrated browser-to-real-HTTP-daemon
+coverage, comprehensive grouped-row/media cases and browser lifecycle races also
+remain unverified; the separate UI and signed-reader results do not cover them.
+
+## Review gates and tradeoffs
+
+The decisions above are the approved defaults, not unresolved implementation
+choices. Before code lands, review the additive viewport contract and
+confirm the main/split consumer map against the implementation base. If that
+requires a breaking public API or a cross-package protocol change, stop and
+re-scope rather than silently expanding this phase.
+
+The visible tradeoff is an explicit transition into a historical window instead
+of a single infinite scrollback containing both all cached ranges and the live
+tail. This limits cross-gap grouping and mutation risk. Smooth simultaneous
+multi-range rendering would require a separate gap-aware projection design.
+Long-gap recovery is memory-bounded but can require many reads; record request
+counts and latency, allow logical cancellation, and do not advertise constant-time
+recovery. Protocol optimization belongs in a separate measured follow-up.

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase2b.md
@@ -2,9 +2,8 @@
 
 ## Status and decision
 
-Implemented locally, 2026-09-07; build and focused verification passed.
-Independent native review remains incomplete: its unattended run timed out
-after ten minutes without a verdict. Independent review is still required.
+Implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208),
+2026-09-07. Review and verification status are tracked on that PR.
 Implementation started on `1a86cd6c5`. User approved the compatibility variant:
 keep `HistoricalTranscriptRange` and the legacy navigation snapshot unchanged;
 expose sequential ranges through an additional viewport snapshot/command surface
@@ -46,20 +45,20 @@ arbitrarily long backward-only gap.
 
 Paths below are relative to `packages/web-shell/client/`.
 
-| Area                                                                                | Verified behavior                                                                                       | Design consequence                                                                                   |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `App.tsx:894`, `:3188`, `:3814`                                                     | Structural live snapshots feed the outer App; `LiveMessageList` projects streaming updates separately.  | Preserve this split and live update throttling.                                                      |
-| `App.tsx:935`                                                                       | The live wrapper updates `messagesRef` and calls the host transcript callback.                          | Historical visibility must not change host callback semantics.                                       |
-| `App.tsx:4073`, `:6455`, `:6488`, `:6603`                                           | Messages/blocks also drive output associations, permissions, Todo, workflow, and task activity.         | Keep business/control consumers on live data.                                                        |
-| `hooks/useMessages.ts:70`, `:380`                                                   | Source block identity is already retained; the hook also reconciles background agents over the network. | Use the pure localized adapter for history, not a second live hook.                                  |
-| `components/MessageList.tsx:2887`, `:3263`                                          | Grouping, metrics, collapse, and the local timeline assume contiguous input.                            | Project one continuous range; do not use a synthetic message to hide a gap between unrelated ranges. |
-| `components/MessageList.tsx:3448`, `:4168`, `:4590`                                 | Session reset, virtual rows, and prepend restoration already exist.                                     | Extend their view identity and anchor contracts instead of replacing the virtualizer.                |
-| `components/MessageList.tsx:3820`, `:5130`                                          | Quiet-period reload and new-message events can enable bottom following.                                 | Historical mode must suppress both behaviors.                                                        |
-| `components/MessageList.tsx:2855`, `:5400`; `App.tsx:13094`                         | Edit/rewind uses a locally counted user-turn index.                                                     | Never enable these actions for a historical fragment.                                                |
-| `components/ChatPane.tsx:1354`                                                      | Split panes have a separate MessageList consumer and provider.                                          | Share the integration adapter, not viewport state.                                                   |
-| `components/SubagentDetail.tsx:204`; `WebShellTranscript.tsx:275`                   | Other consumers include a child session and a provider-free public renderer.                            | MessageList must remain usable without navigation context.                                           |
-| `daemon/session/DaemonSessionProvider.tsx:4277`                                     | Legacy history loads prepend into the live store and update repair checkpoints.                         | Leave this as the compatibility path; capable built-in views use page-table admission.               |
-| `daemon/session/transcript-page-table.ts:176`, `:833` in `turn-navigation-store.ts` | Page selection is available only through turn lookup; gap recovery rereads a turn anchor.               | Add viewport pinning and a non-turn bootstrap origin for sequential browsing.                        |
+| Area                                                                                                      | Verified behavior                                                                                      | Design consequence                                                                                   |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `App.tsx:894`, `:3188`, `:3814`                                                                           | Structural live snapshots feed the outer App; `LiveMessageList` projects streaming updates separately. | Preserve this split and live update throttling.                                                      |
+| `App.tsx:935`                                                                                             | The live wrapper updates `messagesRef` and calls the host transcript callback.                         | Historical visibility must not change host callback semantics.                                       |
+| `App.tsx:4073`, `:6455`, `:6488`, `:6603`                                                                 | Messages/blocks also drive output associations, permissions, Todo, workflow, and task activity.        | Keep business/control consumers on live data.                                                        |
+| `adapters/localizedMessages.ts` (`transcriptBlocksToLocalizedMessages`); `hooks/useTranscriptViewport.ts` | The localized adapter retains source identity without live background-agent reconciliation.            | Use the pure localized adapter for history, not a second live hook.                                  |
+| `components/MessageList.tsx:2887`, `:3263`                                                                | Grouping, metrics, collapse, and the local timeline assume contiguous input.                           | Project one continuous range; do not use a synthetic message to hide a gap between unrelated ranges. |
+| `components/MessageList.tsx:3448`, `:4168`, `:4590`                                                       | Session reset, virtual rows, and prepend restoration already exist.                                    | Extend their view identity and anchor contracts instead of replacing the virtualizer.                |
+| `components/MessageList.tsx:3820`, `:5130`                                                                | Quiet-period reload and new-message events can enable bottom following.                                | Historical mode must suppress both behaviors.                                                        |
+| `components/MessageList.tsx:2855`, `:5400`; `App.tsx:13094`                                               | Edit/rewind uses a locally counted user-turn index.                                                    | Never enable these actions for a historical fragment.                                                |
+| `components/ChatPane.tsx:1354`                                                                            | Split panes have a separate MessageList consumer and provider.                                         | Share the integration adapter, not viewport state.                                                   |
+| `components/artifacts/SubagentDetail.tsx:204`; `components/WebShellTranscript.tsx:275`                    | Other consumers include a child session and a provider-free public renderer.                           | MessageList must remain usable without navigation context.                                           |
+| `daemon/session/DaemonSessionProvider.tsx:4277`                                                           | Legacy history loads prepend into the live store and update repair checkpoints.                        | Leave this as the compatibility path; capable built-in views use page-table admission.               |
+| `daemon/session/transcript-page-table.ts:176`, `:833` in `turn-navigation-store.ts`                       | Page selection is available only through turn lookup; gap recovery rereads a turn anchor.              | Add viewport pinning and a non-turn bootstrap origin for sequential browsing.                        |
 
 The #11143 comparison identified useful interest in rendered identity, but the
 current `sourceBlockIds` projection already supports the first integration.
@@ -91,14 +90,13 @@ SSE changes must not rerun it. Project the entire contiguous range together so
 tool relationships can cross a page boundary, but never across a range boundary.
 Discard derived projections when their pages leave the cache.
 
-Historical tool projection must preserve recorded terminal status without a
-background-agent status poll. The current default pure adapter can force a
-completed background agent back to pending (`transcriptToMessages.ts:1258`).
-Add a narrow recorded-status option consumed by the historical projection while
-retaining normal tool payload/detail projection. Do not simply enable
-`safeToolProjection`: that also removes tool content and changes input/output
-projection. Other callers retain their current behavior. Recorded nonterminal
-tools are labelled as snapshot state, not as proof of a currently running task.
+Historical tools use the existing pure projection without a background-agent
+status poll, retaining normal tool payloads and details. A completed background
+launch tool records successful launch, not the agent's eventual completion.
+Only an in-range background notification supplies the agent's terminal status
+and end time. Without it, the agent remains nonterminal snapshot state, not
+proof that it is currently running. Do not enable `safeToolProjection`: that
+also removes tool content and changes input/output projection.
 
 Keep App/ChatPane live messages as the input to session-wide business logic.
 Only row-local display data, such as historical output cards, use the historical
@@ -366,8 +364,8 @@ change from that PR only when a test demonstrates a missing identity consumer.
 | Existing locale resources                                                    | Boundary, retry, invalidation and return-to-latest labels.                                  |
 | `client/e2e/` (relative to package root)                                     | Focused browser regression spec using existing Playwright setup.                            |
 
-Also update `adapters/transcriptToMessages.ts` and its tests for recorded-status
-projection without changing live reconciliation or discarding historical tool details.
+Verify the pure adapter's launch-only and in-range notification projections
+without changing live reconciliation or discarding historical tool details.
 
 No changes to `packages/core`, `packages/cli`, or `packages/sdk-typescript` are
 planned. No new library or global CSS rewrite. New controls reuse shared UI
@@ -391,8 +389,9 @@ The following requirements remain committed even when that local file is absent:
 - First-visible parallel-agent, collapsed-turn and output rows resolve to an
   exact retained page; multiple embedded viewports do not overwrite each other's
   reading pin or leak pins after unmount.
-- Recorded completed/failed/cancelled background agents stay terminal even when
-  the selected window lacks their completion notification; details remain readable.
+- Background-agent launch records remain nonterminal without an in-range
+  completion notification; terminal status and end time come from that
+  notification when available. Tool details remain readable in both cases.
 - Stream, approve a live request, update Todo/tasks, and queue a prompt while
   history is visible. Live callbacks continue; historical rows do not act live.
 - Reconnect, rewind, snapshot loss, source switch, and split-pane changes reject

--- a/docs/design/web-shell/web-shell-global-turn-navigation-phase3.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation-phase3.md
@@ -1,0 +1,27 @@
+# Continuous scrolling with global turn navigation
+
+## Problem and requested behavior
+
+Phase 2B replaces ordinary upward history loading with an explicit historical snapshot toolbar. The user requests the original continuous scrolling experience plus a left navigation rail covering every persisted turn, with distant transcript content loaded on demand. This supersedes the user-facing snapshot controls in the Phase 2B design; its bounded storage and isolated materialization remain useful internally.
+
+## Design
+
+The default TranscriptViewport passes the existing live MessageList pagination props through unchanged. It keeps the original follow-bottom, upward loading, error handling, and jump-to-latest behavior. Capability detection must not disable ordinary history loading.
+
+A global turn rail uses the navigation store's effective turn count and lazily loads metadata for visible ordinal slots. Its scrollable list renders a bounded number of buttons, including placeholders for unloaded metadata, and supports keyboard navigation. Existing loaded-only navigation remains the fallback for daemons without turn indexes. The rail is hidden in narrow layouts and existing split panes, matching the current compact-layout policy.
+
+Selecting a loaded turn maps its source block ID to the current message ID and uses MessageList's existing scroll and highlight behavior. Selecting a distant turn calls locateOrdinal, then displays the admitted bounded range in the same message area. User input, another selection, return-to-latest, and session or owner changes invalidate pending navigation. Historical content remains isolated from the live transcript and control consumers. No snapshot title or page navigation toolbar is shown.
+
+At the top and bottom of a historical range, scrolling loads the adjacent boundary while preserving the visible block and tool-call anchor. The existing jump-to-latest action remains available throughout historical reading. Reaching a live boundary returns to live content using an overlapping reading anchor where available. Errors retain the current content and expose a retry action rather than silently skipping gaps.
+
+## Components and scope
+
+`useTranscriptViewport` owns local selection intent, range pinning, loading and pending scroll targets. `TranscriptViewport` integrates the rail, restores anchors and observes historical scroll boundaries. A dedicated global rail component reuses shared buttons and theme tokens and bounds rendered ordinal slots. The navigation store adds only internal cancellation support if needed; no daemon routes, persistence format, SDK protocol, or reducer semantics change. Focused component tests and browser tests cover navigation and the restored ordinary scroll path.
+
+## Decisions and limitations
+
+All-history means all ordinal slots, not only cached index pages. The index and transcript caches keep their existing budgets. A distant jump does not load intervening history or replace live reducer state. Split panes retain their existing compact policy. The user explicitly chose all historical turns with content loaded on demand; there are no outstanding scope questions.
+
+## Compact rail presentation
+
+The rail uses the original short ticks and their hover expansion instead of a permanent text list. A shared portal-aware tooltip shows the indexed prompt label and optional detail on hover or keyboard focus. The rail is 64px wide and vertically centered; all ordinal slots remain virtually scrollable with 16px spacing. Hover reads existing metadata only and does not fetch transcript content. Clicking still locates distant content on demand.

--- a/docs/design/web-shell/web-shell-global-turn-navigation.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation.md
@@ -2,9 +2,16 @@
 
 ## Status
 
-Accepted; Phases 1 and 2A implemented. Phase 2B is implemented in
-[#11208](https://github.com/QwenLM/qwen-code/pull/11208); Phase 3 remains proposed.
-Delivery boundary clarified 2026-09-07.
+Phases 1 and 2A merged in #10751 and #11054. Phase 2B and the agreed Phase 3
+global rail are implemented in
+[#11208](https://github.com/QwenLM/qwen-code/pull/11208), which is still open.
+Status updated 2026-09-07 against implementation commit `02e975e9fa`.
+
+Phase 3 functionality and scoped frontend verification are complete. The rail
+preserves ordinary upward scrolling, uses compact ticks with hover/focus previews,
+and loads distant turns on demand. Integrated browser-to-real-daemon lifecycle
+acceptance remains unverified; implementation, frontend verification, and merge
+status are separate milestones. See the delivery and verification sections below.
 
 This design complements
 `web-shell-bounded-transcript-and-subagent-details.md`. That document defines
@@ -30,7 +37,10 @@ The durable turn identity is the UUID of the persisted user record that starts
 the navigable item. A prompt ID is only a live correlation key. A Web Shell
 block ID and an array index are never protocol locators.
 
-## Current state and the actual gap
+## Original baseline and gap
+
+This section describes the baseline before Phases 1–3, not the implementation
+now available in #11208.
 
 The compact rail introduced in `MessageList` is already a useful presentation
 component, but its data source is local:
@@ -433,9 +443,17 @@ subset:
 
 - `aria-setsize=effectiveTurnCount`;
 - `aria-posinset=ordinal + 1`;
-- Home/End select the first/latest turn;
+- Home/End move focus to the first/latest turn; Enter activates it;
 - arrow and page keys move by ordinal and fetch metadata as needed; and
-- placeholder labels announce “Turn N, details loading”.
+- placeholder labels retain the turn number until metadata arrives.
+
+The delivered rail uses short horizontal ticks with a prompt title and available
+public assistant preview on hover or keyboard focus. Hovering does not fetch
+transcript pages. The selected tick marks the last chosen turn; manual body
+scrolling does not update selection. Separate styling for every turn kind and
+loading state, scroll-following selection, and dedicated snapshot-expiry copy
+are optional follow-ups, not requirements for this Phase 3 delivery. Existing
+error, retry, and return-to-latest controls provide recovery.
 
 The current responsive constraints remain: the rail may hide on narrow,
 split-pane, or reduced-layout surfaces. Completeness refers to the underlying
@@ -606,11 +624,21 @@ defines the current client contract and delivery slices.
 
 ### Phase 3: global rail
 
-1. Virtualize `SessionTimeline` by total ordinal count.
-2. Add loaded and unloaded selection paths, retry, placeholders, keyboard
-   navigation, and jump-to-latest integration.
-3. Keep the old `getSessionTimelineEntries(messages)` path as the capability
-   fallback.
+Implemented in #11208 together with Phase 2B:
+
+1. Virtualize the global rail by total ordinal count, with compact ticks and
+   hover/focus previews instead of a persistent text sidebar.
+2. Support loaded and unloaded selection, metadata placeholders, retry,
+   keyboard navigation, logical collection accessibility attributes, and the
+   existing return-to-latest action.
+3. Preserve ordinary upward pagination without a snapshot toolbar; selecting a
+   distant turn opens a bounded historical range while the live tail continues.
+4. Keep `getSessionTimelineEntries(messages)` as the capability fallback and
+   preserve the compact/narrow and split-pane visibility policy.
+
+Frozen historical fragments do not expose row mutation controls, including
+checkpoint branching. `/branch` remains an active-session command while reading
+history; checkpoint branching is available on the normal loaded Assistant rows.
 
 ## Implementation map
 
@@ -629,6 +657,35 @@ route variants must be reviewed against the exact runtime/storage ownership
 rules before the capability is advertised.
 
 ## Verification plan
+
+### Completed frontend verification and remaining acceptance
+
+The final compact-rail build at `02e975e9fa` passed three browser scenarios for
+hover/focus previews, keyboard entry, responsive visibility, 5,000-turn
+virtualization, and loaded/distant selection. Earlier scrolling and cache
+verification is recorded on #11208.
+
+Eight distinct lifecycle browser scenarios passed across an initial run and a
+targeted branch rerun, with no browser page errors. Same-owner SSE reconnect
+preserved the historical reading row; owner replacement returned to fresh live
+replay; rewind refreshed the count and removed tail; branching loaded the child
+and subsequent navigation requested child-session history. Delayed source
+selection and boundary responses could not replace the resulting view. An
+additional 105 targeted store, viewport, provider, and action tests passed; these
+overlap earlier unit runs and must not be added to them as unique coverage.
+
+This does not mean all PR checks passed. The Ubuntu test job for `02e975e9fa`
+failed with an uncaught `requestAnimationFrame is not defined` after the
+`TranscriptViewport.pending.test.tsx` environment was torn down. That CI failure
+remains an integration follow-up; the scoped local results above do not resolve
+it. Current check status is tracked on #11208.
+
+The browser scenarios use real Chromium and the built frontend with deterministic
+HTTP/SSE fixtures, including actual rewind dialogs and branch controls. They do
+not prove real daemon persistence, restart/failover, or filesystem rewind/branch
+semantics. Integrated browser-to-real-daemon acceptance, assistive-technology
+checks, and the larger performance matrix below remain verification follow-ups.
+The scenarios below describe the broader verification plan, not completed runs.
 
 ### Core reader
 

--- a/docs/design/web-shell/web-shell-global-turn-navigation.md
+++ b/docs/design/web-shell/web-shell-global-turn-navigation.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Accepted; Phases 1 and 2A implemented, Phases 2B–3 proposed; delivery boundary
-clarified 2026-09-04.
+Accepted; Phases 1 and 2A implemented. Phase 2B is implemented in
+[#11208](https://github.com/QwenLM/qwen-code/pull/11208); Phase 3 remains proposed.
+Delivery boundary clarified 2026-09-07.
 
 This design complements
 `web-shell-bounded-transcript-and-subagent-details.md`. That document defines
@@ -584,8 +585,11 @@ provisional reconciliation, and canonical locator map — belong to this phase,
 leaving Phase 3 as the rail UI. The detailed design lives in
 `web-shell-global-turn-navigation-phase2.md`.)
 
-Phase 2A (implemented in [#11054](https://github.com/QwenLM/qwen-code/pull/11054),
-under review) delivers steps 1–3. Phase 2B delivers step 4. The
+Phase 2A (merged in [#11054](https://github.com/QwenLM/qwen-code/pull/11054))
+delivers steps 1–3. Phase 2B is implemented in
+[#11208](https://github.com/QwenLM/qwen-code/pull/11208), following the
+[historical viewport design](web-shell-global-turn-navigation-phase2b.md),
+and delivers step 4. The
 [implementation plan](../../plans/2026-09-04-web-shell-global-turn-navigation-phase2.md)
 defines the current client contract and delivery slices.
 
@@ -596,8 +600,9 @@ defines the current client contract and delivery slices.
    window, with bidirectional boundaries, deduplication by record ID, page
    admission, eviction, detached-live behavior, and random anchored reads.
 3. Expose the complete headless state and locator contract needed by the rail.
-4. Migrate existing sequential prepend pagination behind the page-table
-   boundary while preserving its current public behavior.
+4. Add a bounded historical viewport over the same page table for built-in
+   main and split views, preserving legacy public hooks and sequential
+   pagination as the compatibility path.
 
 ### Phase 3: global rail
 

--- a/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
+++ b/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
@@ -1,6 +1,6 @@
 # Web Shell global turn navigation Phase 2 implementation plan
 
-- Status: In progress — Phase 2A implemented; Phase 2B pending
+- Status: Phase 2A merged in #11054; Phase 2B implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208)
 - Date: 2026-09-04
 - Base: `cf44c778c0775d640560143828d851fa30dbd893`
 - Tracks: [#10750](https://github.com/QwenLM/qwen-code/issues/10750)
@@ -10,7 +10,7 @@
 **2026-09-06 update:** Phase 2A merged as #11054. The
 [Phase 2B viewport design](../design/web-shell/web-shell-global-turn-navigation-phase2b.md)
 supersedes this plan's sequential-history migration, public-history-hook
-replacement, and blanket UI/browser-test deferrals. It proposes a separate
+replacement, and blanket UI/browser-test deferrals. It implements a separate
 historical viewport for built-in main/split views, retains legacy public hook
 semantics, and moves minimal scrolling/boundary UI into Phase 2B. The original
 sections below are retained as historical rationale, not competing requirements.

--- a/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
+++ b/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
@@ -1,6 +1,6 @@
 # Web Shell global turn navigation Phase 2 implementation plan
 
-- Status: Phase 2A merged in #11054; Phase 2B implemented in [#11208](https://github.com/QwenLM/qwen-code/pull/11208)
+- Status: Phase 2A merged in #11054; Phase 2B and the agreed Phase 3 rail implemented in open [#11208](https://github.com/QwenLM/qwen-code/pull/11208)
 - Date: 2026-09-04
 - Base: `cf44c778c0775d640560143828d851fa30dbd893`
 - Tracks: [#10750](https://github.com/QwenLM/qwen-code/issues/10750)
@@ -14,6 +14,15 @@ replacement, and blanket UI/browser-test deferrals. It implements a separate
 historical viewport for built-in main/split views, retains legacy public hook
 semantics, and moves minimal scrolling/boundary UI into Phase 2B. The original
 sections below are retained as historical rationale, not competing requirements.
+
+**2026-09-07 delivery update:** #11208 also implements the Phase 3 global rail:
+compact ticks, hover/focus previews, keyboard and distant-turn navigation, and
+the existing return-to-latest action. Ordinary upward pagination is preserved
+without a snapshot toolbar. Scoped frontend lifecycle verification passed;
+integrated browser-to-real-daemon acceptance remains unverified. The
+[parent design](../design/web-shell/web-shell-global-turn-navigation.md) records
+the current scope and optional follow-ups; earlier Phase 3 deferrals below do
+not represent outstanding UI work.
 
 ## Outcome
 
@@ -680,7 +689,13 @@ Opaque snapshot tokens make client lineage proof deliberately conservative.
 Exact overlap is sufficient for ordinary append; lack of proof clears cached
 pages. Correctness is preferred over metadata-cache hit rate.
 
-## Deferred to Phase 3
+## Original Phase 3 deferrals (superseded)
+
+This historical list predates the final #11208 implementation. The parent
+design's Phase 3 delivery section is authoritative: the global rail and frontend
+navigation are implemented; exhaustive state styling and dedicated expiry copy
+are optional, while the broader performance/accessibility and real-daemon
+acceptance matrix remains separate verification work.
 
 - virtualized rail DOM and placeholder ticks;
 - keyboard navigation and WAI-ARIA attributes;

--- a/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
+++ b/docs/plans/2026-09-04-web-shell-global-turn-navigation-phase2.md
@@ -7,6 +7,14 @@
 - Consumes: merged Phase 1 protocol [#10751](https://github.com/QwenLM/qwen-code/pull/10751)
 - Architecture: `docs/design/web-shell/web-shell-global-turn-navigation.md`
 
+**2026-09-06 update:** Phase 2A merged as #11054. The
+[Phase 2B viewport design](../design/web-shell/web-shell-global-turn-navigation-phase2b.md)
+supersedes this plan's sequential-history migration, public-history-hook
+replacement, and blanket UI/browser-test deferrals. It proposes a separate
+historical viewport for built-in main/split views, retains legacy public hook
+semantics, and moves minimal scrolling/boundary UI into Phase 2B. The original
+sections below are retained as historical rationale, not competing requirements.
+
 ## Outcome
 
 Phase 2 will deliver the complete headless client data layer for session-wide

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -992,7 +992,7 @@ vi.mock('./components/ChatEditor', async () => {
   };
 });
 
-vi.mock('./components/MessageList', async () => {
+vi.mock('./components/TranscriptViewport', async () => {
   const React = await import('react');
   const { useInteractionBlocker } = await import('./interactionBlockContext');
   function InteractionBlockerProbe() {
@@ -1016,7 +1016,7 @@ vi.mock('./components/MessageList', async () => {
     );
   }
   return {
-    MessageList: React.forwardRef(function MessageList(
+    TranscriptViewport: React.forwardRef(function TranscriptViewport(
       props: {
         messages?: Array<{
           role?: string;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -9,7 +9,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type ComponentPropsWithoutRef,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
@@ -87,7 +86,11 @@ import {
   isRetryableTurnErrorKind,
   transcriptBlocksToDaemonMessages,
 } from './adapters/transcriptToMessages';
-import { MessageList, type MessageListHandle } from './components/MessageList';
+import type {
+  MessageListProps,
+  MessageListHandle,
+} from './components/MessageList';
+import { TranscriptViewport } from './components/TranscriptViewport';
 import { reorderChildrenUnderParents } from './components/messages/agentForest';
 import { SubagentDetailsProvider } from './subagentDetailsContext';
 import { MonitorDetailsProvider } from './monitorDetailsContext';
@@ -879,7 +882,7 @@ function buildDisplayMessages(
 }
 
 type LiveMessageListProps = Omit<
-  ComponentPropsWithoutRef<typeof MessageList>,
+  MessageListProps,
   'messages' | 'transcriptBlockCount'
 > & {
   baselineBlocks: readonly DaemonTranscriptBlock[];
@@ -940,7 +943,7 @@ const LiveMessageList = memo(
     }, [live.blocks, onTranscriptChange]);
 
     return (
-      <MessageList
+      <TranscriptViewport
         {...props}
         ref={ref}
         messages={displayMessages}

--- a/packages/web-shell/client/adapters/localizedMessages.ts
+++ b/packages/web-shell/client/adapters/localizedMessages.ts
@@ -33,9 +33,11 @@ export function transcriptBlocksToLocalizedMessages(
   blocks: readonly DaemonTranscriptBlock[],
   t: Translator,
   safeToolProjection = false,
+  recordedToolStatus = false,
 ): Message[] {
   return transcriptBlocksToDaemonMessages(blocks, {
     safeToolProjection,
+    recordedToolStatus,
     includeSourceIdentity: true,
     labels: {
       promptCancelled: t('request.cancelled'),

--- a/packages/web-shell/client/adapters/localizedMessages.ts
+++ b/packages/web-shell/client/adapters/localizedMessages.ts
@@ -33,11 +33,9 @@ export function transcriptBlocksToLocalizedMessages(
   blocks: readonly DaemonTranscriptBlock[],
   t: Translator,
   safeToolProjection = false,
-  recordedToolStatus = false,
 ): Message[] {
   return transcriptBlocksToDaemonMessages(blocks, {
     safeToolProjection,
-    recordedToolStatus,
     includeSourceIdentity: true,
     labels: {
       promptCancelled: t('request.cancelled'),

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -192,6 +192,36 @@ function toolBlock(
 }
 
 describe('transcriptBlocksToDaemonMessages', () => {
+  it('preserves recorded terminal background status without dropping tool detail', () => {
+    const block = toolBlock('agent-history', 'agent-1', 'completed', 20, {
+      toolName: 'agent',
+      rawInput: { prompt: 'inspect history' },
+      rawOutput: {
+        type: 'task_execution',
+        status: 'background',
+        result: 'kept detail',
+      },
+    });
+    const live = transcriptBlocksToDaemonMessages([block]);
+    const recorded = transcriptBlocksToDaemonMessages([block], {
+      recordedToolStatus: true,
+    });
+    expect(live[0]).toMatchObject({
+      role: 'tool_group',
+      tools: [{ status: 'pending' }],
+    });
+    expect(recorded[0]).toMatchObject({
+      role: 'tool_group',
+      tools: [
+        {
+          status: 'completed',
+          args: { prompt: 'inspect history' },
+          rawOutput: { result: 'kept detail' },
+        },
+      ],
+    });
+  });
+
   it('preserves user source metadata', () => {
     const messages = transcriptBlocksToDaemonMessages([
       textBlock('user-1', 'user', 'scheduled prompt', 1, false, {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -192,8 +192,8 @@ function toolBlock(
 }
 
 describe('transcriptBlocksToDaemonMessages', () => {
-  it('preserves recorded terminal background status without dropping tool detail', () => {
-    const block = toolBlock('agent-history', 'agent-1', 'completed', 20, {
+  it('does not treat a historical background launch as agent completion', () => {
+    const block = toolBlock('agent-history', 'agent-1', 'completed', 1000, {
       toolName: 'agent',
       rawInput: { prompt: 'inspect history' },
       rawOutput: {
@@ -201,26 +201,68 @@ describe('transcriptBlocksToDaemonMessages', () => {
         status: 'background',
         result: 'kept detail',
       },
+      updatedAt: 1005,
     });
-    const live = transcriptBlocksToDaemonMessages([block]);
-    const recorded = transcriptBlocksToDaemonMessages([block], {
-      recordedToolStatus: true,
+    const messages = transcriptBlocksToDaemonMessages([block]);
+    const tool = messages.find((message) => message.role === 'tool_group')
+      ?.tools[0];
+
+    expect(tool).toMatchObject({
+      status: 'pending',
+      startTime: 1000,
+      endTime: undefined,
+      args: { prompt: 'inspect history' },
+      rawOutput: { result: 'kept detail' },
     });
-    expect(live[0]).toMatchObject({
-      role: 'tool_group',
-      tools: [{ status: 'pending' }],
-    });
-    expect(recorded[0]).toMatchObject({
-      role: 'tool_group',
-      tools: [
-        {
-          status: 'completed',
-          args: { prompt: 'inspect history' },
-          rawOutput: { result: 'kept detail' },
-        },
-      ],
-    });
+    expect(tool?.endTime).toBeUndefined();
   });
+
+  it.each(['completed', 'failed'] as const)(
+    'uses an in-range background notification for historical %s status',
+    (status) => {
+      const messages = transcriptBlocksToDaemonMessages([
+        toolBlock('agent-history', 'agent-1', 'completed', 1000, {
+          toolName: 'agent',
+          rawInput: { prompt: 'inspect history' },
+          rawOutput: {
+            type: 'task_execution',
+            status: 'background',
+            result: 'kept detail',
+          },
+          updatedAt: 1005,
+        }),
+        textBlock(
+          'agent-result',
+          'assistant',
+          `agent ${status}`,
+          60000,
+          false,
+          {
+            meta: {
+              source: 'background_notification',
+              qwenDiscreteMessage: true,
+              backgroundTask: {
+                kind: 'agent',
+                taskId: 'task-1',
+                toolUseId: 'agent-1',
+                status,
+              },
+            },
+          },
+        ),
+      ]);
+      const tool = messages.find((message) => message.role === 'tool_group')
+        ?.tools[0];
+
+      expect(tool).toMatchObject({
+        status,
+        startTime: 1000,
+        endTime: 60000,
+        args: { prompt: 'inspect history' },
+        rawOutput: { result: 'kept detail' },
+      });
+    },
+  );
 
   it('preserves user source metadata', () => {
     const messages = transcriptBlocksToDaemonMessages([

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -57,6 +57,7 @@ interface TranscriptMessageOptions {
   labels?: TranscriptMessageLabels;
   includeSourceIdentity?: boolean;
   safeToolProjection?: boolean;
+  recordedToolStatus?: boolean;
 }
 
 interface BackgroundAgentTaskUpdate {
@@ -698,6 +699,7 @@ export function transcriptBlocksToDaemonMessages(
         const projectedToolCall = daemonToolBlockToToolCall(
           toolBlock,
           safeToolProjection,
+          options.recordedToolStatus === true,
         );
         const backgroundAgentUpdate = backgroundAgentTaskUpdates.get(
           projectedToolCall.callId,
@@ -1230,6 +1232,7 @@ function getString(
 function daemonToolBlockToToolCall(
   block: DaemonToolTranscriptBlock,
   safeToolProjection: boolean,
+  recordedToolStatus: boolean,
 ): DaemonMessageToolCall {
   const rawOutput = getToolRawOutput(block, safeToolProjection);
   const executionMode = safeToolProjection
@@ -1256,7 +1259,9 @@ function daemonToolBlockToToolCall(
     block.status === 'cancelled' ||
     block.status === 'canceled';
   const forceBackgroundPending =
-    isBackgroundAgent && (!safeToolProjection || !isComplete);
+    isBackgroundAgent &&
+    !recordedToolStatus &&
+    (!safeToolProjection || !isComplete);
 
   return {
     callId: block.toolCallId,

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -57,7 +57,6 @@ interface TranscriptMessageOptions {
   labels?: TranscriptMessageLabels;
   includeSourceIdentity?: boolean;
   safeToolProjection?: boolean;
-  recordedToolStatus?: boolean;
 }
 
 interface BackgroundAgentTaskUpdate {
@@ -699,7 +698,6 @@ export function transcriptBlocksToDaemonMessages(
         const projectedToolCall = daemonToolBlockToToolCall(
           toolBlock,
           safeToolProjection,
-          options.recordedToolStatus === true,
         );
         const backgroundAgentUpdate = backgroundAgentTaskUpdates.get(
           projectedToolCall.callId,
@@ -1232,7 +1230,6 @@ function getString(
 function daemonToolBlockToToolCall(
   block: DaemonToolTranscriptBlock,
   safeToolProjection: boolean,
-  recordedToolStatus: boolean,
 ): DaemonMessageToolCall {
   const rawOutput = getToolRawOutput(block, safeToolProjection);
   const executionMode = safeToolProjection
@@ -1259,9 +1256,7 @@ function daemonToolBlockToToolCall(
     block.status === 'cancelled' ||
     block.status === 'canceled';
   const forceBackgroundPending =
-    isBackgroundAgent &&
-    !recordedToolStatus &&
-    (!safeToolProjection || !isComplete);
+    isBackgroundAgent && (!safeToolProjection || !isComplete);
 
   return {
     callId: block.toolCallId,

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -197,8 +197,8 @@ vi.mock('../monitorDetailsContext', async () => {
   };
 });
 
-vi.mock('./MessageList', () => ({
-  MessageList: (props: any) => (
+vi.mock('./TranscriptViewport', () => ({
+  TranscriptViewport: (props: any) => (
     <div
       data-testid="pane-messages"
       data-approval={props.pendingApproval ? 'yes' : 'no'}

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -93,7 +93,8 @@ import {
   useSessionCatalogController,
   useSessionHasActivePrompt,
 } from '../session-catalog/session-catalog-hooks';
-import { MessageList } from './MessageList';
+import type { MessageListHandle } from './MessageList';
+import { TranscriptViewport } from './TranscriptViewport';
 import { StreamingStatus } from './StreamingStatus';
 import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
 import { QueuedPromptDisplay } from './QueuedPromptDisplay';
@@ -510,6 +511,7 @@ export function ChatPane({
       SESSION_TRANSCRIPT_PAGINATION_FEATURE,
     ) === true;
   const editorRef = useRef<EditorHandle | null>(null);
+  const transcriptViewportRef = useRef<MessageListHandle>(null);
   const {
     followupState,
     onAcceptFollowup,
@@ -748,6 +750,7 @@ export function ChatPane({
       if (!trimmed && (images?.length ?? 0) === 0 && (files?.length ?? 0) === 0)
         return false;
       if (admissionPayloadLocked) return false;
+      transcriptViewportRef.current?.scrollToBottom();
       // The host handler is documented as running before Web Shell handles a
       // slash command, so it gets `/goal` first here exactly as it does in the
       // main composer — otherwise an override works on one surface only.
@@ -1351,7 +1354,8 @@ export function ChatPane({
         >
           <SubagentDetailsProvider onOpen={openSubagentDetails}>
             <WorkflowDetailsProvider tasks={sessionTasks}>
-              <MessageList
+              <TranscriptViewport
+                ref={transcriptViewportRef}
                 messages={messages}
                 pendingApproval={pendingToolApproval}
                 loadingTranscript={connection.loadingTranscript}

--- a/packages/web-shell/client/components/GlobalTurnNavigation.test.tsx
+++ b/packages/web-shell/client/components/GlobalTurnNavigation.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, expect, it, vi } from 'vitest';
+import { createDaemonTurnNavigationStore } from '../daemon/session/turn-navigation-store';
+import { GlobalTurnNavigation } from './GlobalTurnNavigation';
+
+vi.mock('../i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, values?: { index: number }) =>
+      values ? `Turn ${values.index}` : key,
+  }),
+}));
+let root: Root;
+let container: HTMLDivElement;
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+async function setup() {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const store = createDaemonTurnNavigationStore();
+  const state = {
+    ...store.getSnapshot(),
+    sessionId: 'session',
+    mode: 'ready' as const,
+    totalTurns: 5000,
+    effectiveTurnCount: 5000,
+  };
+  const load = vi.spyOn(store, 'loadOrdinal').mockResolvedValue();
+  const select = vi.fn();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <GlobalTurnNavigation state={state} store={store} onSelect={select} />,
+    ),
+  );
+  return { load, select, state, store };
+}
+
+it('keeps a keyboard entry point when a rewind reduces the turn count', async () => {
+  const { state, store, select } = await setup();
+  await act(async () =>
+    root.render(
+      <GlobalTurnNavigation
+        state={{ ...state, totalTurns: 10, effectiveTurnCount: 10 }}
+        store={store}
+        onSelect={select}
+      />,
+    ),
+  );
+  expect(
+    container
+      .querySelector('[data-turn-ordinal="9"]')
+      ?.getAttribute('tabindex'),
+  ).toBe('0');
+});
+
+it('keeps a Tab entry after scrolling the focused turn out of the virtual window', async () => {
+  await setup();
+  const scroll = container.querySelector<HTMLElement>('nav > div')!;
+  await act(async () => {
+    scroll.scrollTop = 0;
+    scroll.dispatchEvent(new Event('scroll'));
+  });
+  expect(container.querySelector('[data-turn-ordinal="4999"]')).toBeNull();
+  expect(
+    container.querySelector('[data-turn-ordinal][tabindex="0"]'),
+  ).not.toBeNull();
+});
+
+it('waits for Retry after a metadata failure even when the store republishes its index map', async () => {
+  const { state, store, select, load } = await setup();
+  load.mockClear().mockRejectedValue(new Error('offline'));
+  const scroll = container.querySelector<HTMLElement>('nav > div')!;
+  await act(async () => {
+    scroll.scrollTop = 0;
+    scroll.dispatchEvent(new Event('scroll'));
+  });
+  expect(load).toHaveBeenCalledTimes(1);
+  await act(async () =>
+    root.render(
+      <GlobalTurnNavigation
+        state={{ ...state, indexPages: new Map() }}
+        store={store}
+        onSelect={select}
+      />,
+    ),
+  );
+  expect(load).toHaveBeenCalledTimes(1);
+  const retry = [...container.querySelectorAll('button')].find(
+    (button) => button.textContent === 'history.retry',
+  )!;
+  expect(retry).toBeDefined();
+  await act(async () => retry.click());
+  expect(load).toHaveBeenCalledTimes(2);
+});
+
+it('represents all turns while bounding DOM rows and loading only visible metadata', async () => {
+  const { load } = await setup();
+  expect(container.querySelectorAll('[data-turn-ordinal]').length).toBeLessThan(
+    40,
+  );
+  expect(container.querySelector('[aria-setsize="5000"]')).not.toBeNull();
+  expect(container.querySelector('[data-turn-ordinal="4999"]')).not.toBeNull();
+  // The initial render and the jump to the tail can each request one metadata page.
+  expect(load.mock.calls.length).toBeLessThanOrEqual(2);
+  expect(
+    load.mock.calls.every(([ordinal]) => ordinal < 200 || ordinal >= 4800),
+  ).toBe(true);
+});
+
+it('moves keyboard focus to unloaded first and last turns and selects on click', async () => {
+  const { select, load } = await setup();
+  const last = container.querySelector<HTMLButtonElement>(
+    '[data-turn-ordinal="4999"]',
+  )!;
+  await act(async () =>
+    last.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+    ),
+  );
+  const first = container.querySelector<HTMLButtonElement>(
+    '[data-turn-ordinal="0"]',
+  )!;
+  expect(document.activeElement).toBe(first);
+  await act(async () => first.click());
+  expect(select).toHaveBeenLastCalledWith(0);
+  expect(load.mock.calls.some(([ordinal]) => ordinal < 200)).toBe(true);
+  await act(async () =>
+    first.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
+    ),
+  );
+  expect(document.activeElement?.getAttribute('data-turn-ordinal')).toBe(
+    '4999',
+  );
+});
+
+it('shows a preview on keyboard focus while the tick stays text-free', async () => {
+  const { state, store, select, load } = await setup();
+  const entry = {
+    ordinal: 4999,
+    turnId: 'last',
+    kind: 'prompt' as const,
+    label: 'Review the change',
+    detail: 'The change preserves continuous scrolling.',
+  };
+  await act(async () =>
+    root.render(
+      <GlobalTurnNavigation
+        state={{
+          ...state,
+          indexPages: new Map([
+            [
+              4800,
+              {
+                start: 4800,
+                end: 5000,
+                snapshot: 's',
+                retainedBytes: 100,
+                turns: [entry],
+              },
+            ],
+          ]),
+        }}
+        store={store}
+        onSelect={select}
+      />,
+    ),
+  );
+  const button = container.querySelector<HTMLButtonElement>(
+    '[data-turn-ordinal="4999"]',
+  )!;
+  expect(button.textContent).toBe('');
+  expect(button.getAttribute('aria-label')).toContain(entry.label);
+  const requestsBeforeFocus = load.mock.calls.length;
+  await act(async () => button.focus());
+  const tooltip = document.querySelector('[role="tooltip"]');
+  expect(tooltip?.textContent).toContain(entry.label);
+  expect(tooltip?.textContent).toContain(entry.detail);
+  expect(load.mock.calls.length).toBe(requestsBeforeFocus);
+  await act(async () =>
+    button.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    ),
+  );
+  expect(document.querySelector('[role="tooltip"]')).toBeNull();
+});

--- a/packages/web-shell/client/components/GlobalTurnNavigation.tsx
+++ b/packages/web-shell/client/components/GlobalTurnNavigation.tsx
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type {
+  DaemonTurnNavigationSnapshot,
+  DaemonTurnNavigationStore,
+} from '../daemon/session/turn-navigation-store';
+import { WEB_SHELL_TURN_INDEX_PAGE_SIZE } from '../constants/sessions';
+import { useI18n } from '../i18n';
+import { Button } from './ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
+import timelineStyles from './MessageList.module.css';
+
+const ROW_HEIGHT = 16;
+const OVERSCAN = 4;
+
+export function GlobalTurnNavigation({
+  state,
+  store,
+  onSelect,
+}: {
+  state: DaemonTurnNavigationSnapshot;
+  store: DaemonTurnNavigationStore;
+  onSelect: (ordinal: number) => void;
+}) {
+  const { t } = useI18n();
+  const viewport = useRef<HTMLDivElement>(null);
+  const [top, setTop] = useState(0);
+  const [height, setHeight] = useState(360);
+  const [focus, setFocus] = useState<number>();
+  const pendingFocus = useRef(false);
+  const [failed, setFailed] = useState(false);
+  const [retry, setRetry] = useState(0);
+  const count = state.effectiveTurnCount;
+  const start = Math.max(
+    0,
+    Math.min(count - 1, Math.floor(top / ROW_HEIGHT) - OVERSCAN),
+  );
+  const end = Math.min(
+    count,
+    start + Math.ceil(height / ROW_HEIGHT) + 2 * OVERSCAN,
+  );
+  const entries = new Map(
+    [...state.indexPages.values()].flatMap((page) =>
+      page.turns.map((entry) => [entry.ordinal, entry] as const),
+    ),
+  );
+
+  useLayoutEffect(() => {
+    const element = viewport.current;
+    if (!element) return;
+    const measure = () => setHeight(element.clientHeight || 360);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const initialized = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    if (!count || initialized.current === state.sessionId) return;
+    initialized.current = state.sessionId;
+    const element = viewport.current;
+    if (!element) return;
+    element.scrollTop = Math.max(0, count * ROW_HEIGHT - height);
+    setTop(element.scrollTop);
+    setFocus(count - 1);
+  }, [count, state.sessionId, height]);
+
+  const missing = new Set<number>();
+  for (
+    let ordinal = start;
+    ordinal < Math.min(end, state.totalTurns);
+    ordinal++
+  ) {
+    if (!entries.has(ordinal))
+      missing.add(
+        Math.floor(ordinal / WEB_SHELL_TURN_INDEX_PAGE_SIZE) *
+          WEB_SHELL_TURN_INDEX_PAGE_SIZE,
+      );
+  }
+  const missingPages = [...missing].join(',');
+  const focusOrdinal = Math.max(start, Math.min(focus ?? count - 1, end - 1));
+  useEffect(() => {
+    if (!missingPages) return;
+    let current = true;
+    setFailed(false);
+    void Promise.all(
+      missingPages
+        .split(',')
+        .map((ordinal) => store.loadOrdinal(Number(ordinal))),
+    ).catch(() => {
+      if (current) setFailed(true);
+    });
+    return () => {
+      current = false;
+    };
+  }, [missingPages, store, retry]);
+
+  useLayoutEffect(() => {
+    if (!pendingFocus.current) return;
+    const button = viewport.current?.querySelector<HTMLButtonElement>(
+      `[data-turn-ordinal="${focus}"]`,
+    );
+    if (button) {
+      button.focus({ preventScroll: true });
+      pendingFocus.current = false;
+    }
+  }, [focus, start, end]);
+
+  return (
+    <TooltipProvider disableHoverableContent>
+      <nav
+        aria-label={t('timeline.sessionTimeline')}
+        className="flex h-full min-h-0 w-16 shrink-0 flex-col justify-center px-3 py-4 text-muted-foreground"
+        data-global-turn-navigation
+      >
+        <span className="sr-only">
+          {t('timeline.sessionTimeline')} · {count}
+        </span>
+        <div
+          ref={viewport}
+          className="min-h-0 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          style={{ height: Math.min(count * ROW_HEIGHT, 360) }}
+          onScroll={(event) => setTop(event.currentTarget.scrollTop)}
+        >
+          <ol
+            className="relative m-0 list-none p-0"
+            style={{ height: count * ROW_HEIGHT }}
+          >
+            {Array.from({ length: end - start }, (_, index) => {
+              const ordinal = start + index;
+              const entry = entries.get(ordinal);
+              const label =
+                entry?.label ??
+                state.provisionalTurns[ordinal - state.totalTurns]?.label;
+              const title = `${t('timeline.turnPrefix', { index: ordinal + 1 })}${label ? ` · ${label}` : ''}`;
+              return (
+                <li
+                  key={ordinal}
+                  aria-posinset={ordinal + 1}
+                  aria-setsize={count}
+                  className={`${timelineStyles.sessionTimelineItem} left-0 right-0`}
+                  style={{
+                    position: 'absolute',
+                    top: ordinal * ROW_HEIGHT,
+                    height: ROW_HEIGHT,
+                  }}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className={`${timelineStyles.sessionTimelineButton} ${state.selected?.ordinal === ordinal ? timelineStyles.sessionTimelineButtonCurrent : ''}`}
+                        style={{ top: 0, width: '100%' }}
+                        aria-label={title}
+                        aria-current={
+                          state.selected?.ordinal === ordinal
+                            ? 'location'
+                            : undefined
+                        }
+                        data-turn-ordinal={ordinal}
+                        tabIndex={focusOrdinal === ordinal ? 0 : -1}
+                        onFocus={() => setFocus(ordinal)}
+                        onClick={() => onSelect(ordinal)}
+                        onKeyDown={(event) => {
+                          const step = Math.max(
+                            1,
+                            Math.floor(height / ROW_HEIGHT),
+                          );
+                          const next =
+                            event.key === 'Home'
+                              ? 0
+                              : event.key === 'End'
+                                ? count - 1
+                                : event.key === 'ArrowDown'
+                                  ? ordinal + 1
+                                  : event.key === 'ArrowUp'
+                                    ? ordinal - 1
+                                    : event.key === 'PageDown'
+                                      ? ordinal + step
+                                      : event.key === 'PageUp'
+                                        ? ordinal - step
+                                        : undefined;
+                          if (next === undefined) return;
+                          event.preventDefault();
+                          const target = Math.max(0, Math.min(count - 1, next));
+                          const element = viewport.current!;
+                          if (target * ROW_HEIGHT < element.scrollTop)
+                            element.scrollTop = target * ROW_HEIGHT;
+                          else if (
+                            (target + 1) * ROW_HEIGHT >
+                            element.scrollTop + height
+                          )
+                            element.scrollTop =
+                              (target + 1) * ROW_HEIGHT - height;
+                          setTop(element.scrollTop);
+                          pendingFocus.current = true;
+                          setFocus(target);
+                        }}
+                      >
+                        <span
+                          className={timelineStyles.sessionTimelineTick}
+                          aria-hidden="true"
+                        />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="right"
+                      sideOffset={8}
+                      collisionPadding={12}
+                      className="!animate-none grid w-[350px] max-w-[calc(100vw-100px)] gap-1.5 rounded-xl border border-border bg-background px-3.5 py-3 text-foreground shadow-lg [&_[data-slot=tooltip-arrow]]:hidden"
+                    >
+                      <span className="line-clamp-2 text-sm font-semibold">
+                        {label ??
+                          t('timeline.turnPrefix', { index: ordinal + 1 })}
+                      </span>
+                      {entry?.detail && (
+                        <span className="line-clamp-3 text-[13px] leading-relaxed text-muted-foreground">
+                          {entry.detail}
+                        </span>
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+        {failed && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setRetry((value) => value + 1)}
+          >
+            {t('history.retry')}
+          </Button>
+        )}
+      </nav>
+    </TooltipProvider>
+  );
+}

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -27,6 +27,7 @@ const virtualizerTestState = vi.hoisted(() => ({
   getItemKeys: [] as Array<(index: number) => string | number>,
   itemSizeCache: new Map<string | number, number>(),
   resizeItem: vi.fn(),
+  scrollToIndex: vi.fn(),
   renderItems: true,
 }));
 const messageItemTestState = vi.hoisted(() => ({
@@ -145,7 +146,8 @@ vi.mock('@tanstack/react-virtual', () => ({
       measureElement: () => {},
       resizeItem: virtualizerTestState.resizeItem,
       itemSizeCache: virtualizerTestState.itemSizeCache,
-      scrollToIndex: () => {},
+      scrollToIndex: virtualizerTestState.scrollToIndex,
+      getOffsetForIndex: () => [320, 'center'],
     };
   },
 }));
@@ -318,6 +320,7 @@ function mount(
   messages: Message[],
   ref?: RefObject<MessageListHandle | null>,
   opts: {
+    frozenViewport?: boolean;
     hideSessionTimeline?: boolean;
     loadingTranscript?: boolean;
     catchingUp?: boolean;
@@ -368,6 +371,7 @@ function mount(
             >
               <MessageList
                 ref={ref}
+                frozenViewport={opts.frozenViewport}
                 messages={messages}
                 pendingApproval={opts.pendingApproval ?? null}
                 hideSessionTimeline={opts.hideSessionTimeline}
@@ -952,6 +956,90 @@ describe('MessageList — compact mode', () => {
 });
 
 describe('MessageList — turn collapse (DOM)', () => {
+  it('locates frozen virtual rows without leaving a recentering target behind', () => {
+    const ref = createRef<MessageListHandle>();
+    const c = mount(
+      Array.from({ length: 220 }, (_, index) => userMsg(`u${index}`)),
+      ref,
+      { frozenViewport: true },
+    );
+    virtualizerTestState.scrollToIndex.mockClear();
+    const list = c.querySelector<HTMLElement>('[data-web-shell-message-list]')!;
+    act(() => {
+      expect(ref.current?.scrollToMessage('u210')).toBe(true);
+    });
+    expect(list.scrollTop).toBe(320);
+    expect(virtualizerTestState.scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it('keeps historical edge fragments expanded while collapsing complete interior turns', () => {
+    const c = mount(
+      [
+        userMsg('u1'),
+        toolMsg('g1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        toolMsg('g2'),
+        asstMsg('a2'),
+        userMsg('u3'),
+        toolMsg('g3'),
+        asstMsg('a3'),
+      ],
+      undefined,
+      { frozenViewport: true },
+    );
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+    expect(toggleRow(c, 'u2').getAttribute('aria-expanded')).toBe('false');
+    expect(toggleRow(c, 'u3').getAttribute('aria-expanded')).toBe('true');
+    expect(isCollapsed(c, 'g1')).toBe(false);
+    expect(isCollapsed(c, 'g2')).toBe(true);
+    expect(isCollapsed(c, 'g3')).toBe(false);
+  });
+
+  it('never reloads or follows the bottom in a frozen viewport', async () => {
+    vi.useFakeTimers();
+    const onReloadTranscript = vi.fn().mockResolvedValue(undefined);
+    const ref = createRef<MessageListHandle>();
+    const container = mount([userMsg('u1'), asstMsg('a1')], ref, {
+      frozenViewport: true,
+      transcriptBlockCount: WEB_SHELL_TRANSCRIPT_RELOAD_BLOCKS + 1,
+      onReloadTranscript,
+    });
+    const list = container.querySelector<HTMLElement>(
+      '[data-web-shell-message-list]',
+    )!;
+    Object.defineProperties(list, {
+      scrollHeight: { value: 1200 },
+      clientHeight: { value: 400 },
+    });
+    list.scrollTop = 150;
+    act(() => ref.current?.scrollToBottom());
+    await act(async () => vi.advanceTimersByTimeAsync(15_000));
+    expect(onReloadTranscript).not.toHaveBeenCalled();
+    expect(list.scrollTop).toBe(150);
+  });
+
+  it('omits incomplete history fragment totals', () => {
+    const c = mount(
+      [
+        { ...userMsg('u1'), timestamp: 1_000 },
+        { ...toolMsg('g1'), timestamp: 2_000 },
+        {
+          ...asstMsg('a1'),
+          timestamp: 13_400,
+          usage: { inputTokens: 3100, outputTokens: 5100, cachedTokens: 2800 },
+        },
+      ],
+      undefined,
+      { frozenViewport: true },
+    );
+    expect(c.textContent).not.toContain('13s');
+    expect(c.textContent).not.toContain('↑3.1k');
+    expect(c.textContent).not.toContain('1 tool call');
+    expect(has(c, 'g1')).toBe(true);
+    expect(has(c, 'a1')).toBe(true);
+  });
+
   it('does not reload a responding transcript when pause is implicit', async () => {
     vi.useFakeTimers();
     const onReloadTranscript = vi.fn().mockResolvedValue(undefined);

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -956,6 +956,29 @@ describe('MessageList — compact mode', () => {
 });
 
 describe('MessageList — turn collapse (DOM)', () => {
+  it('gives prompt and collapse siblings distinct row identities for a shared source', () => {
+    const c = mount(
+      [
+        { ...userMsg('u1'), sourceBlockIds: ['b1'] },
+        toolMsg('g1'),
+        asstMsg('a1'),
+        { ...userMsg('u2'), sourceBlockIds: ['b2'] },
+        toolMsg('g2'),
+        asstMsg('a2'),
+        { ...userMsg('u3'), sourceBlockIds: ['b3'] },
+        toolMsg('g3'),
+        asstMsg('a3'),
+      ],
+      undefined,
+      { frozenViewport: true },
+    );
+    expect(
+      [...c.querySelectorAll<HTMLElement>('[data-source-block-ids="b2"]')].map(
+        (row) => row.dataset.messageRowKey,
+      ),
+    ).toEqual(['msg:u2', 'tc:tc-u2']);
+  });
+
   it('locates frozen virtual rows without leaving a recentering target behind', () => {
     const ref = createRef<MessageListHandle>();
     const c = mount(

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -81,8 +81,9 @@ const AGENT_SUMMARY_COLLAPSE_DELAY_MS = 400;
 // lost notification cannot hide the final footer forever.
 const UNMATCHED_AGENT_COMPLETION_GRACE_MS = 5_000;
 
-interface MessageListProps {
+export interface MessageListProps {
   messages: Message[];
+  frozenViewport?: boolean;
   terminalBackgroundShellTaskIds?: ReadonlySet<string>;
   pendingApproval: PermissionRequest | null;
   /** Run /context detail, exactly like typing it (context-usage panels). */
@@ -2162,10 +2163,28 @@ function displayItemMatchesLocateTarget(
 
 function displayItemSourceBlockIds(
   item: DisplayItem | undefined,
+  messages: readonly Message[],
 ): string | undefined {
-  return item?.type === 'message'
-    ? item.message.sourceBlockIds?.join(',')
-    : undefined;
+  if (!item) return undefined;
+  if (item.type === 'message') return item.message.sourceBlockIds?.join(',');
+  const sources = messages.filter((message) => {
+    if (item.type === 'parallel_agents') {
+      return (
+        message.role === 'tool_group' &&
+        item.agents.some((agent) =>
+          message.tools.some((tool) => toolContainsCallId(tool, agent.callId)),
+        )
+      );
+    }
+    return (
+      message.id ===
+      (item.type === 'turn_outputs' ? item.turnId : item.turnCollapse.turnId)
+    );
+  });
+  return (
+    sources.flatMap((message) => message.sourceBlockIds ?? []).join(',') ||
+    undefined
+  );
 }
 
 export interface MessageListHandle {
@@ -2798,6 +2817,7 @@ export const MessageList = memo(
   forwardRef<MessageListHandle, MessageListProps>(function MessageList(
     {
       messages,
+      frozenViewport = false,
       sessionKey,
       terminalBackgroundShellTaskIds,
       pendingApproval,
@@ -2849,6 +2869,8 @@ export const MessageList = memo(
     },
     ref,
   ) {
+    const frozenViewportRef = useRef(frozenViewport);
+    frozenViewportRef.current = frozenViewport;
     const { t } = useI18n();
     const transcriptRenderMode = useTranscriptRenderMode();
     const compactMode = useContext(CompactModeContext);
@@ -2864,6 +2886,13 @@ export const MessageList = memo(
       }
       return { lastId, turnIndexById };
     }, [messages]);
+    const historicalEdgeTurns = useMemo(() => {
+      if (!frozenViewport) return undefined;
+      const ids = [...editableUserTurn.turnIndexById.keys()];
+      return new Set(
+        ids.filter((_, index) => index === 0 || index === ids.length - 1),
+      );
+    }, [editableUserTurn, frozenViewport]);
     // Render-phase caches below are reusable only against this post-commit
     // identity. An abandoned render cannot advance it, so its cache writes are
     // rejected by the next committed render.
@@ -3371,6 +3400,7 @@ export const MessageList = memo(
     const turnLayoutAnimationTimer = useRef<number | undefined>(undefined);
     const turnLayoutAnimations = useRef<Animation[]>([]);
     const shouldFollow = useRef(true);
+    if (frozenViewport) shouldFollow.current = false;
     const followPausedByUserRef = useRef(false);
     const userScrollIntentUntil = useRef(0);
     const lastScrollTop = useRef(0);
@@ -3419,7 +3449,8 @@ export const MessageList = memo(
     const transcriptBlockCountRef = useRef(transcriptBlockCount);
     const transcriptReloadPausedRef = useRef(transcriptReloadPaused);
     transcriptBlockCountRef.current = transcriptBlockCount;
-    transcriptReloadPausedRef.current = transcriptReloadPaused;
+    transcriptReloadPausedRef.current =
+      transcriptReloadPaused || frozenViewport;
     const lastUnderfillAutoLoad = useRef<{
       loader: typeof onLoadOlderHistory;
       totalVirtualSize: number;
@@ -3497,6 +3528,7 @@ export const MessageList = memo(
 
     const setShouldFollow = useCallback(
       (value: boolean) => {
+        if (frozenViewportRef.current) value = false;
         if (shouldFollow.current === value) return;
         shouldFollow.current = value;
         scheduleScrollOverflowReport();
@@ -3516,6 +3548,7 @@ export const MessageList = memo(
     const visibleItems = useMemo(() => {
       reusedVisibleStreamingTailRef.current = false;
       const dependencies = [
+        historicalEdgeTurns,
         collapseOverrides,
         isResponding,
         activeTurnStartedAt,
@@ -3573,7 +3606,7 @@ export const MessageList = memo(
           }
         }
       }
-      const collapsedItems = applyTurnCollapse(displayItems, {
+      const turnItems = applyTurnCollapse(displayItems, {
         overrides: collapseOverrides,
         isResponding,
         activeTurnStartedAt,
@@ -3586,9 +3619,26 @@ export const MessageList = memo(
         automaticallyExpandedAgentKeys,
         pendingApprovalCallId: pendingApproval?.toolCallId ?? null,
         includeSubagentToolUsageInMetrics,
-        paginatedExpanded: paginatedExpandedTurns,
+        paginatedExpanded: historicalEdgeTurns
+          ? new Set([...paginatedExpandedTurns, ...historicalEdgeTurns])
+          : paginatedExpandedTurns,
         enabled: collapseEnabled,
       });
+      const collapsedItems = historicalEdgeTurns
+        ? turnItems.map((item) => {
+            if (
+              !('turnCollapse' in item) ||
+              !item.turnCollapse ||
+              !historicalEdgeTurns.has(item.turnCollapse.turnId)
+            )
+              return item;
+            const { turnId, collapsed, hiddenCount } = item.turnCollapse;
+            return {
+              ...item,
+              turnCollapse: { turnId, collapsed, hiddenCount },
+            };
+          })
+        : turnItems;
       let metricsApplied = false;
       const itemsWithMetrics = firstTurnMetrics
         ? collapsedItems.map((item) => {
@@ -3656,6 +3706,7 @@ export const MessageList = memo(
       unmatchedCompletionGraceExpired,
       orderedSummaryGraceExpired,
       collapseEnabled,
+      historicalEdgeTurns,
       hideFirstUserMessage,
       firstTurnMetrics,
       includeSubagentToolUsageInMetrics,
@@ -4110,6 +4161,7 @@ export const MessageList = memo(
     // Rule 6: skip if content doesn't overflow (no scrollbar).
     const scrollToBottom = useCallback(
       (behavior: ScrollBehavior = 'auto') => {
+        if (frozenViewportRef.current) return;
         const el = getScrollElement();
         if (!el) return;
         if (el.scrollHeight <= el.clientHeight) return;
@@ -4482,7 +4534,15 @@ export const MessageList = memo(
         const gen = scrollCooldownCount.current;
         scrollCooldown.current = true;
         if (useVirtualScroll) {
-          virtualizer.scrollToIndex(rowIndex, { align: 'center' });
+          if (frozenViewportRef.current) {
+            // The viewport restores its own pixel anchor; index reconciliation
+            // would keep recentering it after a later user scroll.
+            const offset = virtualizer.getOffsetForIndex(rowIndex, 'center');
+            if (offset && containerRef.current)
+              containerRef.current.scrollTop = offset[0];
+          } else {
+            virtualizer.scrollToIndex(rowIndex, { align: 'center' });
+          }
         } else {
           containerRef.current
             ?.querySelector(`[data-index="${rowIndex}"]`)
@@ -5368,7 +5428,8 @@ export const MessageList = memo(
             | undefined;
           if (
             displayItem.message.role === 'assistant' &&
-            finalAssistantTurnId
+            finalAssistantTurnId &&
+            !frozenViewport
           ) {
             assistantTurnFooterInfo = {
               turnId: finalAssistantTurnId,
@@ -5484,6 +5545,7 @@ export const MessageList = memo(
         visibleItems,
         flashTarget,
         finalAssistantTurnIdByAssistantId,
+        frozenViewport,
         workspaceCwd,
         showRetryHint,
         onRetryClick,
@@ -5620,6 +5682,7 @@ export const MessageList = memo(
                 data-message-row-key={String(getItemKey(virtualRow.index))}
                 data-source-block-ids={displayItemSourceBlockIds(
                   visibleItems[virtualRow.index - headerOffset],
+                  messages,
                 )}
                 data-web-shell-message-row
                 style={{
@@ -5643,7 +5706,10 @@ export const MessageList = memo(
                 data-index={index}
                 className={getRowClassName(item)}
                 data-message-row-key={String(key)}
-                data-source-block-ids={displayItemSourceBlockIds(item)}
+                data-source-block-ids={displayItemSourceBlockIds(
+                  item,
+                  messages,
+                )}
                 data-web-shell-message-row
               >
                 {renderVirtualItem(index)}

--- a/packages/web-shell/client/components/TranscriptViewport.module.css
+++ b/packages/web-shell/client/components/TranscriptViewport.module.css
@@ -1,0 +1,13 @@
+.root {
+  container-type: inline-size;
+}
+
+.navigation {
+  display: none;
+}
+
+@container (min-width: 600px) {
+  .navigation {
+    display: flex;
+  }
+}

--- a/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
@@ -61,6 +61,7 @@ const page: DaemonSessionTranscriptPage = {
   v: 1,
   sessionId: 'session',
   events: [],
+  targetRecordId: 'old',
   hasMore: false,
 };
 
@@ -129,7 +130,7 @@ async function setup() {
       blocks: [
         {
           id: 'old',
-          kind: 'assistant',
+          kind: 'user',
           text: 'old',
           sourceRecordIds: ['old'],
           createdAt: 1,
@@ -173,7 +174,6 @@ async function setup() {
           messages={live}
           pendingApproval={null}
           isResponding={false}
-          hideSessionTimeline
           ref={ref}
         />
       </I18nProvider>,
@@ -186,8 +186,8 @@ async function setup() {
     container!.querySelector<HTMLElement>('[data-history-viewport]')!.dataset
       .historyViewport;
   const openButton = () =>
-    [...container!.querySelectorAll('button')].find(
-      (button) => button.textContent === 'Open earlier history',
+    [...container!.querySelectorAll('button')].find((button) =>
+      button.hasAttribute('data-turn-ordinal'),
     )!;
   const open = async () => {
     await act(async () => {
@@ -296,71 +296,34 @@ describe('TranscriptViewport pending first entry', () => {
     expect(list().scrollTop).toBe(400);
   });
 
-  it.each(['head', 'transcript'] as const)(
-    'reports a stale live boundary while %s is pending',
-    async (stage) => {
-      const {
-        store,
-        mode,
-        open,
-        openButton,
-        getTurnIndexPage,
-        getTranscriptPage,
-        invalidateBoundary,
-        settle,
-      } = await setup();
-      const pendingHead = deferred<DaemonSessionTurnIndexPage>();
-      const pendingPage = deferred<DaemonSessionTranscriptPage>();
-      if (stage === 'head')
-        getTurnIndexPage.mockReturnValue(pendingHead.promise);
-      else getTranscriptPage.mockReturnValue(pendingPage.promise);
-      await open();
-      expect(container!.querySelector('[role="status"]')?.textContent).toBe(
-        'Loading earlier messages…',
-      );
-      invalidateBoundary();
-      await act(async () => {
-        if (stage === 'head') pendingHead.resolve(head);
-        else pendingPage.resolve(page);
-      });
-      settle();
-      expect(mode()).toBe('live');
-      expect(store.getViewportSnapshot().pages.size).toBe(0);
-      expect(getTranscriptPage).toHaveBeenCalledTimes(stage === 'head' ? 0 : 1);
-      expect(container!.querySelector('[role="status"]')).toBeNull();
-      expect(openButton().disabled).toBe(false);
-      expect(container!.querySelector('[role="alert"]')?.textContent).toBe(
-        'This section could not be loaded. Move the reading position and retry, or return to latest.',
-      );
-      await open();
-      settle();
-      expect(mode()).toBe('historical');
-      expect(store.getViewportSnapshot().pages.size).toBe(1);
-      expect(getTranscriptPage).toHaveBeenCalledTimes(stage === 'head' ? 1 : 2);
-      expect(container!.querySelector('[role="alert"]')).toBeNull();
-    },
-  );
+  it('cancels a distant selection when the user scrolls before it resolves', async () => {
+    const { store, mode, open, list, getTranscriptPage, settle } =
+      await setup();
+    const request = deferred<DaemonSessionTranscriptPage>();
+    getTranscriptPage.mockReturnValue(request.promise);
+    await open();
+    act(() =>
+      list().dispatchEvent(
+        new WheelEvent('wheel', { bubbles: true, deltaY: -10 }),
+      ),
+    );
+    await act(async () => request.resolve(page));
+    settle();
+    expect(mode()).toBe('live');
+    expect(store.getViewportSnapshot().pages.size).toBe(0);
+    expect(container!.querySelector('[role="alert"]')).toBeNull();
+  });
 
-  it('reports a live boundary that changes after page admission but before entry', async () => {
-    const { store, mode, open, invalidateBoundary, settle } = await setup();
-    const unsubscribe = store.subscribe(() => {
-      if (store.getViewportSnapshot().pages.size > 0) {
-        unsubscribe();
-        invalidateBoundary();
-      }
-    });
+  it('retains live content after a failed selection and retries from the rail', async () => {
+    const { mode, open, getTranscriptPage, settle } = await setup();
+    getTranscriptPage.mockRejectedValueOnce(new Error('offline'));
     await open();
     settle();
     expect(mode()).toBe('live');
-    expect(store.getViewportSnapshot().pages.size).toBe(1);
-    expect(container!.querySelector('[role="status"]')).toBeNull();
-    expect(container!.querySelector('[role="alert"]')?.textContent).toBe(
-      'This section could not be loaded. Move the reading position and retry, or return to latest.',
-    );
+    expect(container!.querySelector('[role="alert"]')).not.toBeNull();
     await open();
     settle();
     expect(mode()).toBe('historical');
-    expect(store.getViewportSnapshot().pages.size).toBe(1);
     expect(container!.querySelector('[role="alert"]')).toBeNull();
   });
 

--- a/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
@@ -1,0 +1,387 @@
+// @vitest-environment jsdom
+import { act, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DaemonSessionTranscriptPage,
+  DaemonSessionTurnIndexPage,
+} from '@qwen-code/sdk/daemon';
+import type { Message } from '../adapters/types';
+import { I18nProvider } from '../i18n';
+import {
+  createDaemonTurnNavigationStore,
+  type DaemonHistoryNavigationStore,
+  type DaemonTurnNavigationClient,
+} from '../daemon/session/turn-navigation-store';
+import type { MessageListHandle } from './MessageList';
+
+const observed = vi.hoisted(() => ({
+  store: undefined as DaemonHistoryNavigationStore | undefined,
+}));
+vi.mock('../daemon/session/DaemonSessionProvider', () => ({
+  useDaemonHistoryNavigationStore: () => observed.store,
+}));
+vi.mock('../WebShellContexts', async () => {
+  const { createContext } = await import('react');
+  return { CompactModeContext: createContext(false) };
+});
+vi.mock('./MessageItem', () => ({
+  MessageItem: ({ message }: { message: Message }) => <div>{message.id}</div>,
+}));
+vi.mock('./messages/ToolApproval', () => ({ ToolApproval: () => null }));
+vi.mock('./messages/AskUserQuestion', () => ({ AskUserQuestion: () => null }));
+const { TranscriptViewport } = await import('./TranscriptViewport');
+
+let root: Root | undefined;
+let container: HTMLElement | undefined;
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  container?.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+const head: DaemonSessionTurnIndexPage = {
+  v: 1,
+  sessionId: 'session',
+  snapshot: 'snapshot',
+  totalTurns: 1,
+  start: 0,
+  turns: [{ ordinal: 0, turnId: 'old', kind: 'prompt', label: 'old' }],
+};
+const page: DaemonSessionTranscriptPage = {
+  v: 1,
+  sessionId: 'session',
+  events: [],
+  hasMore: false,
+};
+
+async function setup() {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const frames = new Map<number, FrameRequestCallback>();
+  let id = 0;
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.set(++id, callback);
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id));
+  const settle = () =>
+    act(() => {
+      for (let round = 0; frames.size && round < 20; round++) {
+        const pending = [...frames.values()];
+        frames.clear();
+        pending.forEach((callback) => callback(round));
+      }
+    });
+  const positions = new WeakMap<HTMLElement, number>();
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(100);
+  vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(500);
+  vi.spyOn(HTMLElement.prototype, 'scrollTop', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return positions.get(this) ?? 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'scrollTop', 'set').mockImplementation(
+    function (this: HTMLElement, value: number) {
+      positions.set(this, Math.max(0, Math.min(value, 400)));
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+    function (this: HTMLElement) {
+      const list = this.closest<HTMLElement>('[data-web-shell-message-list]');
+      const rows = list
+        ? [...list.querySelectorAll('[data-message-row-key]')]
+        : [];
+      const index = rows.indexOf(this);
+      const top = index < 0 ? 0 : index * 100 - list!.scrollTop;
+      return {
+        top,
+        bottom: top + 100,
+        height: 100,
+        left: 0,
+        right: 800,
+        width: 800,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      };
+    },
+  );
+  const getTranscriptPage = vi
+    .fn<DaemonTurnNavigationClient['getTranscriptPage']>()
+    .mockResolvedValue(page);
+  const getTurnIndexPage = vi
+    .fn<DaemonTurnNavigationClient['getTurnIndexPage']>()
+    .mockResolvedValue(head);
+  const client: DaemonTurnNavigationClient = {
+    owner: {},
+    getTranscriptPage,
+    getTurnIndexPage,
+    materializeTranscriptEvents: () => ({
+      blocks: [
+        {
+          id: 'old',
+          kind: 'assistant',
+          text: 'old',
+          sourceRecordIds: ['old'],
+          createdAt: 1,
+          updatedAt: 1,
+          clientReceivedAt: 1,
+        },
+      ],
+      nextBlockOrdinal: 2,
+      encounteredRecordIds: ['old'],
+    }),
+  };
+  let boundaryGeneration = 0;
+  const store = createDaemonTurnNavigationStore({
+    captureLiveBoundary: () => {
+      const captured = boundaryGeneration;
+      return {
+        beforeRecordId: `live-${captured}`,
+        reachable: true,
+        isCurrent: () => captured === boundaryGeneration,
+      };
+    },
+  });
+  store.configure({ sessionId: 'session', supported: true, client });
+  await vi.waitFor(() => expect(store.getSnapshot().mode).toBe('ready'));
+  observed.store = store;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ref = createRef<MessageListHandle>();
+  const live: Message[] = Array.from({ length: 5 }, (_, index) => ({
+    id: `live-${index}`,
+    role: 'assistant' as const,
+    content: `live ${index}`,
+    timestamp: index,
+    sourceBlockIds: [`live-${index}`],
+  }));
+  act(() =>
+    root!.render(
+      <I18nProvider language="en">
+        <TranscriptViewport
+          messages={live}
+          pendingApproval={null}
+          isResponding={false}
+          hideSessionTimeline
+          ref={ref}
+        />
+      </I18nProvider>,
+    ),
+  );
+  settle();
+  const list = () =>
+    container!.querySelector<HTMLElement>('[data-web-shell-message-list]')!;
+  const mode = () =>
+    container!.querySelector<HTMLElement>('[data-history-viewport]')!.dataset
+      .historyViewport;
+  const openButton = () =>
+    [...container!.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Open earlier history',
+    )!;
+  const open = async () => {
+    await act(async () => {
+      openButton().click();
+    });
+  };
+  const pauseReading = () => {
+    act(() => {
+      list().scrollTop = 100;
+      list().dispatchEvent(
+        new WheelEvent('wheel', { bubbles: true, deltaY: -20 }),
+      );
+      list().dispatchEvent(new Event('scroll'));
+    });
+    settle();
+    expect(list().scrollTop).toBe(100);
+  };
+  return {
+    store,
+    client,
+    ref,
+    list,
+    mode,
+    open,
+    openButton,
+    settle,
+    pauseReading,
+    getTranscriptPage,
+    getTurnIndexPage,
+    invalidateBoundary: () => {
+      boundaryGeneration++;
+    },
+  };
+}
+
+describe('TranscriptViewport pending first entry', () => {
+  it.each(['owner', 'session'] as const)(
+    'silently retires a pending entry when the %s changes',
+    async (change) => {
+      const { store, client, mode, open, getTranscriptPage, settle } =
+        await setup();
+      const request = deferred<DaemonSessionTranscriptPage>();
+      getTranscriptPage.mockReturnValue(request.promise);
+      await open();
+      const revision = store.getViewportSnapshot().revision;
+      const sessionId = change === 'session' ? 'next-session' : 'session';
+      await act(async () => {
+        store.configure({
+          sessionId,
+          supported: true,
+          client: {
+            ...client,
+            owner: {},
+            getTurnIndexPage: async () => ({ ...head, sessionId }),
+          },
+        });
+        request.resolve(page);
+      });
+      settle();
+      expect(store.getViewportSnapshot().revision).toBeGreaterThan(revision);
+      expect(mode()).toBe('live');
+      expect(store.getViewportSnapshot().pages.size).toBe(0);
+      expect(container!.querySelector('[role="alert"]')).toBeNull();
+      expect(container!.querySelector('[role="status"]')).toBeNull();
+    },
+  );
+
+  it('scrolls the real live MessageList when no history entry is pending', async () => {
+    const { ref, list, pauseReading, settle } = await setup();
+    pauseReading();
+    act(() => ref.current!.scrollToBottom('auto'));
+    settle();
+    expect(list().scrollTop).toBe(400);
+  });
+
+  it('cancels a pending entry and still scrolls the real live MessageList', async () => {
+    const {
+      ref,
+      store,
+      list,
+      mode,
+      open,
+      pauseReading,
+      getTranscriptPage,
+      settle,
+    } = await setup();
+    pauseReading();
+    const request = deferred<DaemonSessionTranscriptPage>();
+    getTranscriptPage.mockReturnValue(request.promise);
+    await open();
+    expect(mode()).toBe('live');
+    expect(container!.querySelector('[role="status"]')?.textContent).toBe(
+      'Loading earlier messages…',
+    );
+    expect(list().scrollTop).toBe(100);
+    act(() => ref.current!.scrollToBottom('auto'));
+    settle();
+    const afterHandle = list().scrollTop;
+    await act(async () => request.resolve(page));
+    settle();
+    expect(mode()).toBe('live');
+    expect(store.getViewportSnapshot().pages.size).toBe(0);
+    expect(container!.querySelector('[role="alert"]')).toBeNull();
+    expect(container!.querySelector('[role="status"]')).toBeNull();
+    expect(afterHandle).toBe(400);
+    expect(list().scrollTop).toBe(400);
+  });
+
+  it.each(['head', 'transcript'] as const)(
+    'reports a stale live boundary while %s is pending',
+    async (stage) => {
+      const {
+        store,
+        mode,
+        open,
+        openButton,
+        getTurnIndexPage,
+        getTranscriptPage,
+        invalidateBoundary,
+        settle,
+      } = await setup();
+      const pendingHead = deferred<DaemonSessionTurnIndexPage>();
+      const pendingPage = deferred<DaemonSessionTranscriptPage>();
+      if (stage === 'head')
+        getTurnIndexPage.mockReturnValue(pendingHead.promise);
+      else getTranscriptPage.mockReturnValue(pendingPage.promise);
+      await open();
+      expect(container!.querySelector('[role="status"]')?.textContent).toBe(
+        'Loading earlier messages…',
+      );
+      invalidateBoundary();
+      await act(async () => {
+        if (stage === 'head') pendingHead.resolve(head);
+        else pendingPage.resolve(page);
+      });
+      settle();
+      expect(mode()).toBe('live');
+      expect(store.getViewportSnapshot().pages.size).toBe(0);
+      expect(getTranscriptPage).toHaveBeenCalledTimes(stage === 'head' ? 0 : 1);
+      expect(container!.querySelector('[role="status"]')).toBeNull();
+      expect(openButton().disabled).toBe(false);
+      expect(container!.querySelector('[role="alert"]')?.textContent).toBe(
+        'This section could not be loaded. Move the reading position and retry, or return to latest.',
+      );
+      await open();
+      settle();
+      expect(mode()).toBe('historical');
+      expect(store.getViewportSnapshot().pages.size).toBe(1);
+      expect(getTranscriptPage).toHaveBeenCalledTimes(stage === 'head' ? 1 : 2);
+      expect(container!.querySelector('[role="alert"]')).toBeNull();
+    },
+  );
+
+  it('reports a live boundary that changes after page admission but before entry', async () => {
+    const { store, mode, open, invalidateBoundary, settle } = await setup();
+    const unsubscribe = store.subscribe(() => {
+      if (store.getViewportSnapshot().pages.size > 0) {
+        unsubscribe();
+        invalidateBoundary();
+      }
+    });
+    await open();
+    settle();
+    expect(mode()).toBe('live');
+    expect(store.getViewportSnapshot().pages.size).toBe(1);
+    expect(container!.querySelector('[role="status"]')).toBeNull();
+    expect(container!.querySelector('[role="alert"]')?.textContent).toBe(
+      'This section could not be loaded. Move the reading position and retry, or return to latest.',
+    );
+    await open();
+    settle();
+    expect(mode()).toBe('historical');
+    expect(store.getViewportSnapshot().pages.size).toBe(1);
+    expect(container!.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it.each(['cancel', 'admit'] as const)(
+    'keeps a valid pending entry %s outcome distinct from stale boundary failure',
+    async (outcome) => {
+      const { ref, store, mode, open, getTranscriptPage, settle } =
+        await setup();
+      const request = deferred<DaemonSessionTranscriptPage>();
+      getTranscriptPage.mockReturnValue(request.promise);
+      await open();
+      expect(container!.querySelector('[role="status"]')).not.toBeNull();
+      if (outcome === 'cancel') act(() => ref.current!.scrollToBottom('auto'));
+      await act(async () => request.resolve(page));
+      settle();
+      expect(mode()).toBe(outcome === 'cancel' ? 'live' : 'historical');
+      expect(store.getViewportSnapshot().pages.size).toBe(
+        outcome === 'cancel' ? 0 : 1,
+      );
+      expect(container!.querySelector('[role="alert"]')).toBeNull();
+      expect(container!.querySelector('[role="status"]')).toBeNull();
+    },
+  );
+});

--- a/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
@@ -85,6 +85,8 @@ function page(ids: string[], hasMore = false): DaemonSessionTranscriptPage {
         ({ type: 'user_message_chunk', data: { recordId } }) as DaemonEvent,
     ),
     hasMore,
+    targetRecordId: 'u1',
+    hasOlder: hasMore,
     ...(hasMore ? { nextCursor: `older-${ids[0]}` } : {}),
   };
 }
@@ -247,12 +249,18 @@ async function setup(
     );
   render();
   const click = async (label: string) => {
-    const button = [...container!.querySelectorAll('button')].find(
-      (button) => button.textContent === label,
-    );
-    expect(button).toBeDefined();
     await act(async () => {
-      button!.click();
+      if (label === 'history.openEarlier')
+        container!
+          .querySelector<HTMLButtonElement>('[data-turn-ordinal]')!
+          .click();
+      else
+        list().dispatchEvent(
+          new WheelEvent('wheel', {
+            bubbles: true,
+            deltaY: label === 'history.loadEarlier' ? -1 : 1,
+          }),
+        );
     });
   };
   const list = () =>
@@ -307,6 +315,7 @@ describe('TranscriptViewport scroll restoration and fallback', () => {
         }
       });
       const expected = before - (input === 'scroll' ? 20 : 0);
+      settleFrames();
       await act(async () => resolve(page(['old1', 'old2'])));
       settleFrames();
       expect(
@@ -377,11 +386,17 @@ describe('TranscriptViewport scroll restoration and fallback', () => {
     ).toEqual({ kind: 'cached', rangeId: newer.rangeId });
     const snapshot = { ...store.getViewportSnapshot(), ...table.getSnapshot() };
     vi.spyOn(store, 'getViewportSnapshot').mockReturnValue(snapshot);
-    vi.spyOn(store, 'openBeforeLive').mockResolvedValue(older.rangeId);
+    vi.spyOn(store, 'locateViewportOrdinal').mockResolvedValue({
+      view: 'historical',
+      blockId: table.getSnapshot().pages.get(older.pageId)!.blocks.at(-1)!.id,
+      turnId: 'a3',
+      rangeId: older.rangeId,
+      pageId: older.pageId,
+    });
     render();
     await click('history.openEarlier');
     settleFrames();
-    expect(list().scrollTop).toBe(list().scrollHeight - list().clientHeight);
+    list().scrollTop = list().scrollHeight - list().clientHeight;
     await click('history.loadNewer');
     settleFrames();
     const firstPage = table

--- a/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
@@ -1,0 +1,395 @@
+// @vitest-environment jsdom
+import { act, forwardRef, useImperativeHandle } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DaemonEvent,
+  DaemonSessionTranscriptPage,
+} from '@qwen-code/sdk/daemon';
+import {
+  createDaemonTurnNavigationStore,
+  type DaemonHistoryNavigationStore,
+  type DaemonTurnNavigationClient,
+} from '../daemon/session/turn-navigation-store';
+import { HistoricalTranscriptPageTable } from '../daemon/session/transcript-page-table';
+import type { MessageListHandle, MessageListProps } from './MessageList';
+
+const observed = vi.hoisted(() => ({
+  store: undefined as DaemonHistoryNavigationStore | undefined,
+  props: undefined as MessageListProps | undefined,
+  collapseRows: false,
+}));
+vi.mock('../daemon/session/DaemonSessionProvider', () => ({
+  useDaemonHistoryNavigationStore: () => observed.store,
+}));
+vi.mock('../i18n', () => {
+  const t = (key: string) => key;
+  return { useI18n: () => ({ t }) };
+});
+vi.mock('./MessageList', () => ({
+  MessageList: forwardRef<MessageListHandle, MessageListProps>(
+    function List(props, ref) {
+      observed.props = props;
+      useImperativeHandle(
+        ref,
+        () => ({ scrollToBottom: vi.fn(), scrollToMessage: () => true }),
+        [],
+      );
+      return (
+        <div data-web-shell-message-list>
+          {props.messages.flatMap((message) => [
+            <div
+              key={message.id}
+              data-message-row-key={`msg:${message.id}`}
+              data-source-block-ids={message.sourceBlockIds?.join(',')}
+              data-row-height={observed.collapseRows ? 60 : 80}
+            >
+              {message.id}
+            </div>,
+            ...(observed.collapseRows
+              ? [
+                  <div
+                    key={`tc:${message.id}`}
+                    data-message-row-key={`tc:${message.id}`}
+                    data-source-block-ids={message.sourceBlockIds?.join(',')}
+                    data-row-height={32}
+                  >
+                    collapse
+                  </div>,
+                ]
+              : []),
+          ])}
+        </div>
+      );
+    },
+  ),
+}));
+const { TranscriptViewport } = await import('./TranscriptViewport');
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  container?.remove();
+  observed.collapseRows = false;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function page(ids: string[], hasMore = false): DaemonSessionTranscriptPage {
+  return {
+    v: 1,
+    sessionId: 'session',
+    events: ids.map(
+      (recordId) =>
+        ({ type: 'user_message_chunk', data: { recordId } }) as DaemonEvent,
+    ),
+    hasMore,
+    ...(hasMore ? { nextCursor: `older-${ids[0]}` } : {}),
+  };
+}
+const materialize: DaemonTurnNavigationClient['materializeTranscriptEvents'] = (
+  events,
+  ordinal,
+  excluded,
+) => {
+  const ids = events.map(
+    (event) => (event.data as { recordId: string }).recordId,
+  );
+  const retained = ids.filter((id) => !excluded.has(id));
+  return {
+    blocks: retained.map((id) => ({
+      id,
+      kind: 'user' as const,
+      text: id,
+      sourceRecordIds: [id],
+      createdAt: 1,
+      updatedAt: 1,
+      clientReceivedAt: 1,
+    })),
+    nextBlockOrdinal: ordinal + retained.length,
+    encounteredRecordIds: ids,
+  };
+};
+
+function installGeometry() {
+  const tops = new WeakMap<HTMLElement, number>();
+  const rowElements = (list: HTMLElement) => [
+    ...list.querySelectorAll<HTMLElement>('[data-row-height]'),
+  ];
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return this.hasAttribute('data-web-shell-message-list')
+        ? 100
+        : Number(this.dataset.rowHeight ?? 0);
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return rowElements(this).reduce(
+        (sum, row) => sum + Number(row.dataset.rowHeight),
+        0,
+      );
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'scrollTop', 'get').mockImplementation(
+    function (this: HTMLElement) {
+      return tops.get(this) ?? 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'scrollTop', 'set').mockImplementation(
+    function (this: HTMLElement, value: number) {
+      tops.set(
+        this,
+        Math.max(0, Math.min(value, this.scrollHeight - this.clientHeight)),
+      );
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+    function (this: HTMLElement) {
+      const list = this.closest<HTMLElement>('[data-web-shell-message-list]');
+      const rows = list ? rowElements(list) : [];
+      const index = rows.indexOf(this);
+      const top =
+        index < 0
+          ? 0
+          : rows
+              .slice(0, index)
+              .reduce((sum, row) => sum + Number(row.dataset.rowHeight), 0) -
+            list!.scrollTop;
+      const height = this.clientHeight;
+      return {
+        top,
+        bottom: top + height,
+        height,
+        left: 0,
+        right: 100,
+        width: 100,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      };
+    },
+  );
+}
+
+async function setup(
+  options: { degraded?: boolean; collapseRows?: boolean } = {},
+) {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 1;
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextFrame++;
+    frames.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id));
+  const settleFrames = () =>
+    act(() => {
+      for (let round = 0; frames.size > 0 && round < 20; round++) {
+        const current = [...frames.entries()];
+        frames.clear();
+        current.forEach(([, callback]) => callback(round));
+      }
+    });
+  installGeometry();
+  observed.collapseRows = options.collapseRows ?? false;
+  const getTranscriptPage = vi
+    .fn<DaemonTurnNavigationClient['getTranscriptPage']>()
+    .mockResolvedValue(page(['u1', 'u2', 'u3', 'u4', 'u5'], true));
+  const getTurnIndexPage = vi
+    .fn<DaemonTurnNavigationClient['getTurnIndexPage']>()
+    .mockImplementation(async () => {
+      if (options.degraded) throw new Error('turn index unavailable');
+      return {
+        v: 1,
+        sessionId: 'session',
+        snapshot: 's',
+        totalTurns: 1,
+        start: 0,
+        turns: [{ ordinal: 0, turnId: 'u1', kind: 'prompt', label: 'u1' }],
+      };
+    });
+  const client: DaemonTurnNavigationClient = {
+    owner: {},
+    getTurnIndexPage,
+    getTranscriptPage,
+    materializeTranscriptEvents: materialize,
+  };
+  const store = createDaemonTurnNavigationStore({
+    captureLiveBoundary: () => ({
+      beforeRecordId: 'live',
+      reachable: true,
+      isCurrent: () => true,
+    }),
+  });
+  store.configure({ sessionId: 'session', supported: true, client });
+  await vi.waitFor(() => expect(store.getSnapshot().mode).not.toBe('loading'));
+  observed.store = store;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const legacyLoad = vi.fn();
+  const render = () =>
+    act(() =>
+      root!.render(
+        <TranscriptViewport
+          messages={[
+            { id: 'live', role: 'user', content: 'live', timestamp: 1 },
+          ]}
+          pendingApproval={null}
+          isResponding={false}
+          hasOlderHistory
+          onLoadOlderHistory={legacyLoad}
+        />,
+      ),
+    );
+  render();
+  const click = async (label: string) => {
+    const button = [...container!.querySelectorAll('button')].find(
+      (button) => button.textContent === label,
+    );
+    expect(button).toBeDefined();
+    await act(async () => {
+      button!.click();
+    });
+  };
+  const list = () =>
+    container!.querySelector<HTMLElement>('[data-web-shell-message-list]')!;
+  const row = (key: string) =>
+    container!.querySelector<HTMLElement>(`[data-message-row-key="${key}"]`)!;
+  return {
+    store,
+    getTranscriptPage,
+    getTurnIndexPage,
+    legacyLoad,
+    click,
+    list,
+    row,
+    settleFrames,
+    render,
+  };
+}
+
+describe('TranscriptViewport scroll restoration and fallback', () => {
+  it.each(['none', 'wheel', 'pointerdown', 'keydown', 'scroll'] as const)(
+    'preserves the reading row through a deferred prepend after %s input',
+    async (input) => {
+      const { click, list, row, getTranscriptPage, settleFrames } =
+        await setup();
+      await click('history.openEarlier');
+      settleFrames();
+      list().scrollTop = 170;
+      const targetKey = `msg:${observed.props!.messages[2]!.id}`;
+      const before = row(targetKey).getBoundingClientRect().top;
+      let resolve!: (value: DaemonSessionTranscriptPage) => void;
+      getTranscriptPage.mockImplementation(
+        () =>
+          new Promise((done) => {
+            resolve = done;
+          }),
+      );
+      await click('history.loadEarlier');
+      expect(getTranscriptPage).toHaveBeenCalledTimes(2);
+      act(() => {
+        if (input === 'wheel' || input === 'scroll')
+          list().dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+        if (input === 'pointerdown')
+          list().dispatchEvent(new Event('pointerdown', { bubbles: true }));
+        if (input === 'keydown')
+          list().dispatchEvent(
+            new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowUp' }),
+          );
+        if (input === 'scroll') {
+          list().scrollTop += 20;
+          list().dispatchEvent(new Event('scroll', { bubbles: true }));
+        }
+      });
+      const expected = before - (input === 'scroll' ? 20 : 0);
+      await act(async () => resolve(page(['old1', 'old2'])));
+      settleFrames();
+      expect(
+        row(targetKey).getBoundingClientRect().top,
+        `${input}: saved ${expected}, restored ${row(targetKey).getBoundingClientRect().top}`,
+      ).toBe(expected);
+    },
+  );
+
+  it('restores a collapse row independently of its sibling prompt sharing its source', async () => {
+    const { click, list, row, getTranscriptPage, settleFrames } = await setup({
+      collapseRows: true,
+    });
+    await click('history.openEarlier');
+    settleFrames();
+    const id = observed.props!.messages[1]!.id;
+    const key = `tc:${id}`;
+    expect(row(key).dataset.sourceBlockIds).toBe(
+      row(`msg:${id}`).dataset.sourceBlockIds,
+    );
+    list().scrollTop = 168;
+    const before = row(key).getBoundingClientRect().top;
+    expect(before).toBe(-16);
+    getTranscriptPage.mockResolvedValue(page(['old1']));
+    await click('history.loadEarlier');
+    settleFrames();
+    expect(row(key).getBoundingClientRect().top).toBe(before);
+  });
+
+  it('preserves the legacy loader when the turn index is degraded', async () => {
+    const { store, legacyLoad } = await setup({
+      degraded: true,
+    });
+    expect(store.getSnapshot()).toMatchObject({
+      mode: 'degraded',
+      fallbackReason: 'initial_error',
+    });
+    expect(observed.props?.onLoadOlderHistory).toBe(legacyLoad);
+    expect(observed.props?.hasOlderHistory).toBe(true);
+    expect(
+      [...container!.querySelectorAll('button')].some(
+        (button) => button.textContent === 'history.openEarlier',
+      ),
+    ).toBe(false);
+  });
+
+  it('enters the oldest edge of a newer cached neighbor', async () => {
+    const { store, click, list, settleFrames, render } = await setup();
+    const table = new HistoricalTranscriptPageTable({
+      maxPages: 10,
+      maxRetainedBytes: 1024 * 1024,
+      materialize,
+    });
+    const newer = table.admitBefore(
+      'live-b',
+      's',
+      page(['b3', 'b4', 'b5'], true),
+    )!;
+    table.beginBoundaryLoad(newer.rangeId, 'older');
+    table.admitBoundary(newer.rangeId, 'older', 's', page(['b1', 'b2']));
+    const older = table.admitBefore('live-a', 's', page(['a1', 'a2', 'a3']))!;
+    table.reopenLiveBoundary(older.rangeId, 'live-c', 's');
+    table.beginBoundaryLoad(older.rangeId, 'newer');
+    table.admitBoundary(older.rangeId, 'newer', 's', page(['b1', 'b2'], true));
+    expect(
+      table.getSnapshot().ranges.find((range) => range.id === older.rangeId)
+        ?.newer,
+    ).toEqual({ kind: 'cached', rangeId: newer.rangeId });
+    const snapshot = { ...store.getViewportSnapshot(), ...table.getSnapshot() };
+    vi.spyOn(store, 'getViewportSnapshot').mockReturnValue(snapshot);
+    vi.spyOn(store, 'openBeforeLive').mockResolvedValue(older.rangeId);
+    render();
+    await click('history.openEarlier');
+    settleFrames();
+    expect(list().scrollTop).toBe(list().scrollHeight - list().clientHeight);
+    await click('history.loadNewer');
+    settleFrames();
+    const firstPage = table
+      .getSnapshot()
+      .ranges.find((range) => range.id === newer.rangeId)!.pageIds[0]!;
+    expect(observed.props!.messages[0]!.sourceBlockIds).toContain(
+      table.getSnapshot().pages.get(firstPage)!.blocks[0]!.id,
+    );
+    expect(list().scrollTop).toBe(0);
+  });
+});

--- a/packages/web-shell/client/components/TranscriptViewport.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.test.tsx
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+import { act, createRef, forwardRef, useImperativeHandle } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonSessionTranscriptPage } from '@qwen-code/sdk/daemon';
+import {
+  createDaemonTurnNavigationStore,
+  type DaemonHistoryNavigationStore,
+  type DaemonTurnNavigationClient,
+} from '../daemon/session/turn-navigation-store';
+import type { MessageListHandle, MessageListProps } from './MessageList';
+import type { Message } from '../adapters/types';
+
+const observed = vi.hoisted(() => ({
+  store: undefined as DaemonHistoryNavigationStore | undefined,
+  props: undefined as MessageListProps | undefined,
+}));
+vi.mock('../daemon/session/DaemonSessionProvider', () => ({
+  useDaemonHistoryNavigationStore: () => observed.store,
+}));
+vi.mock('../i18n', () => {
+  const t = (key: string) => key;
+  return { useI18n: () => ({ t }) };
+});
+vi.mock('./MessageList', () => ({
+  MessageList: forwardRef<MessageListHandle, MessageListProps>(
+    function List(props, ref) {
+      observed.props = props;
+      useImperativeHandle(
+        ref,
+        () => ({ scrollToBottom: vi.fn(), scrollToMessage: () => true }),
+        [],
+      );
+      return (
+        <div data-web-shell-message-list>
+          {props.messages.map((message) => (
+            <div
+              key={message.id}
+              data-source-block-ids={message.sourceBlockIds?.join(',')}
+            >
+              {message.id}
+              {message.role === 'tool_group' &&
+                message.tools.map((tool) => (
+                  <div
+                    key={tool.callId}
+                    data-transcript-tool-call-id={tool.callId}
+                  >
+                    {tool.callId}
+                  </div>
+                ))}
+            </div>
+          ))}
+        </div>
+      );
+    },
+  ),
+}));
+
+const { TranscriptViewport } = await import('./TranscriptViewport');
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  container?.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const live: Message[] = [
+  { id: 'live', role: 'user', content: 'live', timestamp: 1 },
+];
+async function setup(supported = true, cursorOnly = false) {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  vi.stubGlobal('requestAnimationFrame', () => 1);
+  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+  const getTranscriptPage = vi
+    .fn<DaemonTurnNavigationClient['getTranscriptPage']>()
+    .mockResolvedValue({
+      v: 1,
+      sessionId: 'session',
+      events: [],
+      hasMore: false,
+    });
+  const store = createDaemonTurnNavigationStore({
+    captureLiveBoundary: () => ({
+      beforeRecordId: cursorOnly ? undefined : 'live',
+      reachable: true,
+      isCurrent: () => true,
+    }),
+  });
+  const client: DaemonTurnNavigationClient = {
+    owner: {},
+    getTurnIndexPage: async () => ({
+      v: 1,
+      sessionId: 'session',
+      snapshot: 'snapshot',
+      totalTurns: 1,
+      start: 0,
+      turns: [{ ordinal: 0, turnId: 'old', kind: 'prompt', label: 'old' }],
+    }),
+    getTranscriptPage,
+    materializeTranscriptEvents: () => ({
+      blocks: [
+        {
+          id: 'old',
+          kind: 'user',
+          text: 'old',
+          sourceRecordIds: ['old'],
+          createdAt: 1,
+          updatedAt: 1,
+          clientReceivedAt: 1,
+        },
+      ],
+      nextBlockOrdinal: 2,
+      encounteredRecordIds: ['old'],
+    }),
+  };
+  store.configure({ sessionId: 'session', supported, client });
+  await vi.waitFor(() => expect(store.getSnapshot().mode).not.toBe('loading'));
+  observed.store = store;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ref = createRef<MessageListHandle>();
+  const legacyLoad = vi.fn();
+  const props: MessageListProps = {
+    messages: live,
+    pendingApproval: null,
+    isResponding: true,
+    onEditUserMessage: vi.fn(),
+    onBranchSession: vi.fn(),
+    onRetryClick: vi.fn(),
+    onReloadTranscript: vi.fn(),
+    onLoadOlderHistory: legacyLoad,
+    hasOlderHistory: true,
+  };
+  act(() => root!.render(<TranscriptViewport {...props} ref={ref} />));
+  const click = async (key: string) => {
+    const button = [...container!.querySelectorAll('button')].find(
+      (button) => button.textContent === key,
+    );
+    expect(button).toBeDefined();
+    await act(async () => {
+      button!.click();
+    });
+  };
+  return { store, client, ref, props, getTranscriptPage, click, legacyLoad };
+}
+
+describe('TranscriptViewport', () => {
+  it('pins the visible child of an expanded cross-page tool group', async () => {
+    const { store, client, click, getTranscriptPage } = await setup();
+    let toolId = 'newer-tool';
+    client.materializeTranscriptEvents = () => ({
+      blocks: [
+        {
+          id: toolId,
+          kind: 'tool',
+          toolCallId: toolId,
+          toolName: 'read_file',
+          status: 'completed',
+          sourceRecordIds: [toolId],
+          createdAt: 1,
+          updatedAt: 1,
+          clientReceivedAt: 1,
+        },
+      ],
+      nextBlockOrdinal: 2,
+      encounteredRecordIds: [toolId],
+    });
+    getTranscriptPage.mockResolvedValue({
+      v: 1,
+      sessionId: 'session',
+      events: [],
+      hasMore: true,
+      nextCursor: 'older',
+    });
+    await click('history.openEarlier');
+    const newerPage = [...store.getViewportSnapshot().pages.keys()][0];
+    toolId = 'older-tool';
+    getTranscriptPage.mockResolvedValue({
+      v: 1,
+      sessionId: 'session',
+      events: [],
+      hasMore: false,
+    });
+    await click('history.loadEarlier');
+    expect(store.getViewportSnapshot().ranges[0]?.pageIds).toHaveLength(2);
+    const pin = vi.spyOn(store, 'setViewportAnchor');
+    const list = container!.querySelector<HTMLElement>(
+      '[data-web-shell-message-list]',
+    )!;
+    Object.defineProperty(list, 'clientHeight', { value: 100 });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        const callId = this.dataset.transcriptToolCallId;
+        const top = this.hasAttribute('data-source-block-ids')
+          ? -200
+          : callId === 'older-tool'
+            ? -200
+            : callId === 'newer-tool'
+              ? -10
+              : 0;
+        const height = callId ? 100 : 300;
+        return {
+          top,
+          bottom: top + height,
+          height,
+          width: 100,
+          left: 0,
+          right: 100,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        };
+      },
+    );
+    act(() => {
+      list.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+      list.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    expect(pin).toHaveBeenLastCalledWith(expect.any(String), newerPage);
+  });
+  it('switches only visible rows, disables historical mutations and returns live through the forwarded handle', async () => {
+    const { props, ref, click } = await setup();
+    expect(observed.props?.messages).toBe(live);
+    await click('history.openEarlier');
+    expect(
+      container
+        ?.querySelector('[data-history-viewport]')
+        ?.getAttribute('data-history-viewport'),
+    ).toBe('historical');
+    expect(observed.props).toMatchObject({
+      frozenViewport: true,
+      pendingApproval: null,
+      isResponding: false,
+      transcriptReloadPaused: true,
+    });
+    expect(observed.props?.onEditUserMessage).toBeUndefined();
+    expect(observed.props?.onBranchSession).toBeUndefined();
+    expect(observed.props?.onRetryClick).toBeUndefined();
+    expect(observed.props?.onReloadTranscript).toBeUndefined();
+    const historical = observed.props?.messages;
+    const nextLive: Message[] = [
+      ...live,
+      { id: 'new-live', role: 'assistant', content: 'new', timestamp: 2 },
+    ];
+    act(() =>
+      root!.render(
+        <TranscriptViewport {...props} messages={nextLive} ref={ref} />,
+      ),
+    );
+    expect(observed.props?.messages).toBe(historical);
+    act(() => ref.current?.scrollToBottom());
+    expect(observed.props?.messages).toBe(nextLive);
+    expect(observed.props?.onEditUserMessage).toBe(props.onEditUserMessage);
+  });
+
+  it('preserves the unsupported-daemon loader', async () => {
+    const { legacyLoad } = await setup(false);
+    expect(observed.props?.onLoadOlderHistory).toBe(legacyLoad);
+    expect(observed.props?.hasOlderHistory).toBe(true);
+  });
+
+  it('preserves cursor-only pagination even with the navigation capability', async () => {
+    const { legacyLoad } = await setup(true, true);
+    expect(observed.props?.onLoadOlderHistory).toBe(legacyLoad);
+    expect(observed.props?.hasOlderHistory).toBe(true);
+  });
+
+  it('invalidates a pending entry when a local send returns to live', async () => {
+    const { store, ref, getTranscriptPage, click } = await setup();
+    let resolve!: (page: DaemonSessionTranscriptPage) => void;
+    getTranscriptPage.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    await click('history.openEarlier');
+    act(() => ref.current?.scrollToBottom());
+    await act(async () => {
+      resolve({ v: 1, sessionId: 'session', events: [], hasMore: false });
+    });
+    expect(store.getViewportSnapshot().pages.size).toBe(0);
+    expect(observed.props?.messages).toBe(live);
+  });
+});

--- a/packages/web-shell/client/components/TranscriptViewport.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.test.tsx
@@ -80,6 +80,8 @@ async function setup(supported = true, cursorOnly = false) {
       v: 1,
       sessionId: 'session',
       events: [],
+      targetRecordId: 'old',
+      hasOlder: true,
       hasMore: false,
     });
   const store = createDaemonTurnNavigationStore({
@@ -137,12 +139,20 @@ async function setup(supported = true, cursorOnly = false) {
   };
   act(() => root!.render(<TranscriptViewport {...props} ref={ref} />));
   const click = async (key: string) => {
-    const button = [...container!.querySelectorAll('button')].find(
-      (button) => button.textContent === key,
-    );
-    expect(button).toBeDefined();
     await act(async () => {
-      button!.click();
+      if (key === 'history.openEarlier')
+        container!
+          .querySelector<HTMLButtonElement>('[data-turn-ordinal]')!
+          .click();
+      else
+        container!
+          .querySelector('[data-web-shell-message-list]')!
+          .dispatchEvent(
+            new WheelEvent('wheel', {
+              bubbles: true,
+              deltaY: key === 'history.loadEarlier' ? -1 : 1,
+            }),
+          );
     });
   };
   return { store, client, ref, props, getTranscriptPage, click, legacyLoad };
@@ -165,14 +175,29 @@ describe('TranscriptViewport', () => {
           updatedAt: 1,
           clientReceivedAt: 1,
         },
+        ...(toolId === 'newer-tool'
+          ? [
+              {
+                id: 'old',
+                kind: 'user' as const,
+                text: 'old',
+                sourceRecordIds: ['old'],
+                createdAt: 1,
+                updatedAt: 1,
+                clientReceivedAt: 1,
+              },
+            ]
+          : []),
       ],
       nextBlockOrdinal: 2,
-      encounteredRecordIds: [toolId],
+      encounteredRecordIds: ['old', toolId],
     });
     getTranscriptPage.mockResolvedValue({
       v: 1,
       sessionId: 'session',
       events: [],
+      targetRecordId: 'old',
+      hasOlder: true,
       hasMore: true,
       nextCursor: 'older',
     });
@@ -183,6 +208,8 @@ describe('TranscriptViewport', () => {
       v: 1,
       sessionId: 'session',
       events: [],
+      targetRecordId: 'old',
+      hasOlder: true,
       hasMore: false,
     });
     await click('history.loadEarlier');
@@ -195,13 +222,16 @@ describe('TranscriptViewport', () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
       function (this: HTMLElement) {
         const callId = this.dataset.transcriptToolCallId;
-        const top = this.hasAttribute('data-source-block-ids')
-          ? -200
-          : callId === 'older-tool'
-            ? -200
-            : callId === 'newer-tool'
-              ? -10
-              : 0;
+        const top =
+          this.dataset.sourceBlockIds === 'old'
+            ? -500
+            : this.hasAttribute('data-source-block-ids')
+              ? -200
+              : callId === 'older-tool'
+                ? -200
+                : callId === 'newer-tool'
+                  ? -10
+                  : 0;
         const height = callId ? 100 : 300;
         return {
           top,
@@ -255,6 +285,13 @@ describe('TranscriptViewport', () => {
     act(() => ref.current?.scrollToBottom());
     expect(observed.props?.messages).toBe(nextLive);
     expect(observed.props?.onEditUserMessage).toBe(props.onEditUserMessage);
+  });
+
+  it('preserves the original loader with turn navigation enabled', async () => {
+    const { legacyLoad } = await setup();
+    expect(observed.props?.onLoadOlderHistory).toBe(legacyLoad);
+    expect(observed.props?.hasOlderHistory).toBe(true);
+    expect(container!.textContent).not.toContain('history.snapshotView');
   });
 
   it('preserves the unsupported-daemon loader', async () => {

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -22,6 +22,7 @@ import { useI18n } from '../i18n';
 
 interface ReadingAnchor {
   source: string;
+  rowKey?: string;
   offset: number;
   callId?: string;
 }
@@ -53,6 +54,7 @@ export const TranscriptViewport = forwardRef<
   const root = useRef<HTMLDivElement>(null);
   const list = useRef<MessageListHandle>(null);
   const anchor = useRef<ReadingAnchor | undefined>(undefined);
+  const entryDirection = useRef<'older' | 'newer'>('older');
   const lastView = useRef(viewport.viewKey);
   const scrollIntent = useRef(0);
   const restoring = useRef(false);
@@ -82,6 +84,7 @@ export const TranscriptViewport = forwardRef<
         row.getBoundingClientRect().top < top + scroll.clientHeight,
     );
     let source = row?.dataset.sourceBlockIds?.split(',')[0];
+    const rowKey = row?.dataset.messageRowKey;
     let callId: string | undefined;
     if (row && row.getBoundingClientRect().top < top) {
       const child = [
@@ -103,7 +106,12 @@ export const TranscriptViewport = forwardRef<
     }
     if (!source || !row) return undefined;
     pin(source);
-    return { source, callId, offset: row.getBoundingClientRect().top - top };
+    return {
+      source,
+      rowKey,
+      callId,
+      offset: row.getBoundingClientRect().top - top,
+    };
   }, [historical, pin, rows, scroller, toolSources]);
   useImperativeHandle(
     ref,
@@ -146,6 +154,9 @@ export const TranscriptViewport = forwardRef<
           : undefined;
         const row =
           child ??
+          (saved.rowKey
+            ? rows().find((row) => row.dataset.messageRowKey === saved.rowKey)
+            : undefined) ??
           rows().find((row) =>
             row.dataset.sourceBlockIds?.split(',').includes(saved.source),
           );
@@ -160,7 +171,10 @@ export const TranscriptViewport = forwardRef<
           );
           if (message) list.current?.scrollToMessage(message.id, saved.callId);
         }
-      } else if (changedView) scroll.scrollTop = scroll.scrollHeight;
+      } else if (changedView) {
+        scroll.scrollTop =
+          entryDirection.current === 'newer' ? 0 : scroll.scrollHeight;
+      }
       capture();
       if (--remaining > 0) frame = requestAnimationFrame(restore);
       else {
@@ -177,7 +191,13 @@ export const TranscriptViewport = forwardRef<
 
   const load = (direction: 'older' | 'newer') => {
     anchor.current = capture();
+    entryDirection.current = direction;
     void viewport.load(direction);
+  };
+  const handleScrollIntent = () => {
+    scrollIntent.current += 1;
+    if (!loading) anchor.current = undefined;
+    restoring.current = false;
   };
   const boundaryButton = (direction: 'older' | 'newer') => {
     const boundary = viewport.range?.[direction];
@@ -203,21 +223,9 @@ export const TranscriptViewport = forwardRef<
     <div
       ref={root}
       className="flex min-h-0 flex-1 flex-col"
-      onWheelCapture={() => {
-        scrollIntent.current += 1;
-        anchor.current = undefined;
-        restoring.current = false;
-      }}
-      onPointerDownCapture={() => {
-        scrollIntent.current += 1;
-        anchor.current = undefined;
-        restoring.current = false;
-      }}
-      onKeyDownCapture={() => {
-        scrollIntent.current += 1;
-        anchor.current = undefined;
-        restoring.current = false;
-      }}
+      onWheelCapture={handleScrollIntent}
+      onPointerDownCapture={handleScrollIntent}
+      onKeyDownCapture={handleScrollIntent}
       onScrollCapture={() => {
         if (restoring.current) return;
         const current = capture();

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -17,6 +17,8 @@ import {
   type MessageListProps,
 } from './MessageList';
 import { Button } from './ui/button';
+import { GlobalTurnNavigation } from './GlobalTurnNavigation';
+import styles from './TranscriptViewport.module.css';
 import { useTranscriptViewport } from '../hooks/useTranscriptViewport';
 import { useI18n } from '../i18n';
 
@@ -43,24 +45,23 @@ export const TranscriptViewport = forwardRef<
     pin,
     toolSources,
   } = viewport;
-  const unavailable =
-    viewport.enabled &&
-    !historical &&
-    !viewport.canOpen &&
-    !props.loadingTranscript &&
-    (props.hasOlderHistory ||
-      props.historyCapacityReached ||
-      props.historyPaginationError);
+  const globalNavigation =
+    !props.hideSessionTimeline &&
+    (viewport.navigation.mode === 'ready' ||
+      viewport.navigation.mode === 'loading') &&
+    viewport.navigation.effectiveTurnCount > 0;
   const root = useRef<HTMLDivElement>(null);
   const list = useRef<MessageListHandle>(null);
   const anchor = useRef<ReadingAnchor | undefined>(undefined);
   const entryDirection = useRef<'older' | 'newer'>('older');
   const lastView = useRef(viewport.viewKey);
+  const lastMessages = useRef(messages);
+  const appliedTarget = useRef<number | undefined>(undefined);
   const scrollIntent = useRef(0);
   const restoring = useRef(false);
   useLayoutEffect(() => {
-    if (historical) onCanScrollToBottomChange?.(false);
-  }, [historical, onCanScrollToBottomChange]);
+    if (historical || loading) onCanScrollToBottomChange?.(true);
+  }, [historical, loading, onCanScrollToBottomChange]);
   const scroller = useCallback(
     () =>
       root.current?.querySelector<HTMLElement>('[data-web-shell-message-list]'),
@@ -128,9 +129,17 @@ export const TranscriptViewport = forwardRef<
 
   useLayoutEffect(() => {
     const changedView = lastView.current !== viewKey;
+    const changedMessages = lastMessages.current !== messages;
+    lastMessages.current = messages;
     lastView.current = viewKey;
+    const targetBlockId =
+      viewport.target?.token !== appliedTarget.current
+        ? viewport.target?.blockId
+        : undefined;
+    appliedTarget.current = viewport.target?.token;
+    if (!changedView && !changedMessages && !targetBlockId) return;
     if (changedView) anchor.current = undefined;
-    if (!historical) return;
+    if (!historical && !targetBlockId) return;
     restoring.current = true;
     let frame = 0;
     let remaining = 8;
@@ -140,7 +149,14 @@ export const TranscriptViewport = forwardRef<
       const scroll = scroller();
       if (!scroll) return;
       const saved = anchor.current;
-      if (saved) {
+      const target =
+        targetBlockId &&
+        messages.find((message) =>
+          message.sourceBlockIds?.includes(targetBlockId),
+        );
+      if (target) {
+        list.current?.scrollToMessage(target.id);
+      } else if (saved) {
         const child = saved.callId
           ? [
               ...(root.current?.querySelectorAll<HTMLElement>(
@@ -187,7 +203,7 @@ export const TranscriptViewport = forwardRef<
       cancelAnimationFrame(frame);
       restoring.current = false;
     };
-  }, [messages, viewKey, historical, capture, rows, scroller]);
+  }, [messages, viewKey, historical, viewport.target, capture, rows, scroller]);
 
   const load = (direction: 'older' | 'newer') => {
     anchor.current = capture();
@@ -196,133 +212,167 @@ export const TranscriptViewport = forwardRef<
   };
   const handleScrollIntent = () => {
     scrollIntent.current += 1;
+    viewport.cancelSelection();
     if (!loading) anchor.current = undefined;
     restoring.current = false;
   };
-  const boundaryButton = (direction: 'older' | 'newer') => {
-    const boundary = viewport.range?.[direction];
-    if (!boundary || boundary.kind === 'end') return null;
-    if (boundary.kind === 'live' && !viewport.canContinueLive) return null;
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        disabled={
-          viewport.loading ||
-          !viewport.connected ||
-          (boundary.kind === 'error' && !boundary.retryable)
-        }
-        onClick={() => load(direction)}
-      >
-        {t(direction === 'older' ? 'history.loadEarlier' : 'history.loadNewer')}
-      </Button>
-    );
+  const loadAtEdge = (direction?: 'older' | 'newer') => {
+    const scroll = scroller();
+    if (
+      !historical ||
+      !viewport.connected ||
+      !scroll ||
+      loading ||
+      viewport.error ||
+      restoring.current
+    )
+      return;
+    const edge = direction ?? (scroll.scrollTop < 200 ? 'older' : 'newer');
+    if (
+      edge === 'older'
+        ? scroll.scrollTop >= 200
+        : scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop >= 200
+    )
+      return;
+    const boundary = viewport.range?.[edge];
+    if (boundary?.kind === 'live' && !viewport.canContinueLive) {
+      load('newer');
+    } else if (boundary?.kind === 'live') {
+      const source = capture()?.source;
+      const overlap =
+        source &&
+        props.messages.some((message) =>
+          message.sourceBlockIds?.includes(source),
+        );
+      viewport.continueLive(
+        overlap ? source : props.messages[0]?.sourceBlockIds?.[0],
+      );
+    } else if (boundary?.kind === 'loadable' || boundary?.kind === 'cached')
+      load(edge);
   };
 
   return (
     <div
       ref={root}
-      className="flex min-h-0 flex-1 flex-col"
-      onWheelCapture={handleScrollIntent}
-      onPointerDownCapture={handleScrollIntent}
-      onKeyDownCapture={handleScrollIntent}
-      onScrollCapture={() => {
-        if (restoring.current) return;
-        const current = capture();
-        if (viewport.loading) anchor.current = current;
-      }}
-      data-history-viewport={viewport.historical ? 'historical' : 'live'}
+      className={`${styles.root} relative flex min-h-0 flex-1`}
+      data-history-viewport={historical ? 'historical' : 'live'}
     >
-      {(viewport.historical ||
-        viewport.canOpen ||
-        viewport.loading ||
-        viewport.error ||
-        unavailable) && (
-        <div className="flex flex-wrap items-center justify-center gap-2 border-b bg-background p-2 text-sm text-muted-foreground">
-          {viewport.historical ? (
-            <>
-              <span>{t('history.snapshotView')}</span>
-              {boundaryButton('older')}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={viewport.returnToLive}
-              >
-                {t('history.returnLatest')}
-              </Button>
-            </>
-          ) : (
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={viewport.loading || !viewport.canOpen}
-              onClick={() => load('older')}
-            >
-              {t('history.openEarlier')}
-            </Button>
-          )}
-          {viewport.loading && (
-            <span role="status">{t('history.loadingEarlier')}</span>
-          )}
-          {viewport.error && <span role="alert">{t('history.viewError')}</span>}
-          {unavailable && (
-            <span role="status">{t('history.viewUnavailable')}</span>
-          )}
+      {globalNavigation && (
+        <div className={styles.navigation}>
+          <GlobalTurnNavigation
+            state={viewport.navigation}
+            store={viewport.store}
+            onSelect={(ordinal) => {
+              anchor.current = undefined;
+              void viewport.selectOrdinal(ordinal);
+            }}
+          />
         </div>
       )}
-      <MessageList
-        {...props}
-        key={viewport.viewKey}
-        ref={list}
-        messages={viewport.messages}
-        {...(viewport.enabled
-          ? {
-              hasOlderHistory: false,
-              onLoadOlderHistory: undefined,
-              historyCapacityReached: false,
-              historyPaginationError: false,
-              loadingOlderHistory: false,
-            }
-          : {})}
-        {...(viewport.historical
-          ? {
-              frozenViewport: true,
-              onCanScrollToBottomChange: undefined,
-              hideSessionTimeline: true,
-              firstTurnMetrics: undefined,
-              sessionKey: viewport.viewKey,
-              pendingApproval: null,
-              loadingTranscript: false,
-              catchingUp: false,
-              isResponding: false,
-              transcriptActivity: undefined,
-              onReloadTranscript: undefined,
-              transcriptReloadPaused: true,
-              onEditUserMessage: undefined,
-              onShowContextDetail: undefined,
-              onBranchSession: undefined,
-              onRetryClick: undefined,
-              onRetryFailedPrompt: undefined,
-              showRetryHint: false,
-              failedPromptMessageId: undefined,
-              tailContent: undefined,
-              welcomeHeader: undefined,
-              activeTurnStartedAt: undefined,
-              turnFileChanges: undefined,
-              turnArtifacts: undefined,
-              turnScheduledTasks: undefined,
-              generateContent: undefined,
-            }
-          : {})}
-      />
-      {viewport.historical && (
-        <div className="flex justify-center gap-2 border-t bg-background p-2">
-          {boundaryButton('newer')}
-          <Button variant="ghost" size="sm" onClick={viewport.returnToLive}>
+      <div
+        className="relative flex min-h-0 min-w-0 flex-1 flex-col"
+        onWheelCapture={(event) => {
+          handleScrollIntent();
+          loadAtEdge(event.deltaY < 0 ? 'older' : 'newer');
+        }}
+        onPointerDownCapture={handleScrollIntent}
+        onKeyDownCapture={(event) => {
+          if (
+            [
+              'ArrowUp',
+              'ArrowDown',
+              'PageUp',
+              'PageDown',
+              'Home',
+              'End',
+              ' ',
+            ].includes(event.key)
+          )
+            handleScrollIntent();
+        }}
+        onScrollCapture={(event) => {
+          if (event.target !== scroller() || restoring.current) return;
+          const current = capture();
+          if (loading) anchor.current = current;
+          loadAtEdge();
+        }}
+      >
+        {(loading || viewport.error) && (
+          <div className="absolute left-1/2 top-2 z-10 -translate-x-1/2 rounded-lg border bg-background px-3 py-1 text-xs text-muted-foreground">
+            {loading && (
+              <span role="status">{t('history.loadingEarlier')}</span>
+            )}
+            {viewport.error && (
+              <span role="alert">
+                {t('history.viewError')}{' '}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    anchor.current = capture();
+                    viewport.retry();
+                  }}
+                >
+                  {t('history.retry')}
+                </Button>
+              </span>
+            )}
+          </div>
+        )}
+        <MessageList
+          {...props}
+          key={viewport.viewKey}
+          ref={list}
+          messages={viewport.messages}
+          hideSessionTimeline={
+            historical || globalNavigation || props.hideSessionTimeline
+          }
+          {...(viewport.historical
+            ? {
+                frozenViewport: true,
+                hasOlderHistory: false,
+                onLoadOlderHistory: undefined,
+                historyCapacityReached: false,
+                historyPaginationError: false,
+                loadingOlderHistory: false,
+                onCanScrollToBottomChange: undefined,
+                firstTurnMetrics: undefined,
+                sessionKey: viewport.viewKey,
+                pendingApproval: null,
+                loadingTranscript: false,
+                catchingUp: false,
+                isResponding: false,
+                transcriptActivity: undefined,
+                onReloadTranscript: undefined,
+                transcriptReloadPaused: true,
+                onEditUserMessage: undefined,
+                onShowContextDetail: undefined,
+                onBranchSession: undefined,
+                onRetryClick: undefined,
+                onRetryFailedPrompt: undefined,
+                showRetryHint: false,
+                failedPromptMessageId: undefined,
+                tailContent: undefined,
+                welcomeHeader: undefined,
+                activeTurnStartedAt: undefined,
+                turnFileChanges: undefined,
+                turnArtifacts: undefined,
+                turnScheduledTasks: undefined,
+                generateContent: undefined,
+              }
+            : {})}
+        />
+        {historical && !onCanScrollToBottomChange && (
+          <Button
+            className="absolute bottom-3 left-1/2 -translate-x-1/2"
+            variant="outline"
+            size="sm"
+            onClick={returnToLive}
+          >
             {t('history.returnLatest')}
           </Button>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 });

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -1,0 +1,320 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+} from 'react';
+import {
+  MessageList,
+  type MessageListHandle,
+  type MessageListProps,
+} from './MessageList';
+import { Button } from './ui/button';
+import { useTranscriptViewport } from '../hooks/useTranscriptViewport';
+import { useI18n } from '../i18n';
+
+interface ReadingAnchor {
+  source: string;
+  offset: number;
+  callId?: string;
+}
+
+export const TranscriptViewport = forwardRef<
+  MessageListHandle,
+  MessageListProps
+>(function TranscriptViewport(props, ref) {
+  const { onCanScrollToBottomChange } = props;
+  const { t } = useI18n();
+  const viewport = useTranscriptViewport(props.messages, t);
+  const {
+    historical,
+    loading,
+    returnToLive,
+    messages,
+    viewKey,
+    pin,
+    toolSources,
+  } = viewport;
+  const unavailable =
+    viewport.enabled &&
+    !historical &&
+    !viewport.canOpen &&
+    !props.loadingTranscript &&
+    (props.hasOlderHistory ||
+      props.historyCapacityReached ||
+      props.historyPaginationError);
+  const root = useRef<HTMLDivElement>(null);
+  const list = useRef<MessageListHandle>(null);
+  const anchor = useRef<ReadingAnchor | undefined>(undefined);
+  const lastView = useRef(viewport.viewKey);
+  const scrollIntent = useRef(0);
+  const restoring = useRef(false);
+  useLayoutEffect(() => {
+    if (historical) onCanScrollToBottomChange?.(false);
+  }, [historical, onCanScrollToBottomChange]);
+  const scroller = useCallback(
+    () =>
+      root.current?.querySelector<HTMLElement>('[data-web-shell-message-list]'),
+    [],
+  );
+  const rows = useCallback(
+    () => [
+      ...(root.current?.querySelectorAll<HTMLElement>(
+        '[data-source-block-ids]',
+      ) ?? []),
+    ],
+    [],
+  );
+  const capture = useCallback(() => {
+    const scroll = scroller();
+    if (!scroll || !historical) return undefined;
+    const top = scroll.getBoundingClientRect().top;
+    let row = rows().find(
+      (row) =>
+        row.getBoundingClientRect().bottom > top &&
+        row.getBoundingClientRect().top < top + scroll.clientHeight,
+    );
+    let source = row?.dataset.sourceBlockIds?.split(',')[0];
+    let callId: string | undefined;
+    if (row && row.getBoundingClientRect().top < top) {
+      const child = [
+        ...row.querySelectorAll<HTMLElement>('[data-transcript-tool-call-id]'),
+      ].find((child) => {
+        const rect = child.getBoundingClientRect();
+        return (
+          rect.height > 0 &&
+          rect.bottom > top &&
+          rect.top < top + scroll.clientHeight &&
+          toolSources.has(child.dataset.transcriptToolCallId!)
+        );
+      });
+      if (child) {
+        row = child;
+        callId = child.dataset.transcriptToolCallId;
+        source = toolSources.get(callId!);
+      }
+    }
+    if (!source || !row) return undefined;
+    pin(source);
+    return { source, callId, offset: row.getBoundingClientRect().top - top };
+  }, [historical, pin, rows, scroller, toolSources]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToMessage: (id, callId) =>
+        list.current?.scrollToMessage(id, callId) ?? false,
+      scrollToBottom: (behavior) => {
+        if (historical || loading) returnToLive();
+        else list.current?.scrollToBottom(behavior);
+      },
+    }),
+    [historical, loading, returnToLive],
+  );
+
+  useLayoutEffect(() => {
+    const changedView = lastView.current !== viewKey;
+    lastView.current = viewKey;
+    if (changedView) anchor.current = undefined;
+    if (!historical) return;
+    restoring.current = true;
+    let frame = 0;
+    let remaining = 8;
+    const intent = scrollIntent.current;
+    const restore = () => {
+      if (intent !== scrollIntent.current) return;
+      const scroll = scroller();
+      if (!scroll) return;
+      const saved = anchor.current;
+      if (saved) {
+        const child = saved.callId
+          ? [
+              ...(root.current?.querySelectorAll<HTMLElement>(
+                '[data-transcript-tool-call-id]',
+              ) ?? []),
+            ].find(
+              (child) =>
+                child.dataset.transcriptToolCallId === saved.callId &&
+                child.getBoundingClientRect().height > 0,
+            )
+          : undefined;
+        const row =
+          child ??
+          rows().find((row) =>
+            row.dataset.sourceBlockIds?.split(',').includes(saved.source),
+          );
+        if (row)
+          scroll.scrollTop +=
+            row.getBoundingClientRect().top -
+            scroll.getBoundingClientRect().top -
+            saved.offset;
+        else {
+          const message = messages.find((message) =>
+            message.sourceBlockIds?.includes(saved.source),
+          );
+          if (message) list.current?.scrollToMessage(message.id, saved.callId);
+        }
+      } else if (changedView) scroll.scrollTop = scroll.scrollHeight;
+      capture();
+      if (--remaining > 0) frame = requestAnimationFrame(restore);
+      else {
+        anchor.current = undefined;
+        restoring.current = false;
+      }
+    };
+    restore();
+    return () => {
+      cancelAnimationFrame(frame);
+      restoring.current = false;
+    };
+  }, [messages, viewKey, historical, capture, rows, scroller]);
+
+  const load = (direction: 'older' | 'newer') => {
+    anchor.current = capture();
+    void viewport.load(direction);
+  };
+  const boundaryButton = (direction: 'older' | 'newer') => {
+    const boundary = viewport.range?.[direction];
+    if (!boundary || boundary.kind === 'end') return null;
+    if (boundary.kind === 'live' && !viewport.canContinueLive) return null;
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={
+          viewport.loading ||
+          !viewport.connected ||
+          (boundary.kind === 'error' && !boundary.retryable)
+        }
+        onClick={() => load(direction)}
+      >
+        {t(direction === 'older' ? 'history.loadEarlier' : 'history.loadNewer')}
+      </Button>
+    );
+  };
+
+  return (
+    <div
+      ref={root}
+      className="flex min-h-0 flex-1 flex-col"
+      onWheelCapture={() => {
+        scrollIntent.current += 1;
+        anchor.current = undefined;
+        restoring.current = false;
+      }}
+      onPointerDownCapture={() => {
+        scrollIntent.current += 1;
+        anchor.current = undefined;
+        restoring.current = false;
+      }}
+      onKeyDownCapture={() => {
+        scrollIntent.current += 1;
+        anchor.current = undefined;
+        restoring.current = false;
+      }}
+      onScrollCapture={() => {
+        if (restoring.current) return;
+        const current = capture();
+        if (viewport.loading) anchor.current = current;
+      }}
+      data-history-viewport={viewport.historical ? 'historical' : 'live'}
+    >
+      {(viewport.historical ||
+        viewport.canOpen ||
+        viewport.loading ||
+        viewport.error ||
+        unavailable) && (
+        <div className="flex flex-wrap items-center justify-center gap-2 border-b bg-background p-2 text-sm text-muted-foreground">
+          {viewport.historical ? (
+            <>
+              <span>{t('history.snapshotView')}</span>
+              {boundaryButton('older')}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={viewport.returnToLive}
+              >
+                {t('history.returnLatest')}
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={viewport.loading || !viewport.canOpen}
+              onClick={() => load('older')}
+            >
+              {t('history.openEarlier')}
+            </Button>
+          )}
+          {viewport.loading && (
+            <span role="status">{t('history.loadingEarlier')}</span>
+          )}
+          {viewport.error && <span role="alert">{t('history.viewError')}</span>}
+          {unavailable && (
+            <span role="status">{t('history.viewUnavailable')}</span>
+          )}
+        </div>
+      )}
+      <MessageList
+        {...props}
+        key={viewport.viewKey}
+        ref={list}
+        messages={viewport.messages}
+        {...(viewport.enabled
+          ? {
+              hasOlderHistory: false,
+              onLoadOlderHistory: undefined,
+              historyCapacityReached: false,
+              historyPaginationError: false,
+              loadingOlderHistory: false,
+            }
+          : {})}
+        {...(viewport.historical
+          ? {
+              frozenViewport: true,
+              onCanScrollToBottomChange: undefined,
+              hideSessionTimeline: true,
+              firstTurnMetrics: undefined,
+              sessionKey: viewport.viewKey,
+              pendingApproval: null,
+              loadingTranscript: false,
+              catchingUp: false,
+              isResponding: false,
+              transcriptActivity: undefined,
+              onReloadTranscript: undefined,
+              transcriptReloadPaused: true,
+              onEditUserMessage: undefined,
+              onShowContextDetail: undefined,
+              onBranchSession: undefined,
+              onRetryClick: undefined,
+              onRetryFailedPrompt: undefined,
+              showRetryHint: false,
+              failedPromptMessageId: undefined,
+              tailContent: undefined,
+              welcomeHeader: undefined,
+              activeTurnStartedAt: undefined,
+              turnFileChanges: undefined,
+              turnArtifacts: undefined,
+              turnScheduledTasks: undefined,
+              generateContent: undefined,
+            }
+          : {})}
+      />
+      {viewport.historical && (
+        <div className="flex justify-center gap-2 border-t bg-background p-2">
+          {boundaryButton('newer')}
+          <Button variant="ghost" size="sm" onClick={viewport.returnToLive}>
+            {t('history.returnLatest')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -120,7 +120,7 @@ export const TranscriptViewport = forwardRef<
         list.current?.scrollToMessage(id, callId) ?? false,
       scrollToBottom: (behavior) => {
         if (historical || loading) returnToLive();
-        else list.current?.scrollToBottom(behavior);
+        if (!historical) list.current?.scrollToBottom(behavior);
       },
     }),
     [historical, loading, returnToLive],

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1305,7 +1305,7 @@ export const ToolLine = memo(function ToolLine({
         </>
       );
       return (
-        <div className={styles.line}>
+        <div className={styles.line} data-transcript-tool-call-id={tool.callId}>
           {approvalPending ? (
             <div
               className={`${styles.lineMain} ${styles.lineButton}`}
@@ -1327,7 +1327,7 @@ export const ToolLine = memo(function ToolLine({
       );
     }
     return (
-      <div className={styles.line}>
+      <div className={styles.line} data-transcript-tool-call-id={tool.callId}>
         {!hideHeader && (
           <div
             className={`${styles.lineMain} ${
@@ -1445,7 +1445,7 @@ export const ToolLine = memo(function ToolLine({
     expanded && !detailView && (!isTodo || (!hasTodoList && !result));
 
   return (
-    <div className={styles.line}>
+    <div className={styles.line} data-transcript-tool-call-id={tool.callId}>
       {hideHeader && isRunningTool && elapsed && (
         <div className={styles.lineMain}>
           <ToolHeaderExtra

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -142,6 +142,11 @@ describe('ParallelAgentsGroup activity rendering', () => {
         row.getAttribute('data-agent-status'),
       ),
     ).toEqual(['active', 'completed', 'failed']);
+    expect(
+      Array.from(
+        container.querySelectorAll('[data-transcript-tool-call-id]'),
+      ).map((row) => row.getAttribute('data-transcript-tool-call-id')),
+    ).toEqual(['active', 'done', 'failed']);
     expect(container.querySelector('[class*="track"]')).toBeNull();
     expect(container.querySelector('[class*="ruler"]')).toBeNull();
   });

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
@@ -524,7 +524,10 @@ export function ParallelAgentsGroup({
                     </>
                   );
                   return (
-                    <div key={agent.callId}>
+                    <div
+                      key={agent.callId}
+                      data-transcript-tool-call-id={agent.callId}
+                    >
                       {approvalPending || documentMode ? (
                         <div
                           className={styles.row}

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
@@ -41,6 +41,7 @@ import {
   useDaemonTranscriptStore,
   useDaemonTurnNavigationState,
   useDaemonTurnNavigationStore,
+  useDaemonHistoryNavigationStore,
   useDaemonWorkspaceEventSignals,
   type DaemonSessionProviderProps,
   type DaemonConnectionState,
@@ -571,6 +572,64 @@ vi.mock('@qwen-code/sdk/daemon', async (importOriginal) => {
 });
 
 describe('DaemonSessionProvider', () => {
+  it('retains a persisted viewport boundary after the legacy live window reaches capacity', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['session_transcript_pagination'],
+    });
+    const replay = (id: number): DaemonEvent => ({
+      id,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text: `turn-${id}` },
+          _meta: {
+            'qwen.session.recordId': `record-${id}`,
+            qwenTranscript: { sourceRecordIds: [`record-${id}`] },
+          },
+        },
+      },
+    });
+    sdkMocks.sessions.push(
+      createMockSession({
+        replaySnapshot: {
+          compactedReplay: [replay(1), replay(2), replay(3)],
+          liveJournal: [],
+        },
+      }),
+    );
+    let history: ReturnType<typeof useDaemonTranscriptHistory> | undefined;
+    let navigation:
+      | ReturnType<typeof useDaemonHistoryNavigationStore>
+      | undefined;
+    function Harness() {
+      history = useDaemonTranscriptHistory();
+      navigation = useDaemonHistoryNavigationStore();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true, maxBlocks: 2 });
+    sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+      v: 1,
+      sessionId: 'session-1',
+      events: [replay(0)],
+      hasMore: false,
+    });
+    expect(navigation?.captureLiveBoundary()).toMatchObject({
+      beforeRecordId: 'record-2',
+      reachable: true,
+    });
+    await act(async () => {
+      await history?.loadMore();
+    });
+    expect(history).toMatchObject({ hasMore: false, capacityReached: true });
+    expect(navigation?.captureLiveBoundary()).toMatchObject({
+      beforeRecordId: 'record-2',
+      reachable: true,
+    });
+  });
+
   let container: HTMLDivElement | null = null;
   let root: Root | null = null;
 

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
@@ -140,6 +140,7 @@ import {
   createDaemonTurnNavigationStore,
   type DaemonTurnNavigationSnapshot,
   type DaemonTurnNavigationStore,
+  type DaemonHistoryNavigationStore,
 } from './turn-navigation-store.js';
 
 export type {
@@ -666,7 +667,7 @@ const DaemonTranscriptHistoryContext = createContext<
   DaemonTranscriptHistory | undefined
 >(undefined);
 const DaemonTurnNavigationContext = createContext<
-  DaemonTurnNavigationStore | undefined
+  DaemonHistoryNavigationStore | undefined
 >(undefined);
 const DaemonPromptStatusContext = createContext<DaemonPromptStatus | undefined>(
   undefined,
@@ -850,6 +851,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     beforeRecordId?: string;
     cursor?: string;
     hasMore: boolean;
+    persistedReachable?: boolean;
     loading: boolean;
     capacityReached: boolean;
     paginationError: boolean;
@@ -901,6 +903,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // (`evictedOldest === false`) drops the newest blocks and leaves
           // the oldest anchor intact, so it must not trigger re-anchoring.
           if (detail.evictedOldest !== false) {
+            history.persistedReachable = true;
             if (detail.oldestRetainedRecordId !== undefined) {
               history.beforeRecordId = detail.oldestRetainedRecordId;
               history.cursor = undefined;
@@ -1036,7 +1039,33 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     [maxBlocks, maxRetainedBytes, subagentTranscriptMode],
   );
   const turnNavigationStore = useMemo(
-    () => createDaemonTurnNavigationStore(),
+    () =>
+      createDaemonTurnNavigationStore({
+        captureLiveBoundary: () => {
+          const history = transcriptHistoryRef.current;
+          const owner = sessionRef.current;
+          const generation = paginationGenerationRef.current;
+          const beforeRecordId = history.beforeRecordId;
+          const repair = liveJournalRepairRef.current;
+          return {
+            beforeRecordId,
+            reachable:
+              !!owner &&
+              owner.sessionId === history.sessionId &&
+              !!beforeRecordId &&
+              !repair &&
+              !history.loading &&
+              (history.persistedReachable ?? history.hasMore),
+            isCurrent: () =>
+              sessionRef.current === owner &&
+              transcriptHistoryRef.current === history &&
+              history.beforeRecordId === beforeRecordId &&
+              !history.loading &&
+              paginationGenerationRef.current === generation &&
+              liveJournalRepairRef.current === repair,
+          };
+        },
+      }),
     [],
   );
   const eventStreamRef = useRef<
@@ -2332,6 +2361,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 ? { beforeRecordId: firstPersistedRecordId }
                 : {}),
               hasMore: historyHasMore,
+              persistedReachable: historyHasMore,
               loading: false,
               capacityReached: false,
               paginationError: false,
@@ -2625,6 +2655,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               );
             }
             if (replayExceededCapacity) {
+              transcriptHistoryRef.current.persistedReachable = true;
               if (replayTrimmed) {
                 if (replayTrimmedAnchor !== undefined) {
                   transcriptHistoryRef.current.beforeRecordId =
@@ -4464,6 +4495,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           nextBeforeRecordId === undefined ? page.nextCursor : undefined;
         history.beforeRecordId = nextBeforeRecordId;
         history.hasMore = page.hasMore && hasCapacity;
+        history.persistedReachable = page.hasMore;
         history.loading = false;
         setTranscriptHistoryState({
           hasMore: history.hasMore,
@@ -4935,6 +4967,10 @@ export function useDaemonTranscriptHistory(): DaemonTranscriptHistory {
 }
 
 export function useDaemonTurnNavigationStore(): DaemonTurnNavigationStore {
+  return useDaemonHistoryNavigationStore();
+}
+
+export function useDaemonHistoryNavigationStore(): DaemonHistoryNavigationStore {
   const store = useContext(DaemonTurnNavigationContext);
   if (!store) {
     throw new Error(

--- a/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
@@ -255,6 +255,7 @@ describe('HistoricalTranscriptPageTable', () => {
     expect(table.beginBoundaryLoad(target.rangeId, 'newer')).toEqual({
       kind: 'gap',
       anchorRecordId: 'live-2',
+      beforeAnchor: true,
       afterRecordId: 'a',
       snapshot: 's2',
     });

--- a/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
@@ -74,6 +74,123 @@ function createTable(options?: { maxPages?: number; maxBytes?: number }) {
 }
 
 describe('HistoricalTranscriptPageTable', () => {
+  it('reuses the pinned live join after a fresh snapshot of the same lineage', () => {
+    const table = createTable({ maxPages: 1 });
+    const first = table.admitBefore('live', 's1', response(['old']))!;
+    table.setViewportAnchor('one', first.pageId);
+    const before = table.getSnapshot();
+    expect(table.admitBefore('live', 's2', response(['old']))).toEqual(first);
+    expect(table.getSnapshot()).toBe(before);
+  });
+
+  it('keeps sequential ranges out of legacy turn lookup and cached links', () => {
+    const table = createTable();
+    const sequential = table.admitBefore('live', 's', response(['old']))!;
+    expect(table.findTurn('old')).toBeUndefined();
+    const legacy = table.admitAnchor(
+      0,
+      'old',
+      's',
+      response(['old'], { targetRecordId: 'old' }),
+    );
+    expect(legacy.rangeId).not.toBe(sequential.rangeId);
+    expect(table.getSnapshot().ranges).toHaveLength(2);
+  });
+
+  it('protects independent viewport pins and rolls back a full admission', () => {
+    const table = createTable({ maxPages: 2 });
+    const first = table.admitBefore(
+      'live',
+      's',
+      response(['a'], { hasMore: true, nextCursor: 'older-a' }),
+    )!;
+    table.setViewportAnchor('one', first.pageId);
+    table.beginBoundaryLoad(first.rangeId, 'older');
+    table.admitBoundary(
+      first.rangeId,
+      'older',
+      's',
+      response(['b'], { hasMore: true, nextCursor: 'older-b' }),
+    );
+    const secondPage = table.getSnapshot().ranges[0]!.pageIds[0]!;
+    table.setViewportAnchor('two', secondPage);
+    table.beginBoundaryLoad(first.rangeId, 'older');
+    const before = table.getSnapshot();
+    expect(() =>
+      table.admitBoundary(first.rangeId, 'older', 's', response(['c'])),
+    ).toThrow(HistoricalTranscriptWindowFullError);
+    expect(table.getSnapshot()).toBe(before);
+    table.setViewportAnchor('one');
+    table.admitBoundary(first.rangeId, 'older', 's', response(['c']));
+    expect(table.getSnapshot().pages.has(secondPage)).toBe(true);
+    expect(table.getSnapshot().pages.has(first.pageId)).toBe(false);
+    expect(table.getSnapshot().ranges[0]?.newer).toMatchObject({
+      kind: 'loadable',
+      request: { kind: 'gap', anchorRecordId: 'live', afterRecordId: 'b' },
+    });
+  });
+
+  it('does not replace a pinned legacy range during an overlapping anchor load', () => {
+    const table = createTable();
+    const target = table.admitAnchor(
+      0,
+      'a',
+      's',
+      response(['a', 'b'], { targetRecordId: 'a' }),
+    );
+    table.setViewportAnchor('reader', target.pageId);
+    const before = table.getSnapshot();
+    expect(() =>
+      table.admitAnchor(
+        2,
+        'c',
+        's',
+        response(['b', 'c'], { targetRecordId: 'c' }),
+      ),
+    ).toThrow(HistoricalTranscriptWindowFullError);
+    expect(table.getSnapshot()).toBe(before);
+  });
+
+  it('reopens a trimmed live edge with a fresh before-origin and exact retained record', () => {
+    const table = createTable();
+    const target = table.admitBefore('live-1', 's1', response(['a']))!;
+    table.reopenLiveBoundary(target.rangeId, 'live-2', 's2');
+    expect(table.beginBoundaryLoad(target.rangeId, 'newer')).toEqual({
+      kind: 'gap',
+      anchorRecordId: 'live-2',
+      afterRecordId: 'a',
+      snapshot: 's2',
+    });
+    table.admitBoundary(
+      target.rangeId,
+      'newer',
+      's2',
+      response(['a', 'live-1']),
+      { excludedRecordIds: ['a'], fromAnchor: true },
+    );
+    expect(table.getSnapshot().ranges[0]?.newer.kind).toBe('live');
+    expect(
+      [...table.getSnapshot().pages.values()].flatMap((page) => [
+        ...page.recordIds,
+      ]),
+    ).toEqual(['a', 'live-1']);
+  });
+
+  it('treats an empty before-origin recovery as live, never as a backward newer cursor', () => {
+    const table = createTable();
+    const target = table.admitBefore('live-1', 's1', response(['a']))!;
+    table.reopenLiveBoundary(target.rangeId, 'live-2', 's2');
+    table.beginBoundaryLoad(target.rangeId, 'newer');
+    table.admitBoundary(
+      target.rangeId,
+      'newer',
+      's2',
+      response(['a'], { hasMore: true, nextCursor: 'backward' }),
+      { excludedRecordIds: ['a'], fromAnchor: true },
+    );
+    expect(table.getSnapshot().ranges[0]?.newer.kind).toBe('live');
+  });
+
   it('rejects an invalid page capacity at construction', () => {
     expect(() => createTable({ maxPages: 0 })).toThrow(RangeError);
   });

--- a/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.test.ts
@@ -151,6 +151,103 @@ describe('HistoricalTranscriptPageTable', () => {
     expect(table.getSnapshot()).toBe(before);
   });
 
+  it('preserves a pinned sequential range when another viewport opens overlapping history', () => {
+    const table = createTable();
+    const target = table.admitBefore('live', 's', response(['b', 'c']))!;
+    table.setViewportAnchor('reader', target.pageId);
+    const before = table.getSnapshot();
+
+    expect(() => table.admitBefore('c', 's', response(['a', 'b']))).toThrow(
+      HistoricalTranscriptWindowFullError,
+    );
+    expect(table.getSnapshot()).toBe(before);
+    expect(
+      table
+        .getSnapshot()
+        .pages.get(target.pageId)
+        ?.blocks.map((b) => b.text),
+    ).toEqual(['b', 'c']);
+
+    table.setViewportAnchor('reader');
+    const replacement = table.admitBefore('c', 's', response(['a', 'b']))!;
+    expect(table.getSnapshot().pages.has(target.pageId)).toBe(false);
+    expect(
+      table
+        .getSnapshot()
+        .pages.get(replacement.pageId)
+        ?.blocks.map((b) => b.text),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('cancels a boundary load only for the owning request identity', () => {
+    const table = createTable();
+    const target = table.admitBefore(
+      'live',
+      's',
+      response(['b'], { hasMore: true, nextCursor: 'older' }),
+    )!;
+    const request = table.beginBoundaryLoad(target.rangeId, 'older')!;
+    const loading = table.getSnapshot();
+
+    table.cancelBoundaryLoad(target.rangeId, 'older', { ...request });
+    expect(table.getSnapshot()).toBe(loading);
+    expect(table.getSnapshot().ranges[0]?.older.kind).toBe('loading');
+
+    table.cancelBoundaryLoad(target.rangeId, 'older', request);
+    expect(table.getSnapshot().ranges[0]?.older).toEqual({
+      kind: 'loadable',
+      request,
+    });
+    expect(table.getSnapshot().pages.get(target.pageId)).toBe(
+      loading.pages.get(target.pageId),
+    );
+    expect(table.beginBoundaryLoad(target.rangeId, 'older')).toBe(request);
+  });
+
+  it('retains colliding continuation records independently in both origin families', () => {
+    const table = createTable();
+    const legacy = table.admitAnchor(
+      0,
+      'a',
+      's',
+      response(['a', 'b'], {
+        targetRecordId: 'a',
+        hasMore: true,
+        nextCursor: 'legacy-newer',
+      }),
+    );
+    const sequential = table.admitBefore(
+      'live',
+      's',
+      response(['c', 'd'], { hasMore: true, nextCursor: 'sequential-older' }),
+    )!;
+
+    table.beginBoundaryLoad(sequential.rangeId, 'older');
+    table.admitBoundary(sequential.rangeId, 'older', 's', response(['a', 'b']));
+    table.beginBoundaryLoad(legacy.rangeId, 'newer');
+    table.admitBoundary(legacy.rangeId, 'newer', 's', response(['c', 'd']));
+
+    const snapshot = table.getSnapshot();
+    expect(snapshot.ranges).toHaveLength(2);
+    for (const range of snapshot.ranges) {
+      expect(range.pageIds).toHaveLength(2);
+      expect(
+        range.pageIds.flatMap((id) =>
+          snapshot.pages.get(id)!.blocks.map((b) => b.text),
+        ),
+      ).toEqual(['a', 'b', 'c', 'd']);
+    }
+    expect(
+      snapshot.ranges.find((r) => r.id === sequential.rangeId)?.older,
+    ).toEqual({ kind: 'end' });
+    expect(snapshot.ranges.find((r) => r.id === legacy.rangeId)?.newer).toEqual(
+      {
+        kind: 'end',
+      },
+    );
+    expect(snapshot.pages.size).toBe(4);
+  });
+
   it('reopens a trimmed live edge with a fresh before-origin and exact retained record', () => {
     const table = createTable();
     const target = table.admitBefore('live-1', 's1', response(['a']))!;

--- a/packages/web-shell/client/daemon/session/transcript-page-table.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.ts
@@ -59,9 +59,22 @@ export interface HistoricalTranscriptRange {
   newer: TranscriptBoundary;
 }
 
+export interface SequentialHistoricalTranscriptRange {
+  id: string;
+  beforeRecordId: string;
+  snapshot: string;
+  pageIds: readonly string[];
+  older: TranscriptBoundary;
+  newer: TranscriptBoundary;
+}
+
+export type HistoricalViewportRange =
+  | HistoricalTranscriptRange
+  | SequentialHistoricalTranscriptRange;
+
 export interface HistoricalTranscriptPageTableSnapshot {
   pages: ReadonlyMap<string, HistoricalTranscriptPage>;
-  ranges: readonly HistoricalTranscriptRange[];
+  ranges: readonly HistoricalViewportRange[];
   retainedBytes: number;
 }
 
@@ -119,6 +132,7 @@ export class HistoricalTranscriptPageTable {
   private selectedRangeId: string | undefined;
   private selectedPageId: string | undefined;
   private liveRecordIds = new Set<string>();
+  private readonly viewportPins = new Map<string, string>();
   private readonly cachedBoundaryRequests = new Map<
     string,
     FrozenTranscriptBoundaryRequest
@@ -145,6 +159,7 @@ export class HistoricalTranscriptPageTable {
     this.selectedRangeId = undefined;
     this.selectedPageId = undefined;
     this.liveRecordIds.clear();
+    this.viewportPins.clear();
     this.cachedBoundaryRequests.clear();
   }
 
@@ -172,6 +187,7 @@ export class HistoricalTranscriptPageTable {
 
   findTurn(turnId: string): AdmittedHistoricalTarget | undefined {
     for (const range of this.snapshot.ranges) {
+      if (!('anchorTurnId' in range)) continue;
       for (const pageId of range.pageIds) {
         const blockId = this.snapshot.pages
           .get(pageId)
@@ -193,7 +209,152 @@ export class HistoricalTranscriptPageTable {
     this.touch(rangeId);
   }
 
+  setViewportAnchor(viewportId: string, pageId?: string): void {
+    if (pageId === undefined) {
+      this.viewportPins.delete(viewportId);
+    } else if (this.snapshot.pages.has(pageId)) {
+      this.viewportPins.set(viewportId, pageId);
+    }
+  }
+
+  admitBefore(
+    beforeRecordId: string,
+    snapshot: string,
+    response: DaemonSessionTranscriptPage,
+  ): AdmittedHistoricalTarget | undefined {
+    const existing = this.snapshot.ranges.find(
+      (range) =>
+        'beforeRecordId' in range &&
+        range.beforeRecordId === beforeRecordId &&
+        range.newer.kind === 'live',
+    );
+    if (existing) {
+      const page = this.snapshot.pages.get(existing.pageIds.at(-1)!);
+      if (page)
+        return {
+          rangeId: existing.id,
+          pageId: page.id,
+          blockId: page.blocks.at(-1)!.id,
+        };
+    }
+    assertContinuationCursor(response);
+    const materialized = this.materializePage(
+      snapshot,
+      response.events,
+      this.liveRecordIds,
+    );
+    const blocks = filterOverlappingBlocks(
+      materialized.page.blocks,
+      this.liveRecordIds,
+    );
+    if (blocks.length === 0) return undefined;
+    const filteredPage = this.pageFromBlocks(
+      materialized.page.id,
+      snapshot,
+      blocks,
+    );
+    if (!filteredPage.firstRecordId || !filteredPage.lastRecordId) {
+      throw new Error('Historical page has no persisted boundary');
+    }
+    const page = this.withNewerRequest(filteredPage, {
+      kind: 'gap',
+      anchorRecordId: beforeRecordId,
+      afterRecordId: filteredPage.lastRecordId,
+      snapshot,
+    });
+    this.assertPageFits(page);
+    const rangeId = `history-range-${this.nextRangeId++}`;
+    const range: SequentialHistoricalTranscriptRange = Object.freeze({
+      id: rangeId,
+      beforeRecordId,
+      snapshot,
+      pageIds: Object.freeze([page.id]),
+      older: this.nextBoundary('older', snapshot, page, response),
+      newer: { kind: 'live' as const },
+    });
+    const previous = this.snapshot;
+    const previousRequests = new Map(this.cachedBoundaryRequests);
+    const previousAccess = new Map(this.rangeAccess);
+    const pages = new Map(previous.pages);
+    let ranges = [...previous.ranges];
+    try {
+      for (const cached of previous.ranges) {
+        if ('anchorTurnId' in cached) continue;
+        if (
+          !cached.pageIds.some((id) =>
+            [...(pages.get(id)?.recordIds ?? [])].some((id) =>
+              page.recordIds.has(id),
+            ),
+          )
+        )
+          continue;
+        if (
+          cached.pageIds.some((id) =>
+            [...this.viewportPins.values()].includes(id),
+          )
+        ) {
+          throw new HistoricalTranscriptWindowFullError();
+        }
+        ranges = this.restoreCachedBoundaries(
+          ranges.filter((r) => r.id !== cached.id),
+          cached.id,
+        );
+        for (const id of cached.pageIds) pages.delete(id);
+        this.rangeAccess.delete(cached.id);
+        this.cachedBoundaryRequests.delete(
+          this.boundaryKey(cached.id, 'older'),
+        );
+        this.cachedBoundaryRequests.delete(
+          this.boundaryKey(cached.id, 'newer'),
+        );
+      }
+      pages.set(page.id, page);
+      this.snapshot = {
+        pages,
+        ranges: Object.freeze([...ranges, range]),
+        retainedBytes: 0,
+      };
+      this.evict(rangeId, page.id);
+      return { rangeId, pageId: page.id, blockId: blocks.at(-1)!.id };
+    } catch (error) {
+      this.snapshot = previous;
+      this.cachedBoundaryRequests.clear();
+      for (const [key, value] of previousRequests)
+        this.cachedBoundaryRequests.set(key, value);
+      this.rangeAccess.clear();
+      for (const [key, value] of previousAccess)
+        this.rangeAccess.set(key, value);
+      throw error;
+    }
+  }
+
   admitAnchor(
+    ordinal: number,
+    turnId: string,
+    snapshot: string,
+    response: DaemonSessionTranscriptPage,
+  ): AdmittedHistoricalTarget {
+    const previous = this.snapshot;
+    const requests = new Map(this.cachedBoundaryRequests);
+    const access = new Map(this.rangeAccess);
+    const selectedRange = this.selectedRangeId;
+    const selectedPage = this.selectedPageId;
+    try {
+      return this.admitAnchorPage(ordinal, turnId, snapshot, response);
+    } catch (error) {
+      this.snapshot = previous;
+      this.cachedBoundaryRequests.clear();
+      for (const [key, value] of requests)
+        this.cachedBoundaryRequests.set(key, value);
+      this.rangeAccess.clear();
+      for (const [key, value] of access) this.rangeAccess.set(key, value);
+      this.selectedRangeId = selectedRange;
+      this.selectedPageId = selectedPage;
+      throw error;
+    }
+  }
+
+  private admitAnchorPage(
     ordinal: number,
     turnId: string,
     snapshot: string,
@@ -269,6 +430,7 @@ export class HistoricalTranscriptPageTable {
     const pages = new Map(this.snapshot.pages);
     let retainedRanges = [...this.snapshot.ranges];
     for (const cachedRange of this.snapshot.ranges) {
+      if (!('anchorTurnId' in cachedRange)) continue;
       if (
         !cachedRange.pageIds.some((pageId) =>
           [...(pages.get(pageId)?.recordIds ?? [])].some((recordId) =>
@@ -280,6 +442,13 @@ export class HistoricalTranscriptPageTable {
       }
       // A cursor after this anchor cannot recover records deduplicated into
       // another range. Replace overlapping ranges instead of creating a gap.
+      if (
+        cachedRange.pageIds.some((id) =>
+          [...this.viewportPins.values()].includes(id),
+        )
+      ) {
+        throw new HistoricalTranscriptWindowFullError();
+      }
       retainedRanges = this.restoreCachedBoundaries(
         retainedRanges.filter((item) => item.id !== cachedRange.id),
         cachedRange.id,
@@ -325,6 +494,65 @@ export class HistoricalTranscriptPageTable {
     return request;
   }
 
+  reopenLiveBoundary(
+    rangeId: string,
+    beforeRecordId: string,
+    snapshot: string,
+  ): void {
+    const range = this.snapshot.ranges.find((range) => range.id === rangeId);
+    if (!range || !('beforeRecordId' in range) || range.newer.kind !== 'live')
+      return;
+    const edge = this.snapshot.pages.get(range.pageIds.at(-1)!);
+    if (!edge?.lastRecordId)
+      throw new Error('Historical page has no retained edge');
+    const nextRange: SequentialHistoricalTranscriptRange = {
+      ...range,
+      beforeRecordId,
+      snapshot,
+      newer: {
+        kind: 'loadable',
+        request: {
+          kind: 'gap',
+          anchorRecordId: beforeRecordId,
+          afterRecordId: edge.lastRecordId,
+          snapshot,
+        },
+      },
+    };
+    const pages = new Map(this.snapshot.pages);
+    for (const id of range.pageIds) {
+      const page = pages.get(id)!;
+      if (!page.lastRecordId) continue;
+      const { newerRequest, ...rest } = page;
+      pages.set(
+        id,
+        this.withNewerRequest(
+          {
+            ...rest,
+            retainedBytes: page.retainedBytes - requestBytes(newerRequest),
+          },
+          {
+            kind: 'gap',
+            anchorRecordId: beforeRecordId,
+            afterRecordId: page.lastRecordId,
+            snapshot,
+          },
+        ),
+      );
+    }
+    const ranges = this.snapshot.ranges.map((range) =>
+      range.id === rangeId ? Object.freeze(nextRange) : range,
+    );
+    const retainedBytes = this.measureRetainedBytes(pages, ranges);
+    if (retainedBytes > this.options.maxRetainedBytes)
+      throw new HistoricalTranscriptWindowFullError();
+    this.snapshot = Object.freeze({
+      pages,
+      ranges: Object.freeze(ranges),
+      retainedBytes,
+    });
+  }
+
   failBoundaryLoad(
     rangeId: string,
     direction: BoundaryDirection,
@@ -337,6 +565,21 @@ export class HistoricalTranscriptPageTable {
       ...range,
       [direction]: { kind: 'error', request, retryable },
     });
+  }
+
+  cancelBoundaryLoad(
+    rangeId: string,
+    direction: BoundaryDirection,
+    request: FrozenTranscriptBoundaryRequest,
+  ): void {
+    const range = this.snapshot.ranges.find((item) => item.id === rangeId);
+    const boundary = range?.[direction];
+    if (range && boundary?.kind === 'loading' && boundary.request === request) {
+      this.replaceRange(rangeId, {
+        ...range,
+        [direction]: { kind: 'loadable', request },
+      });
+    }
   }
 
   admitBoundary(
@@ -376,7 +619,7 @@ export class HistoricalTranscriptPageTable {
     const range = this.snapshot.ranges.find((item) => item.id === rangeId);
     if (!range || range[direction].kind !== 'loading') return;
     const admittedRequest = range[direction].request;
-    const knownRecordIds = this.allRecordIds();
+    const knownRecordIds = this.allRecordIds(range);
     for (const recordId of recovery?.excludedRecordIds ?? []) {
       knownRecordIds.add(recordId);
     }
@@ -401,16 +644,23 @@ export class HistoricalTranscriptPageTable {
       blocks.length === page.blocks.length
         ? page
         : this.pageFromBlocks(page.id, snapshot, blocks);
+    const sequentialTerminal =
+      'beforeRecordId' in range && recovery?.fromAnchor === true;
     const newerRequest =
       (direction === 'older' || (recovery && !recovery.fromAnchor)) &&
       filteredPage.lastRecordId
         ? {
             kind: 'gap' as const,
-            anchorRecordId: range.anchorTurnId,
+            anchorRecordId:
+              'anchorTurnId' in range
+                ? range.anchorTurnId
+                : range.beforeRecordId,
             afterRecordId: filteredPage.lastRecordId,
-            snapshot,
+            snapshot: 'beforeRecordId' in range ? range.snapshot : snapshot,
           }
-        : forwardRequest(response);
+        : sequentialTerminal
+          ? undefined
+          : forwardRequest(response);
     const admittedPage = this.withNewerRequest(filteredPage, newerRequest);
     if (admittedPage.blocks.length === 0) {
       if (recovery && !recovery.fromAnchor && !reachedLive && !cachedRangeId) {
@@ -420,16 +670,21 @@ export class HistoricalTranscriptPageTable {
         range,
         direction,
         response,
-        reachedLive,
+        reachedLive || sequentialTerminal,
         cachedRangeId,
       );
-      const activeRangeId = this.selectedRangeId ?? rangeId;
+      const activeRangeId =
+        'beforeRecordId' in range ? rangeId : (this.selectedRangeId ?? rangeId);
       const activeRange = this.snapshot.ranges.find(
         (item) => item.id === activeRangeId,
       );
       this.evict(
         activeRangeId,
-        this.selectedPageId ?? activeRange?.pageIds[0] ?? range.pageIds[0]!,
+        (activeRangeId === this.selectedRangeId
+          ? this.selectedPageId
+          : undefined) ??
+          activeRange?.pageIds[0] ??
+          range.pageIds[0]!,
         activeRangeId === rangeId
           ? { direction, request: admittedRequest }
           : undefined,
@@ -444,18 +699,19 @@ export class HistoricalTranscriptPageTable {
       direction === 'older'
         ? [admittedPage.id, ...range.pageIds]
         : [...range.pageIds, admittedPage.id];
-    const boundary = reachedLive
-      ? ({ kind: 'live' } as const)
-      : cachedRangeId
-        ? this.cachedBoundary(
-            rangeId,
-            direction,
-            cachedRangeId,
-            admittedRequest,
-          )
-        : direction === 'newer'
-          ? requestBoundary(newerRequest)
-          : this.nextBoundary(direction, snapshot, admittedPage, response);
+    const boundary =
+      reachedLive || sequentialTerminal
+        ? ({ kind: 'live' } as const)
+        : cachedRangeId
+          ? this.cachedBoundary(
+              rangeId,
+              direction,
+              cachedRangeId,
+              admittedRequest,
+            )
+          : direction === 'newer'
+            ? requestBoundary(newerRequest)
+            : this.nextBoundary(direction, snapshot, admittedPage, response);
     const nextRange = Object.freeze({
       ...range,
       pageIds: Object.freeze(pageIds),
@@ -472,13 +728,21 @@ export class HistoricalTranscriptPageTable {
       retainedBytes: this.measureRetainedBytes(pages, ranges),
     });
     this.touch(rangeId);
-    const activeRangeId = this.selectedRangeId ?? rangeId;
+    const activeRangeId =
+      'beforeRecordId' in range ? rangeId : (this.selectedRangeId ?? rangeId);
     const activeRange = this.snapshot.ranges.find(
       (item) => item.id === activeRangeId,
     );
     this.evict(
       activeRangeId,
-      this.selectedPageId ?? activeRange?.pageIds[0] ?? range.pageIds[0]!,
+      (activeRangeId === this.selectedRangeId
+        ? this.selectedPageId
+        : undefined) ??
+        [...this.viewportPins.values()].find((id) =>
+          range.pageIds.includes(id),
+        ) ??
+        activeRange?.pageIds[0] ??
+        range.pageIds[0]!,
       activeRangeId === rangeId
         ? { direction, request: admittedRequest, pageId: admittedPage.id }
         : undefined,
@@ -598,7 +862,7 @@ export class HistoricalTranscriptPageTable {
   }
 
   private finishBoundaryWithoutPage(
-    range: HistoricalTranscriptRange,
+    range: HistoricalViewportRange,
     direction: BoundaryDirection,
     response: DaemonSessionTranscriptPage,
     reachedLive: boolean,
@@ -625,11 +889,15 @@ export class HistoricalTranscriptPageTable {
     this.replaceRange(range.id, { ...range, [direction]: terminal });
   }
 
-  private allRecordIds(): Set<string> {
+  private allRecordIds(origin: HistoricalViewportRange): Set<string> {
     const ids = new Set(this.liveRecordIds);
-    for (const page of this.snapshot.pages.values()) {
-      for (const id of page.recordIds) {
-        ids.add(id);
+    for (const range of this.snapshot.ranges) {
+      if ('anchorTurnId' in range !== 'anchorTurnId' in origin) continue;
+      for (const pageId of range.pageIds) {
+        const page = this.snapshot.pages.get(pageId)!;
+        for (const id of page.recordIds) {
+          ids.add(id);
+        }
       }
     }
     return ids;
@@ -641,8 +909,12 @@ export class HistoricalTranscriptPageTable {
     direction: BoundaryDirection,
   ): string | undefined {
     const encountered = [...recordIds];
+    const origin = this.snapshot.ranges.find(
+      (range) => range.id === excludedRangeId,
+    )!;
     for (const range of this.snapshot.ranges) {
       if (range.id === excludedRangeId) continue;
+      if ('anchorTurnId' in range !== 'anchorTurnId' in origin) continue;
       const edgePageId =
         direction === 'older' ? range.pageIds.at(-1) : range.pageIds[0];
       const edgePage = edgePageId
@@ -690,7 +962,7 @@ export class HistoricalTranscriptPageTable {
     return `${rangeId}:${direction}`;
   }
 
-  private replaceRange(rangeId: string, next: HistoricalTranscriptRange): void {
+  private replaceRange(rangeId: string, next: HistoricalViewportRange): void {
     const ranges = Object.freeze(
       this.snapshot.ranges.map((range) =>
         range.id === rangeId ? Object.freeze(next) : range,
@@ -725,7 +997,13 @@ export class HistoricalTranscriptPageTable {
 
     while (overBudget()) {
       const inactive = ranges
-        .filter((range) => range.id !== activeRangeId)
+        .filter(
+          (range) =>
+            range.id !== activeRangeId &&
+            !range.pageIds.some((id) =>
+              [...this.viewportPins.values()].includes(id),
+            ),
+        )
         .sort(
           (left, right) =>
             (this.rangeAccess.get(left.id) ?? 0) -
@@ -770,6 +1048,7 @@ export class HistoricalTranscriptPageTable {
           });
           throw new HistoricalTranscriptWindowFullError();
         }
+        if (overBudget()) throw new HistoricalTranscriptWindowFullError();
         break;
       }
       const edges =
@@ -778,7 +1057,9 @@ export class HistoricalTranscriptPageTable {
           : [active.pageIds[0], active.pageIds.at(-1)];
       const removable = edges.find(
         (pageId) =>
-          pageId !== targetPageId && pageId !== admittedBoundary?.pageId,
+          pageId !== targetPageId &&
+          pageId !== admittedBoundary?.pageId &&
+          ![...this.viewportPins.values()].includes(pageId!),
       );
       if (!removable) throw new HistoricalTranscriptWindowFullError();
       const removedFirst = removable === active.pageIds[0];
@@ -840,7 +1121,7 @@ export class HistoricalTranscriptPageTable {
 
   private measureRetainedBytes(
     pages: ReadonlyMap<string, HistoricalTranscriptPage>,
-    ranges: readonly HistoricalTranscriptRange[],
+    ranges: readonly HistoricalViewportRange[],
   ): number {
     let bytes = 128;
     for (const page of pages.values()) bytes += page.retainedBytes;
@@ -848,7 +1129,10 @@ export class HistoricalTranscriptPageTable {
       bytes +=
         128 +
         range.id.length * 2 +
-        range.anchorTurnId.length * 2 +
+        ('anchorTurnId' in range
+          ? range.anchorTurnId.length
+          : range.beforeRecordId.length + range.snapshot.length) *
+          2 +
         range.pageIds.length * 24;
       bytes += this.measureBoundaryBytes(range.id, 'older', range.older);
       bytes += this.measureBoundaryBytes(range.id, 'newer', range.newer);
@@ -872,9 +1156,9 @@ export class HistoricalTranscriptPageTable {
   }
 
   private restoreCachedBoundaries(
-    ranges: readonly HistoricalTranscriptRange[],
+    ranges: readonly HistoricalViewportRange[],
     removedRangeId: string,
-  ): HistoricalTranscriptRange[] {
+  ): HistoricalViewportRange[] {
     return ranges.map((range) => {
       const older = this.restoreCachedBoundary(range, 'older', removedRangeId);
       const newer = this.restoreCachedBoundary(range, 'newer', removedRangeId);
@@ -885,7 +1169,7 @@ export class HistoricalTranscriptPageTable {
   }
 
   private restoreCachedBoundary(
-    range: HistoricalTranscriptRange,
+    range: HistoricalViewportRange,
     direction: BoundaryDirection,
     removedRangeId: string,
   ): TranscriptBoundary {

--- a/packages/web-shell/client/daemon/session/transcript-page-table.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.ts
@@ -209,6 +209,11 @@ export class HistoricalTranscriptPageTable {
     this.touch(rangeId);
   }
 
+  clearSelection(): void {
+    this.selectedRangeId = undefined;
+    this.selectedPageId = undefined;
+  }
+
   setViewportAnchor(viewportId: string, pageId?: string): void {
     if (pageId === undefined) {
       this.viewportPins.delete(viewportId);
@@ -1000,6 +1005,7 @@ export class HistoricalTranscriptPageTable {
         .filter(
           (range) =>
             range.id !== activeRangeId &&
+            range.id !== this.selectedRangeId &&
             !range.pageIds.some((id) =>
               [...this.viewportPins.values()].includes(id),
             ),
@@ -1058,6 +1064,7 @@ export class HistoricalTranscriptPageTable {
       const removable = edges.find(
         (pageId) =>
           pageId !== targetPageId &&
+          pageId !== this.selectedPageId &&
           pageId !== admittedBoundary?.pageId &&
           ![...this.viewportPins.values()].includes(pageId!),
       );

--- a/packages/web-shell/client/daemon/session/transcript-page-table.ts
+++ b/packages/web-shell/client/daemon/session/transcript-page-table.ts
@@ -19,6 +19,7 @@ export type FrozenTranscriptBoundaryRequest =
       anchorRecordId: string;
       afterRecordId: string;
       snapshot: string;
+      beforeAnchor?: true;
     };
 
 export interface TranscriptGapResolution {
@@ -505,19 +506,18 @@ export class HistoricalTranscriptPageTable {
     snapshot: string,
   ): void {
     const range = this.snapshot.ranges.find((range) => range.id === rangeId);
-    if (!range || !('beforeRecordId' in range) || range.newer.kind !== 'live')
-      return;
+    if (!range || range.newer.kind !== 'live') return;
     const edge = this.snapshot.pages.get(range.pageIds.at(-1)!);
     if (!edge?.lastRecordId)
       throw new Error('Historical page has no retained edge');
-    const nextRange: SequentialHistoricalTranscriptRange = {
+    const nextRange: HistoricalViewportRange = {
       ...range,
-      beforeRecordId,
-      snapshot,
+      ...('beforeRecordId' in range ? { beforeRecordId, snapshot } : {}),
       newer: {
         kind: 'loadable',
         request: {
           kind: 'gap',
+          beforeAnchor: true,
           anchorRecordId: beforeRecordId,
           afterRecordId: edge.lastRecordId,
           snapshot,
@@ -538,6 +538,7 @@ export class HistoricalTranscriptPageTable {
           },
           {
             kind: 'gap',
+            beforeAnchor: true,
             anchorRecordId: beforeRecordId,
             afterRecordId: page.lastRecordId,
             snapshot,
@@ -650,16 +651,24 @@ export class HistoricalTranscriptPageTable {
         ? page
         : this.pageFromBlocks(page.id, snapshot, blocks);
     const sequentialTerminal =
-      'beforeRecordId' in range && recovery?.fromAnchor === true;
+      ('beforeRecordId' in range ||
+        (admittedRequest.kind === 'gap' &&
+          admittedRequest.beforeAnchor === true)) &&
+      recovery?.fromAnchor === true;
     const newerRequest =
       (direction === 'older' || (recovery && !recovery.fromAnchor)) &&
       filteredPage.lastRecordId
         ? {
             kind: 'gap' as const,
+            ...(admittedRequest.kind === 'gap' && admittedRequest.beforeAnchor
+              ? { beforeAnchor: true as const }
+              : {}),
             anchorRecordId:
-              'anchorTurnId' in range
-                ? range.anchorTurnId
-                : range.beforeRecordId,
+              admittedRequest.kind === 'gap'
+                ? admittedRequest.anchorRecordId
+                : 'anchorTurnId' in range
+                  ? range.anchorTurnId
+                  : range.beforeRecordId,
             afterRecordId: filteredPage.lastRecordId,
             snapshot: 'beforeRecordId' in range ? range.snapshot : snapshot,
           }
@@ -1211,6 +1220,7 @@ function requestBytes(
   if (request.kind === 'gap') {
     return (
       80 +
+      (request.beforeAnchor ? 16 : 0) +
       2 *
         (request.anchorRecordId.length +
           request.afterRecordId.length +

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
@@ -332,6 +332,74 @@ describe('createDaemonTurnNavigationStore', () => {
     expect(store.getViewportSnapshot().pages.size).toBe(0);
   });
 
+  it('recovers a trimmed live connection for a globally located range before continuing', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn', 'live-1']));
+    getTranscriptPage.mockResolvedValue(
+      transcriptPage(['turn', 'live-1'], { targetRecordId: 'turn' }),
+    );
+    let beforeRecordId = 'live-1';
+    const store = createDaemonTurnNavigationStore({
+      captureLiveBoundary: () => ({
+        beforeRecordId,
+        reachable: true,
+        isCurrent: () => true,
+      }),
+    });
+    store.configure({ sessionId: 'session-1', supported: true, client });
+    await flushInitialHead(store);
+    store.observeLiveBlocks([userBlock('live-one', 'live-1')]);
+    const location = await store.locateOrdinal(0);
+    const rangeId = location.rangeId!;
+    expect(store.getViewportSnapshot().ranges[0]?.newer.kind).toBe('live');
+    beforeRecordId = 'live-2';
+    store.observeLiveBlocks([
+      { ...userBlock('live-two', 'live-2'), kind: 'assistant' },
+    ]);
+    getTurnIndexPage.mockResolvedValue(
+      turnPage(0, ['turn', 'live-1'], { snapshot: 'fresh' }),
+    );
+    getTranscriptPage.mockClear().mockImplementation(async (options) => {
+      if (options.atRecordId) throw new Error('invalid_turn_anchor');
+      return transcriptPage(
+        options.beforeRecordId === 'live-2'
+          ? ['late']
+          : options.beforeRecordId === 'late'
+            ? ['gap', 'live-1']
+            : ['turn'],
+      );
+    });
+    await store.loadViewportBoundary(rangeId, 'newer', {
+      isCurrent: () => true,
+    });
+    expect(getTranscriptPage).toHaveBeenNthCalledWith(1, {
+      beforeRecordId: 'live-2',
+      snapshot: 'fresh',
+      limit: 200,
+    });
+    expect(
+      [...store.getViewportSnapshot().pages.values()].flatMap((page) => [
+        ...page.recordIds,
+      ]),
+    ).toEqual(['turn', 'gap', 'live-1']);
+    expect(store.getViewportSnapshot().ranges[0]?.newer).toMatchObject({
+      kind: 'loadable',
+      request: { kind: 'gap', anchorRecordId: 'live-2', beforeAnchor: true },
+    });
+    await store.loadViewportBoundary(rangeId, 'newer', {
+      isCurrent: () => true,
+    });
+    expect(store.getViewportSnapshot().ranges[0]?.newer.kind).toBe('live');
+    expect(
+      getTranscriptPage.mock.calls.every(([options]) => !options.atRecordId),
+    ).toBe(true);
+    expect(
+      [...store.getViewportSnapshot().pages.values()].flatMap((page) => [
+        ...page.recordIds,
+      ]),
+    ).toEqual(['turn', 'gap', 'live-1', 'late']);
+  });
+
   it('recovers the new live-trim gap from the fresh before-origin', async () => {
     const { client, getTurnIndexPage, getTranscriptPage } = createClient();
     getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
@@ -153,6 +153,128 @@ function indexPage(
 }
 
 describe('createDaemonTurnNavigationStore', () => {
+  it('keeps the frozen viewport identity on disconnect but retires it for a new owner', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));
+    getTranscriptPage.mockResolvedValue(transcriptPage(['old']));
+    const store = createDaemonTurnNavigationStore();
+    await ready(store, client);
+    await store.openBeforeLive('live', { isCurrent: () => true });
+    const before = store.getViewportSnapshot();
+    store.configure({ sessionId: 'session-1', supported: true });
+    expect(store.getViewportSnapshot()).toMatchObject({
+      revision: before.revision,
+      connected: false,
+      pages: before.pages,
+      ranges: before.ranges,
+    });
+    store.configure({
+      sessionId: 'session-1',
+      supported: true,
+      client: { ...client, owner: {} },
+    });
+    expect(store.getViewportSnapshot().revision).toBeGreaterThan(
+      before.revision,
+    );
+    await flushInitialHead(store);
+  });
+
+  it('opens a sequential tool-only page with a fresh snapshot and no legacy range', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    client.materializeTranscriptEvents = (events, ordinal, excluded) => ({
+      ...materialize(events, ordinal, excluded),
+      blocks: materialize(events, ordinal, excluded).blocks.map((block) => ({
+        ...block,
+        kind: 'assistant' as const,
+      })),
+    });
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));
+    getTranscriptPage.mockResolvedValue(transcriptPage(['tool-only']));
+    const store = createDaemonTurnNavigationStore();
+    store.configure({ sessionId: 'session-1', supported: true, client });
+    await flushInitialHead(store);
+    getTurnIndexPage.mockResolvedValue(
+      turnPage(0, ['turn'], { snapshot: 'fresh' }),
+    );
+    const id = await store.openBeforeLive('live', { isCurrent: () => true });
+    expect(getTranscriptPage).toHaveBeenLastCalledWith({
+      beforeRecordId: 'live',
+      snapshot: 'fresh',
+      limit: 200,
+    });
+    expect(store.getViewportSnapshot().ranges[0]).toMatchObject({
+      id,
+      beforeRecordId: 'live',
+    });
+    expect(store.getSnapshot().historicalRanges).toEqual([]);
+    expect(store.getSnapshot().historicalPages.size).toBe(0);
+  });
+
+  it('rejects a cancelled bootstrap without admitting its response', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));
+    let current = true;
+    let resolve!: (value: DaemonSessionTranscriptPage) => void;
+    getTranscriptPage.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const store = createDaemonTurnNavigationStore();
+    store.configure({ sessionId: 'session-1', supported: true, client });
+    await flushInitialHead(store);
+    const pending = store.openBeforeLive('live', { isCurrent: () => current });
+    await vi.waitFor(() => expect(getTranscriptPage).toHaveBeenCalled());
+    current = false;
+    resolve(transcriptPage(['old']));
+    await expect(pending).rejects.toThrow('History view changed');
+    expect(store.getViewportSnapshot().pages.size).toBe(0);
+  });
+
+  it('recovers the new live-trim gap from the fresh before-origin', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));
+    getTranscriptPage.mockResolvedValue(transcriptPage(['old']));
+    let beforeRecordId = 'live-1';
+    const store = createDaemonTurnNavigationStore({
+      captureLiveBoundary: () => ({
+        beforeRecordId,
+        reachable: true,
+        isCurrent: () => true,
+      }),
+    });
+    store.configure({ sessionId: 'session-1', supported: true, client });
+    await flushInitialHead(store);
+    const id = await store.openBeforeLive(beforeRecordId, {
+      isCurrent: () => true,
+    });
+    beforeRecordId = 'live-2';
+    store.observeLiveBlocks([userBlock('overlap', 'old')]);
+    expect(store.hasLiveOverlap(id)).toBe(true);
+    const reads = getTranscriptPage.mock.calls.length;
+    await store.loadViewportBoundary(id, 'newer', { isCurrent: () => true });
+    expect(getTranscriptPage).toHaveBeenCalledTimes(reads);
+    store.observeLiveBlocks([]);
+    expect(store.hasLiveOverlap(id)).toBe(false);
+    getTurnIndexPage.mockResolvedValue(
+      turnPage(0, ['turn'], { snapshot: 'fresh' }),
+    );
+    getTranscriptPage.mockResolvedValue(transcriptPage(['old', 'live-1']));
+    await store.loadViewportBoundary(id, 'newer', { isCurrent: () => true });
+    expect(getTranscriptPage).toHaveBeenLastCalledWith({
+      beforeRecordId: 'live-2',
+      snapshot: 'fresh',
+      limit: 200,
+    });
+    expect(
+      [...store.getViewportSnapshot().pages.values()].flatMap((page) => [
+        ...page.recordIds,
+      ]),
+    ).toEqual(['old', 'live-1']);
+    expect(store.getViewportSnapshot().ranges[0]?.newer.kind).toBe('live');
+  });
+
   it.each([
     ['admit', 'echo', 'index'],
     ['echo', 'admit', 'index'],

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.test.ts
@@ -153,6 +153,106 @@ function indexPage(
 }
 
 describe('createDaemonTurnNavigationStore', () => {
+  it('protects the legacy selected page when opening a sequential viewport', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn-0']));
+    getTranscriptPage
+      .mockResolvedValueOnce(transcriptPage('turn-0'))
+      .mockResolvedValueOnce(transcriptPage(['history-before-live']));
+    const store = createDaemonTurnNavigationStore({ maxHistoricalPages: 1 });
+    await ready(store, client);
+    const location = await store.locateOrdinal(0);
+    expect(store.getSnapshot().selected).toMatchObject({
+      status: 'ready',
+      location,
+    });
+    expect(store.getSnapshot().historicalPages.has(location.pageId!)).toBe(
+      true,
+    );
+
+    await expect(
+      store.openBeforeLive('live', { isCurrent: () => true }),
+    ).rejects.toThrow('window is full');
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.selected).toMatchObject({ status: 'ready', location });
+    expect(snapshot.historicalPages.has(location.pageId!)).toBe(true);
+  });
+
+  it('retains a viewport-pinned legacy selection under sequential capacity pressure', async () => {
+    const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+    getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn-0']));
+    getTranscriptPage
+      .mockResolvedValueOnce(transcriptPage('turn-0'))
+      .mockResolvedValueOnce(transcriptPage(['history-before-live']));
+    const store = createDaemonTurnNavigationStore({ maxHistoricalPages: 1 });
+    await ready(store, client);
+    const location = await store.locateOrdinal(0);
+    store.setViewportAnchor('legacy-view', location.pageId);
+
+    await expect(
+      store.openBeforeLive('live', { isCurrent: () => true }),
+    ).rejects.toThrow('window is full');
+
+    expect(store.getSnapshot().historicalPages.has(location.pageId!)).toBe(
+      true,
+    );
+    expect(store.getSnapshot().selected).toMatchObject({
+      status: 'ready',
+      location,
+    });
+  });
+
+  it.each([false, true])(
+    'releases a historical selection after moving to live with viewport pin=%s',
+    async (viewportPinned) => {
+      const { client, getTurnIndexPage, getTranscriptPage } = createClient();
+      getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn-0', 'turn-1']));
+      getTranscriptPage
+        .mockResolvedValueOnce(transcriptPage('turn-0'))
+        .mockResolvedValue(transcriptPage(['history-before-live']));
+      const store = createDaemonTurnNavigationStore({ maxHistoricalPages: 1 });
+      await ready(store, client);
+      const historical = await store.locateOrdinal(0);
+      if (viewportPinned) {
+        store.setViewportAnchor('historical-reader', historical.pageId);
+      }
+      store.observeLiveBlocks([userBlock('live-1', 'turn-1')]);
+      const live = await store.locateOrdinal(1);
+      expect(live).toMatchObject({ view: 'live', blockId: 'live-1' });
+      expect(store.getSnapshot().selected).toMatchObject({
+        status: 'ready',
+        location: live,
+      });
+
+      if (viewportPinned) {
+        await expect(
+          store.openBeforeLive('turn-1', { isCurrent: () => true }),
+        ).rejects.toThrow('window is full');
+        expect(store.getViewportSnapshot().pages.has(historical.pageId!)).toBe(
+          true,
+        );
+        store.setViewportAnchor('historical-reader');
+      }
+
+      const rangeId = await store.openBeforeLive('turn-1', {
+        isCurrent: () => true,
+      });
+
+      expect(store.getViewportSnapshot().pages.size).toBe(1);
+      expect(store.getViewportSnapshot().pages.has(historical.pageId!)).toBe(
+        false,
+      );
+      expect(store.getViewportSnapshot().ranges).toMatchObject([
+        { id: rangeId, beforeRecordId: 'turn-1' },
+      ]);
+      expect(store.getSnapshot().selected).toMatchObject({
+        status: 'ready',
+        location: live,
+      });
+    },
+  );
+
   it('keeps the frozen viewport identity on disconnect but retires it for a new owner', async () => {
     const { client, getTurnIndexPage, getTranscriptPage } = createClient();
     getTurnIndexPage.mockResolvedValue(turnPage(0, ['turn']));

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.ts
@@ -149,6 +149,11 @@ export interface HistoryViewportRequest {
 
 export interface DaemonHistoryNavigationStore
   extends DaemonTurnNavigationStore {
+  locateViewportOrdinal(
+    ordinal: number,
+    request: HistoryViewportRequest,
+    releaseAnchor: () => void,
+  ): Promise<DaemonTurnLocation>;
   getViewportSnapshot(): DaemonHistoryViewportSnapshot;
   captureLiveBoundary(): LiveHistoryBoundary;
   hasLiveOverlap(rangeId: string): boolean;
@@ -788,7 +793,11 @@ export function createDaemonTurnNavigationStore(
     }
   }
 
-  async function locateOrdinal(ordinal: number): Promise<DaemonTurnLocation> {
+  async function locateOrdinal(
+    ordinal: number,
+    request?: HistoryViewportRequest,
+    releaseAnchor?: () => void,
+  ): Promise<DaemonTurnLocation> {
     assertOrdinal(ordinal);
     const generation = ++selectionGeneration;
     publish({
@@ -801,7 +810,7 @@ export function createDaemonTurnNavigationStore(
     });
     try {
       await loadOrdinal(ordinal, generation);
-      if (generation !== selectionGeneration)
+      if (generation !== selectionGeneration || request?.isCurrent() === false)
         throw new Error('Selection changed');
       const entryWithSnapshot = findIndexEntry(ordinal);
       if (!entryWithSnapshot) throw new Error('Turn metadata is unavailable');
@@ -835,6 +844,7 @@ export function createDaemonTurnNavigationStore(
       });
       if (
         generation !== selectionGeneration ||
+        request?.isCurrent() === false ||
         capturedSession !== sessionEpoch ||
         capturedChain !== chainEpoch ||
         !isCurrentClient(activeClient)
@@ -862,6 +872,7 @@ export function createDaemonTurnNavigationStore(
         });
         return live;
       }
+      releaseAnchor?.();
       const target = pageTable.admitAnchor(
         ordinal,
         entryWithSnapshot.entry.turnId,
@@ -886,7 +897,10 @@ export function createDaemonTurnNavigationStore(
       });
       return location;
     } catch (error) {
-      if (generation === selectionGeneration) {
+      if (
+        generation === selectionGeneration &&
+        request?.isCurrent() !== false
+      ) {
         if (isTranscriptTooLarge(error)) {
           enterTooLargeFallback();
         } else {
@@ -945,8 +959,9 @@ export function createDaemonTurnNavigationStore(
           .getSnapshot()
           .ranges.find((range) => range.id === rangeId);
         if (!origin) return;
+        const beforeAnchor = 'beforeRecordId' in origin || request.beforeAnchor;
         response = await activeClient.getTranscriptPage({
-          ...('beforeRecordId' in origin
+          ...(beforeAnchor
             ? { beforeRecordId: request.anchorRecordId }
             : { atRecordId: request.anchorRecordId }),
           snapshot: request.snapshot,
@@ -961,6 +976,7 @@ export function createDaemonTurnNavigationStore(
           validateHistoricalResponse(response, sessionId);
           if (
             fromAnchor &&
+            !beforeAnchor &&
             'anchorTurnId' in origin &&
             response.targetRecordId !== request.anchorRecordId
           ) {
@@ -1154,9 +1170,9 @@ export function createDaemonTurnNavigationStore(
       !activeClient ||
       !boundary?.reachable ||
       !boundary.beforeRecordId ||
-      !('beforeRecordId' in range) ||
       hasLiveOverlap(range.id) ||
-      boundary.beforeRecordId === range.beforeRecordId
+      ('beforeRecordId' in range &&
+        boundary.beforeRecordId === range.beforeRecordId)
     )
       return;
     const revision = viewportSnapshot.revision;
@@ -1453,8 +1469,10 @@ export function createDaemonTurnNavigationStore(
         isCurrent: () => false,
       },
     openBeforeLive,
-    setViewportAnchor: (viewportId, pageId) =>
-      pageTable.setViewportAnchor(viewportId, pageId),
+    setViewportAnchor: (viewportId, pageId) => {
+      pageTable.setViewportAnchor(viewportId, pageId);
+      if (pageId) pageTable.clearSelection();
+    },
     loadViewportBoundary,
     subscribe(listener) {
       listeners.add(listener);
@@ -1467,6 +1485,7 @@ export function createDaemonTurnNavigationStore(
     handleSessionEvent,
     loadOrdinal,
     locateOrdinal,
+    locateViewportOrdinal: locateOrdinal,
     refreshHead,
     loadOlder: (rangeId) => loadBoundary(rangeId, 'older'),
     loadNewer: (rangeId) => loadBoundary(rangeId, 'newer'),

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.ts
@@ -27,6 +27,7 @@ import {
   HistoricalTranscriptPageTable,
   type HistoricalTranscriptPage,
   type HistoricalTranscriptRange,
+  type HistoricalViewportRange,
   type MaterializedTranscriptPage,
   type TranscriptGapResolution,
 } from './transcript-page-table.js';
@@ -134,12 +135,47 @@ export interface DaemonTurnNavigationStore {
   retry(): Promise<void>;
 }
 
+export interface DaemonHistoryViewportSnapshot {
+  sessionId?: string;
+  revision: number;
+  connected: boolean;
+  pages: ReadonlyMap<string, HistoricalTranscriptPage>;
+  ranges: readonly HistoricalViewportRange[];
+}
+
+export interface HistoryViewportRequest {
+  isCurrent(): boolean;
+}
+
+export interface DaemonHistoryNavigationStore
+  extends DaemonTurnNavigationStore {
+  getViewportSnapshot(): DaemonHistoryViewportSnapshot;
+  captureLiveBoundary(): LiveHistoryBoundary;
+  hasLiveOverlap(rangeId: string): boolean;
+  openBeforeLive(
+    beforeRecordId: string,
+    request: HistoryViewportRequest,
+  ): Promise<string>;
+  setViewportAnchor(viewportId: string, pageId?: string): void;
+  loadViewportBoundary(
+    rangeId: string,
+    direction: 'older' | 'newer',
+    request: HistoryViewportRequest,
+  ): Promise<void>;
+}
+
 export interface CreateDaemonTurnNavigationStoreOptions {
+  captureLiveBoundary?: () => LiveHistoryBoundary;
   indexPageSize?: number;
   maxIndexPages?: number;
   maxIndexBytes?: number;
   maxHistoricalPages?: number;
   maxHistoricalBytes?: number;
+}
+
+export interface LiveHistoryBoundary extends HistoryViewportRequest {
+  beforeRecordId?: string;
+  reachable: boolean;
 }
 
 const EMPTY_MAP = new Map<never, never>();
@@ -161,7 +197,7 @@ interface InternalIndexPage extends DaemonTurnIndexPage {
 
 export function createDaemonTurnNavigationStore(
   options: CreateDaemonTurnNavigationStoreOptions = {},
-): DaemonTurnNavigationStore {
+): DaemonHistoryNavigationStore {
   const indexPageSize = options.indexPageSize ?? WEB_SHELL_TURN_INDEX_PAGE_SIZE;
   const maxIndexPages = options.maxIndexPages ?? WEB_SHELL_TURN_INDEX_MAX_PAGES;
   const maxIndexBytes = options.maxIndexBytes ?? WEB_SHELL_TURN_INDEX_MAX_BYTES;
@@ -184,10 +220,18 @@ export function createDaemonTurnNavigationStore(
   let liveBlockIdByPromptId = new Map<string, string>();
   let lastLiveBlocks: readonly DaemonTranscriptBlock[] | undefined;
   let headRequest: Promise<void> | undefined;
+  let headReadGeneration = 0;
+  let ownerRevision = 0;
   let headDirty = false;
   let headRetryPending = false;
   let tooLarge = false;
   let pageTable = createPageTable();
+  let viewportSnapshot: DaemonHistoryViewportSnapshot = Object.freeze({
+    revision: 0,
+    connected: false,
+    pages: EMPTY_MAP,
+    ranges: Object.freeze([]),
+  });
 
   function createPageTable(): HistoricalTranscriptPageTable {
     return new HistoricalTranscriptPageTable({
@@ -212,6 +256,22 @@ export function createDaemonTurnNavigationStore(
 
   function publish(update: Partial<DaemonTurnNavigationSnapshot> = {}): void {
     const table = pageTable.getSnapshot();
+    const legacyRanges = table.ranges.filter(
+      (range): range is HistoricalTranscriptRange => 'anchorTurnId' in range,
+    );
+    const legacyPageIds = new Set(
+      legacyRanges.flatMap((range) => range.pageIds),
+    );
+    const legacyPages = new Map(
+      [...table.pages].filter(([id]) => legacyPageIds.has(id)),
+    );
+    const historicalPages =
+      legacyPages.size === snapshot.historicalPages.size &&
+      [...legacyPages].every(
+        ([id, page]) => snapshot.historicalPages.get(id) === page,
+      )
+        ? snapshot.historicalPages
+        : legacyPages;
     const error = 'error' in update ? update.error : snapshot.error;
     const boundaryOperation =
       error?.operation === 'older' || error?.operation === 'newer'
@@ -236,7 +296,7 @@ export function createDaemonTurnNavigationStore(
         locations.set(turnId, location);
       }
     }
-    for (const range of table.ranges) {
+    for (const range of legacyRanges) {
       for (const pageId of range.pageIds) {
         const page = table.pages.get(pageId);
         if (!page) continue;
@@ -267,9 +327,16 @@ export function createDaemonTurnNavigationStore(
       provisionalTurns: Object.freeze([...provisionals]),
       effectiveTurnCount:
         (update.totalTurns ?? snapshot.totalTurns) + provisionals.length,
-      historicalPages: table.pages,
-      historicalRanges: table.ranges,
+      historicalPages,
+      historicalRanges: Object.freeze(legacyRanges),
       locations,
+    });
+    viewportSnapshot = Object.freeze({
+      sessionId,
+      revision: ownerRevision + chainEpoch,
+      connected: client !== undefined,
+      pages: table.pages,
+      ranges: table.ranges,
     });
     for (const listener of listeners) listener();
   }
@@ -380,6 +447,7 @@ export function createDaemonTurnNavigationStore(
       return;
     }
     if (!next.client) {
+      const disconnected = client !== undefined;
       let releasedBoundary = false;
       if (client) {
         sessionEpoch += 1;
@@ -392,6 +460,7 @@ export function createDaemonTurnNavigationStore(
       clientWasConnected = false;
       if (
         sessionChanged ||
+        disconnected ||
         releasedBoundary ||
         snapshot.selected?.status === 'loading'
       ) {
@@ -411,6 +480,7 @@ export function createDaemonTurnNavigationStore(
     }
     const ownerChanged = clientOwner !== next.client.owner;
     if (ownerChanged && clientOwner !== undefined) {
+      ownerRevision += 1;
       sessionEpoch += 1;
       selectionGeneration += 1;
       headRequest = undefined;
@@ -426,6 +496,7 @@ export function createDaemonTurnNavigationStore(
     client = next.client;
     clientOwner = next.client.owner;
     clientWasConnected = true;
+    if (shouldRefresh) publish();
     if (!shouldRefresh || snapshot.fallbackReason === 'too_large') return;
     if (pages.size === 0)
       publish({ mode: 'loading', fallbackReason: undefined });
@@ -603,6 +674,7 @@ export function createDaemonTurnNavigationStore(
         if (!activeClient) return;
         const capturedSession = sessionEpoch;
         const capturedChain = chainEpoch;
+        const readGeneration = ++headReadGeneration;
         try {
           const response = await activeClient.getTurnIndexPage({
             limit: indexPageSize,
@@ -610,6 +682,7 @@ export function createDaemonTurnNavigationStore(
           if (
             capturedSession !== sessionEpoch ||
             capturedChain !== chainEpoch ||
+            readGeneration !== headReadGeneration ||
             !isCurrentClient(activeClient)
           ) {
             return;
@@ -619,6 +692,7 @@ export function createDaemonTurnNavigationStore(
           if (
             capturedSession !== sessionEpoch ||
             capturedChain !== chainEpoch ||
+            readGeneration !== headReadGeneration ||
             !isCurrentClient(activeClient)
           ) {
             return;
@@ -833,9 +907,11 @@ export function createDaemonTurnNavigationStore(
   async function loadBoundary(
     rangeId: string,
     direction: 'older' | 'newer',
+    viewportRequest?: HistoryViewportRequest,
   ): Promise<void> {
     const activeClient = client;
-    if (!activeClient) return;
+    if (!activeClient || (viewportRequest && !viewportRequest.isCurrent()))
+      return;
     const request = pageTable.beginBoundaryLoad(rangeId, direction);
     if (!request) return;
     const clearBoundaryError = () =>
@@ -855,15 +931,22 @@ export function createDaemonTurnNavigationStore(
         capturedChain === chainEpoch &&
         isCurrentClient(activeClient) &&
         boundary?.kind === 'loading' &&
-        boundary.request === request
+        boundary.request === request &&
+        (viewportRequest?.isCurrent() ?? true)
       );
     };
     try {
       let response: DaemonSessionTranscriptPage;
       let recovery: TranscriptGapResolution | undefined;
       if (request.kind === 'gap') {
+        const origin = pageTable
+          .getSnapshot()
+          .ranges.find((range) => range.id === rangeId);
+        if (!origin) return;
         response = await activeClient.getTranscriptPage({
-          atRecordId: request.anchorRecordId,
+          ...('beforeRecordId' in origin
+            ? { beforeRecordId: request.anchorRecordId }
+            : { atRecordId: request.anchorRecordId }),
           snapshot: request.snapshot,
           limit: WEB_SHELL_HISTORY_PAGE_SIZE,
         });
@@ -876,6 +959,7 @@ export function createDaemonTurnNavigationStore(
           validateHistoricalResponse(response, sessionId);
           if (
             fromAnchor &&
+            'anchorTurnId' in origin &&
             response.targetRecordId !== request.anchorRecordId
           ) {
             throw new Error('Gap recovery response did not contain its anchor');
@@ -965,7 +1049,137 @@ export function createDaemonTurnNavigationStore(
         if (extractHttpStatus(error) === 409) void refreshHead();
       }
       throw error;
+    } finally {
+      if (
+        viewportRequest &&
+        !viewportRequest.isCurrent() &&
+        capturedSession === sessionEpoch &&
+        capturedChain === chainEpoch
+      ) {
+        pageTable.cancelBoundaryLoad(rangeId, direction, request);
+        publish();
+      }
     }
+  }
+
+  async function openBeforeLive(
+    beforeRecordId: string,
+    request: HistoryViewportRequest,
+  ): Promise<string> {
+    const activeClient = client;
+    if (!activeClient || snapshot.mode === 'legacy' || !beforeRecordId) {
+      throw new Error('Session history is unavailable');
+    }
+    const epoch = sessionEpoch;
+    const chain = chainEpoch;
+    const current = () =>
+      epoch === sessionEpoch &&
+      chain === chainEpoch &&
+      isCurrentClient(activeClient) &&
+      request.isCurrent();
+    const head = await readFreshHead(activeClient, current);
+    let response = await activeClient.getTranscriptPage({
+      beforeRecordId,
+      snapshot: head.snapshot,
+      limit: WEB_SHELL_HISTORY_PAGE_SIZE,
+    });
+    let previousCursor: string | undefined;
+    while (current()) {
+      validateHistoricalResponse(response, sessionId);
+      const target = pageTable.admitBefore(
+        beforeRecordId,
+        head.snapshot,
+        response,
+      );
+      if (target) {
+        publish();
+        return target.rangeId;
+      }
+      if (
+        !response.hasMore ||
+        !response.nextCursor ||
+        response.nextCursor === previousCursor
+      ) {
+        throw new Error('Earlier history could not be displayed');
+      }
+      previousCursor = response.nextCursor;
+      response = await activeClient.getTranscriptPage({
+        cursor: response.nextCursor,
+        limit: WEB_SHELL_HISTORY_PAGE_SIZE,
+      });
+    }
+    throw new Error('History view changed');
+  }
+
+  async function readFreshHead(
+    activeClient: DaemonTurnNavigationClient,
+    current: () => boolean,
+  ): Promise<DaemonSessionTurnIndexPage> {
+    await headRequest;
+    if (!current()) throw new Error('History view changed');
+    const generation = ++headReadGeneration;
+    try {
+      const head = await activeClient.getTurnIndexPage({
+        limit: indexPageSize,
+      });
+      if (!current() || generation !== headReadGeneration)
+        throw new Error('History view changed');
+      admitHead(head);
+      if (!current()) throw new Error('History view changed');
+      return head;
+    } catch (error) {
+      if (current() && generation === headReadGeneration)
+        handleIndexError(error);
+      throw error;
+    }
+  }
+
+  async function loadViewportBoundary(
+    rangeId: string,
+    direction: 'older' | 'newer',
+    request: HistoryViewportRequest,
+  ): Promise<void> {
+    const range = pageTable
+      .getSnapshot()
+      .ranges.find((range) => range.id === rangeId);
+    if (!range || !request.isCurrent()) return;
+    if (direction !== 'newer' || range.newer.kind !== 'live') {
+      return loadBoundary(rangeId, direction, request);
+    }
+    const boundary = options.captureLiveBoundary?.();
+    const activeClient = client;
+    if (
+      !activeClient ||
+      !boundary?.reachable ||
+      !boundary.beforeRecordId ||
+      !('beforeRecordId' in range) ||
+      hasLiveOverlap(range.id) ||
+      boundary.beforeRecordId === range.beforeRecordId
+    )
+      return;
+    const revision = viewportSnapshot.revision;
+    const current = () =>
+      request.isCurrent() &&
+      boundary.isCurrent() &&
+      viewportSnapshot.revision === revision &&
+      isCurrentClient(activeClient);
+    const head = await readFreshHead(activeClient, current);
+    pageTable.reopenLiveBoundary(
+      rangeId,
+      boundary.beforeRecordId,
+      head.snapshot,
+    );
+    publish();
+    return loadBoundary(rangeId, direction, { isCurrent: current });
+  }
+
+  function hasLiveOverlap(rangeId: string): boolean {
+    const table = pageTable.getSnapshot();
+    const range = table.ranges.find((range) => range.id === rangeId);
+    const edge = range
+      ? table.pages.get(range.pageIds.at(-1)!)?.lastRecordId
+      : undefined;
+    return edge !== undefined && liveRecordIds.has(edge);
   }
 
   async function retry(): Promise<void> {
@@ -1229,6 +1443,17 @@ export function createDaemonTurnNavigationStore(
 
   return {
     getSnapshot: () => snapshot,
+    getViewportSnapshot: () => viewportSnapshot,
+    hasLiveOverlap,
+    captureLiveBoundary: () =>
+      options.captureLiveBoundary?.() ?? {
+        reachable: false,
+        isCurrent: () => false,
+      },
+    openBeforeLive,
+    setViewportAnchor: (viewportId, pageId) =>
+      pageTable.setViewportAnchor(viewportId, pageId),
+    loadViewportBoundary,
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);

--- a/packages/web-shell/client/daemon/session/turn-navigation-store.ts
+++ b/packages/web-shell/client/daemon/session/turn-navigation-store.ts
@@ -255,6 +255,8 @@ export function createDaemonTurnNavigationStore(
   }
 
   function publish(update: Partial<DaemonTurnNavigationSnapshot> = {}): void {
+    const selected = 'selected' in update ? update.selected : snapshot.selected;
+    if (selected?.location?.view !== 'historical') pageTable.clearSelection();
     const table = pageTable.getSnapshot();
     const legacyRanges = table.ranges.filter(
       (range): range is HistoricalTranscriptRange => 'anchorTurnId' in range,

--- a/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
@@ -1,0 +1,271 @@
+import { expect, test, type Locator } from '@playwright/test';
+import {
+  createWebShellDaemonScenario,
+  installMockDaemon,
+  permissionRequestEvent,
+  replayCompleteEvent,
+  turnCompleteEvent,
+} from './utils/mockDaemon';
+
+function recordEvent(record: number, text = `HISTORY ${record}`) {
+  return {
+    v: 1 as const,
+    id: record + 10,
+    type: 'session_update' as const,
+    data: {
+      update: {
+        sessionUpdate:
+          record % 2 ? 'agent_message_chunk' : 'user_message_chunk',
+        content: { type: 'text', text },
+        _meta: {
+          'qwen.session.recordId': `record-${record}`,
+          qwenTranscript: { sourceRecordIds: [`record-${record}`] },
+        },
+      },
+    },
+  };
+}
+
+async function readingAnchor(viewport: Locator) {
+  return viewport.evaluate((root) => {
+    const scroll = root.querySelector<HTMLElement>(
+      '[data-web-shell-message-list]',
+    )!;
+    const top = scroll.getBoundingClientRect().top;
+    const row = [
+      ...root.querySelectorAll<HTMLElement>('[data-source-block-ids]'),
+    ].find(
+      (row) =>
+        row.getBoundingClientRect().bottom > top &&
+        row.getBoundingClientRect().top < top + scroll.clientHeight,
+    )!;
+    return {
+      source: row.dataset.sourceBlockIds!.split(',')[0],
+      offset: row.getBoundingClientRect().top - top,
+    };
+  });
+}
+
+async function moveReadingPosition(
+  scroll: Locator,
+  direction: 'older' | 'newer',
+) {
+  await scroll.hover();
+  const edgeDistance = () =>
+    scroll.evaluate(
+      (element, direction) =>
+        direction === 'older'
+          ? element.scrollTop
+          : element.scrollHeight - element.clientHeight - element.scrollTop,
+      direction,
+    );
+  for (const offset of [0, 80]) {
+    await expect
+      .poll(async () => {
+        const delta = (await edgeDistance()) - offset;
+        if (Math.abs(delta) > 2) {
+          await scroll
+            .page()
+            .mouse.wheel(0, direction === 'older' ? -delta : delta);
+        }
+        return Math.abs((await edgeDistance()) - offset);
+      })
+      .toBeLessThanOrEqual(2);
+  }
+}
+
+for (const pageRecords of [16, 200]) {
+  test(`history viewport preserves the reading row across bounded ${pageRecords}-record pages`, async ({
+    page,
+    baseURL,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    const count = pageRecords * 12;
+    const sessionId = `history-viewport-${pageRecords}`;
+    const live = [
+      recordEvent(count, 'LIVE prompt'),
+      recordEvent(count + 1, 'LIVE answer'),
+      turnCompleteEvent('live-prompt', { id: count + 20 }),
+      permissionRequestEvent('live-approval', { id: count + 21, sessionId }),
+    ];
+    const scenario = createWebShellDaemonScenario({ sessionId, events: live });
+    scenario.capabilities.features.push(
+      'session_turn_navigation',
+      'session_transcript_pagination',
+    );
+    const daemon = await installMockDaemon(page, scenario, { baseURL });
+    const transcriptRequests: Array<{ start: number; end: number }> = [];
+    await page.route(`${baseURL}/**`, async (route) => {
+      const url = new URL(route.request().url());
+      if (/\/session\/[^/]+\/(load|resume)$/.test(url.pathname)) {
+        await route.fulfill({
+          json: {
+            sessionId,
+            workspaceCwd: scenario.workspaceCwd,
+            attached: true,
+            createdAt: new Date().toISOString(),
+            hasActivePrompt: false,
+            clientId: scenario.clientId,
+            state: scenario.state,
+            compactedReplay: live,
+            liveJournal: [],
+            lastEventId: count + 21,
+            historyHasMore: true,
+            historyAnchorRecordId: `record-${count}`,
+          },
+        });
+      } else if (url.pathname.endsWith('/turn-index')) {
+        const totalTurns = count / 2 + 1;
+        const limit = Number(url.searchParams.get('limit'));
+        const start = Number(
+          url.searchParams.get('start') ?? Math.max(0, totalTurns - limit),
+        );
+        await route.fulfill({
+          json: {
+            v: 1,
+            sessionId,
+            snapshot: 'mock-snapshot',
+            totalTurns,
+            start,
+            turns: Array.from(
+              { length: Math.min(limit, totalTurns - start) },
+              (_, index) => ({
+                ordinal: start + index,
+                turnId: `record-${2 * (start + index)}`,
+                kind: 'prompt',
+                label: `History ${start + index}`,
+              }),
+            ),
+          },
+        });
+      } else if (url.pathname.endsWith('/transcript')) {
+        const before = url.searchParams.get('beforeRecordId');
+        const cursor = url.searchParams.get('cursor');
+        const end = Number(
+          before?.split('-').at(-1) ?? cursor?.split(':').at(-1),
+        );
+        const start = Math.max(0, end - pageRecords);
+        transcriptRequests.push({ start, end });
+        await route.fulfill({
+          json: {
+            v: 1,
+            sessionId,
+            events: Array.from({ length: end - start }, (_, index) =>
+              recordEvent(start + index),
+            ),
+            hasMore: start > 0,
+            ...(start > 0 ? { nextCursor: `before:${start}` } : {}),
+          },
+        });
+      } else await route.fallback();
+    });
+    await page.goto(`/session/${sessionId}`);
+    await daemon.sse.waitForConnection(sessionId);
+    await daemon.sendEvent(
+      replayCompleteEvent({ sessionId, replayedCount: live.length }),
+    );
+    await page
+      .getByRole('button', { name: /^(Open earlier history|打开更早历史)$/ })
+      .click();
+    const viewport = page.locator('[data-history-viewport="historical"]');
+    await expect(viewport).toBeVisible();
+    const bootstrapEnd = transcriptRequests.at(-1)!.end;
+    const scroll = viewport.locator('[data-web-shell-message-list]');
+    const directions = [
+      'older',
+      'older',
+      'older',
+      'older',
+      'older',
+      'older',
+      'newer',
+      'newer',
+    ] as const;
+    for (const [round, direction] of directions.entries()) {
+      await test.step(`${direction} admission ${round + 1}`, async () => {
+        await moveReadingPosition(scroll, direction);
+        const anchor = await readingAnchor(viewport);
+        const requests = transcriptRequests.length;
+        const button = viewport.getByRole('button', {
+          name:
+            direction === 'older'
+              ? /^(Load earlier|加载更早记录)$/
+              : /^(Load newer|加载较新记录)$/,
+        });
+        await button.click();
+        await expect
+          .poll(() => transcriptRequests.length)
+          .toBeGreaterThan(requests);
+        await expect(
+          viewport.getByText(/^(Loading earlier messages…|正在加载更早消息…)$/),
+        ).toHaveCount(0);
+        await expect(viewport.locator('[role="alert"]')).toHaveCount(0);
+        let stableAnchorSamples = 0;
+        await expect
+          .poll(
+            async () => {
+              const delta = await viewport.evaluate((root, anchor) => {
+                const scroll = root.querySelector<HTMLElement>(
+                  '[data-web-shell-message-list]',
+                )!;
+                const row = [
+                  ...root.querySelectorAll<HTMLElement>(
+                    '[data-source-block-ids]',
+                  ),
+                ].find((row) =>
+                  row.dataset.sourceBlockIds
+                    ?.split(',')
+                    .includes(anchor.source),
+                );
+                return row
+                  ? Math.abs(
+                      row.getBoundingClientRect().top -
+                        scroll.getBoundingClientRect().top -
+                        anchor.offset,
+                    )
+                  : Number.MAX_VALUE;
+              }, anchor);
+              stableAnchorSamples = delta <= 2 ? stableAnchorSamples + 1 : 0;
+              return stableAnchorSamples;
+            },
+            { intervals: [100] },
+          )
+          .toBeGreaterThanOrEqual(4);
+        if (direction === 'newer') {
+          await moveReadingPosition(scroll, 'newer');
+          const expectedNewest = bootstrapEnd - pageRecords * (7 - round) - 1;
+          await expect(scroll).toContainText(`HISTORY ${expectedNewest}`);
+        }
+      });
+    }
+    await expect(
+      viewport.getByRole('button', { name: /第 \d+ 轮|Turn \d+/ }),
+    ).toHaveCount(0);
+    await expect(
+      viewport.locator('[data-web-shell-permission-option]'),
+    ).toHaveCount(0);
+    await page
+      .locator(
+        '[data-web-shell-permission-option][data-option-id="allow_once"]',
+      )
+      .first()
+      .click();
+    await expect
+      .poll(() => daemon.permissionRequests().length)
+      .toBeGreaterThan(0);
+    const anchor = await readingAnchor(viewport);
+    await daemon.sendEvent({
+      ...recordEvent(count + 3, 'BACKGROUND LIVE answer'),
+      id: count + 40,
+    });
+    await page.waitForTimeout(250);
+    expect(await readingAnchor(viewport)).toEqual(anchor);
+    await viewport
+      .getByRole('button', { name: /^(Return to latest|返回最新)$/ })
+      .first()
+      .click();
+    await expect(page.locator('[data-history-viewport="live"]')).toContainText(
+      'BACKGROUND LIVE answer',
+    );
+  });
+}

--- a/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
@@ -2,9 +2,7 @@ import { expect, test, type Locator } from '@playwright/test';
 import {
   createWebShellDaemonScenario,
   installMockDaemon,
-  permissionRequestEvent,
   replayCompleteEvent,
-  turnCompleteEvent,
 } from './utils/mockDaemon';
 
 function recordEvent(record: number, text = `HISTORY ${record}`) {
@@ -47,132 +45,173 @@ async function readingAnchor(viewport: Locator) {
   });
 }
 
-async function moveReadingPosition(
-  scroll: Locator,
-  direction: 'older' | 'newer',
+async function historyScenario(
+  page: import('@playwright/test').Page,
+  baseURL: string | undefined,
+  pageRecords: number,
 ) {
-  await scroll.hover();
-  const edgeDistance = () =>
-    scroll.evaluate(
-      (element, direction) =>
-        direction === 'older'
-          ? element.scrollTop
-          : element.scrollHeight - element.clientHeight - element.scrollTop,
-      direction,
-    );
-  for (const offset of [0, 80]) {
-    await expect
-      .poll(async () => {
-        const delta = (await edgeDistance()) - offset;
-        if (Math.abs(delta) > 2) {
-          await scroll
-            .page()
-            .mouse.wheel(0, direction === 'older' ? -delta : delta);
-        }
-        return Math.abs((await edgeDistance()) - offset);
-      })
-      .toBeLessThanOrEqual(2);
-  }
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const count = pageRecords * 12;
+  const sessionId = `history-navigation-${pageRecords}`;
+  const live = Array.from({ length: 40 }, (_, index) =>
+    recordEvent(count + index, `LIVE ${count + index}`),
+  );
+  const scenario = createWebShellDaemonScenario({ sessionId, events: live });
+  scenario.capabilities.features.push(
+    'session_turn_navigation',
+    'session_transcript_pagination',
+  );
+  const daemon = await installMockDaemon(page, scenario, { baseURL });
+  const requests: Array<{ start: number; end: number; anchored: boolean }> = [];
+  let hold = false;
+  let release: (() => void) | undefined;
+  await page.route(`${baseURL}/**`, async (route) => {
+    const url = new URL(route.request().url());
+    if (/\/session\/[^/]+\/(load|resume)$/.test(url.pathname)) {
+      await route.fulfill({
+        json: {
+          sessionId,
+          workspaceCwd: scenario.workspaceCwd,
+          attached: true,
+          createdAt: new Date().toISOString(),
+          hasActivePrompt: false,
+          clientId: scenario.clientId,
+          state: scenario.state,
+          compactedReplay: live,
+          liveJournal: [],
+          lastEventId: count + 60,
+          historyHasMore: true,
+          historyAnchorRecordId: `record-${count}`,
+        },
+      });
+    } else if (url.pathname.endsWith('/turn-index')) {
+      const totalTurns = (count + 40) / 2;
+      const limit = Number(url.searchParams.get('limit'));
+      const start = Number(
+        url.searchParams.get('start') ?? Math.max(0, totalTurns - limit),
+      );
+      await route.fulfill({
+        json: {
+          v: 1,
+          sessionId,
+          snapshot: 'mock-snapshot',
+          totalTurns,
+          start,
+          turns: Array.from(
+            { length: Math.min(limit, totalTurns - start) },
+            (_, index) => ({
+              ordinal: start + index,
+              turnId: `record-${2 * (start + index)}`,
+              kind: 'prompt',
+              label: `History ${start + index}`,
+            }),
+          ),
+        },
+      });
+    } else if (url.pathname.endsWith('/transcript')) {
+      const at = url.searchParams.get('atRecordId');
+      const before = url.searchParams.get('beforeRecordId');
+      const after = url.searchParams.get('afterRecordId');
+      const cursor = url.searchParams.get('cursor');
+      const backward = !!before || cursor?.startsWith('before:');
+      const boundary = Number(
+        (at ?? before ?? after ?? cursor)?.split(/[-:]/).at(-1),
+      );
+      const start = backward
+        ? Math.max(0, boundary - pageRecords)
+        : boundary + (after ? 1 : 0);
+      const end = backward
+        ? boundary
+        : Math.min(count + 40, start + pageRecords);
+      requests.push({ start, end, anchored: !!at });
+      if (hold && !at)
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      await route.fulfill({
+        json: {
+          v: 1,
+          sessionId,
+          events: Array.from({ length: end - start }, (_, index) =>
+            recordEvent(start + index),
+          ),
+          hasMore: backward ? start > 0 : end < count + 40,
+          ...((backward ? start > 0 : end < count + 40)
+            ? { nextCursor: backward ? `before:${start}` : `after:${end}` }
+            : {}),
+          ...(at ? { targetRecordId: at, hasOlder: start > 0 } : {}),
+        },
+      });
+    } else await route.fallback();
+  });
+  await page.goto(`/session/${sessionId}`);
+  await daemon.sse.waitForConnection(sessionId);
+  await daemon.sendEvent(
+    replayCompleteEvent({ sessionId, replayedCount: live.length }),
+  );
+  return {
+    count,
+    sessionId,
+    daemon,
+    requests,
+    hold: () => {
+      hold = true;
+    },
+    release: () => {
+      hold = false;
+      release?.();
+      release = undefined;
+    },
+  };
 }
 
+test('continuous history preserves the original upward loader with global navigation enabled @smoke', async ({
+  page,
+  baseURL,
+}) => {
+  const { requests } = await historyScenario(page, baseURL, 16);
+  const scroll = page.locator('[data-web-shell-message-list]');
+  await expect(page.locator('[data-global-turn-navigation]')).toBeVisible();
+  await expect(
+    page.getByText(
+      /Historical snapshot|历史快照|Open earlier history|打开更早历史/,
+    ),
+  ).toHaveCount(0);
+  await scroll.hover();
+  await page.mouse.wheel(0, -100000);
+  await expect
+    .poll(() => requests.filter((request) => !request.anchored).length)
+    .toBeGreaterThan(0);
+  await expect(page.locator('[data-history-viewport="live"]')).toBeVisible();
+});
+
 for (const pageRecords of [16, 200]) {
-  test(`history viewport preserves the reading row across bounded ${pageRecords}-record pages @smoke`, async ({
+  test(`global turn navigation preserves the reading row across bounded ${pageRecords}-record pages @smoke`, async ({
     page,
     baseURL,
   }) => {
-    await page.setViewportSize({ width: 1440, height: 1000 });
-    const count = pageRecords * 12;
-    const sessionId = `history-viewport-${pageRecords}`;
-    const live = [
-      recordEvent(count, 'LIVE prompt'),
-      recordEvent(count + 1, 'LIVE answer'),
-      turnCompleteEvent('live-prompt', { id: count + 20 }),
-      permissionRequestEvent('live-approval', { id: count + 21, sessionId }),
-    ];
-    const scenario = createWebShellDaemonScenario({ sessionId, events: live });
-    scenario.capabilities.features.push(
-      'session_turn_navigation',
-      'session_transcript_pagination',
-    );
-    const daemon = await installMockDaemon(page, scenario, { baseURL });
-    const transcriptRequests: Array<{ start: number; end: number }> = [];
-    await page.route(`${baseURL}/**`, async (route) => {
-      const url = new URL(route.request().url());
-      if (/\/session\/[^/]+\/(load|resume)$/.test(url.pathname)) {
-        await route.fulfill({
-          json: {
-            sessionId,
-            workspaceCwd: scenario.workspaceCwd,
-            attached: true,
-            createdAt: new Date().toISOString(),
-            hasActivePrompt: false,
-            clientId: scenario.clientId,
-            state: scenario.state,
-            compactedReplay: live,
-            liveJournal: [],
-            lastEventId: count + 21,
-            historyHasMore: true,
-            historyAnchorRecordId: `record-${count}`,
-          },
-        });
-      } else if (url.pathname.endsWith('/turn-index')) {
-        const totalTurns = count / 2 + 1;
-        const limit = Number(url.searchParams.get('limit'));
-        const start = Number(
-          url.searchParams.get('start') ?? Math.max(0, totalTurns - limit),
-        );
-        await route.fulfill({
-          json: {
-            v: 1,
-            sessionId,
-            snapshot: 'mock-snapshot',
-            totalTurns,
-            start,
-            turns: Array.from(
-              { length: Math.min(limit, totalTurns - start) },
-              (_, index) => ({
-                ordinal: start + index,
-                turnId: `record-${2 * (start + index)}`,
-                kind: 'prompt',
-                label: `History ${start + index}`,
-              }),
-            ),
-          },
-        });
-      } else if (url.pathname.endsWith('/transcript')) {
-        const before = url.searchParams.get('beforeRecordId');
-        const cursor = url.searchParams.get('cursor');
-        const end = Number(
-          before?.split('-').at(-1) ?? cursor?.split(':').at(-1),
-        );
-        const start = Math.max(0, end - pageRecords);
-        transcriptRequests.push({ start, end });
-        await route.fulfill({
-          json: {
-            v: 1,
-            sessionId,
-            events: Array.from({ length: end - start }, (_, index) =>
-              recordEvent(start + index),
-            ),
-            hasMore: start > 0,
-            ...(start > 0 ? { nextCursor: `before:${start}` } : {}),
-          },
-        });
-      } else await route.fallback();
-    });
-    await page.goto(`/session/${sessionId}`);
-    await daemon.sse.waitForConnection(sessionId);
-    await daemon.sendEvent(
-      replayCompleteEvent({ sessionId, replayedCount: live.length }),
-    );
-    await page
-      .getByRole('button', { name: /^(Open earlier history|打开更早历史)$/ })
-      .click();
+    const fixture = await historyScenario(page, baseURL, pageRecords);
+    const ordinal = (fixture.count - 2 * pageRecords) / 2;
+    const rail = page.locator('[data-global-turn-navigation]');
+    await expect(rail).toBeVisible();
+    await rail
+      .locator('div')
+      .first()
+      .evaluate((element, ordinal) => {
+        const item = element.querySelector<HTMLElement>('[aria-setsize]')!;
+        element.scrollTop =
+          ordinal *
+          (element.scrollHeight / Number(item.getAttribute('aria-setsize')));
+      }, ordinal);
+    await rail.locator(`[data-turn-ordinal="${ordinal}"]`).click();
     const viewport = page.locator('[data-history-viewport="historical"]');
     await expect(viewport).toBeVisible();
-    const bootstrapEnd = transcriptRequests.at(-1)!.end;
+    await expect
+      .poll(() => fixture.requests.filter((request) => request.anchored).length)
+      .toBe(1);
     const scroll = viewport.locator('[data-web-shell-message-list]');
-    const directions = [
+    await expect(scroll).toContainText(`HISTORY ${ordinal * 2}`);
+    for (const direction of [
       'older',
       'older',
       'older',
@@ -181,91 +220,51 @@ for (const pageRecords of [16, 200]) {
       'older',
       'newer',
       'newer',
-    ] as const;
-    for (const [round, direction] of directions.entries()) {
-      await test.step(`${direction} admission ${round + 1}`, async () => {
-        await moveReadingPosition(scroll, direction);
+    ] as const) {
+      await test.step(`scroll ${direction}`, async () => {
+        fixture.hold();
+        const previous = fixture.requests.length;
+        await scroll.hover();
+        await page.mouse.wheel(0, direction === 'older' ? -100000 : 100000);
+        await expect
+          .poll(() => fixture.requests.length)
+          .toBeGreaterThan(previous);
         const anchor = await readingAnchor(viewport);
-        const requests = transcriptRequests.length;
-        const button = viewport.getByRole('button', {
-          name:
-            direction === 'older'
-              ? /^(Load earlier|加载更早记录)$/
-              : /^(Load newer|加载较新记录)$/,
-        });
-        await button.click();
-        await expect
-          .poll(() => transcriptRequests.length)
-          .toBeGreaterThan(requests);
-        await expect(
-          viewport.getByText(/^(Loading earlier messages…|正在加载更早消息…)$/),
-        ).toHaveCount(0);
+        fixture.release();
+        await expect(viewport.locator('[role="status"]')).toHaveCount(0);
         await expect(viewport.locator('[role="alert"]')).toHaveCount(0);
-        let stableAnchorSamples = 0;
         await expect
-          .poll(
-            async () => {
-              const delta = await viewport.evaluate((root, anchor) => {
-                const scroll = root.querySelector<HTMLElement>(
-                  '[data-web-shell-message-list]',
-                )!;
-                const row = [
-                  ...root.querySelectorAll<HTMLElement>(
-                    '[data-source-block-ids]',
-                  ),
-                ].find((row) =>
-                  anchor.rowKey
-                    ? row.dataset.messageRowKey === anchor.rowKey
-                    : row.dataset.sourceBlockIds
-                        ?.split(',')
-                        .includes(anchor.source),
-                );
-                return row
-                  ? Math.abs(
-                      row.getBoundingClientRect().top -
-                        scroll.getBoundingClientRect().top -
-                        anchor.offset,
-                    )
-                  : Number.MAX_VALUE;
-              }, anchor);
-              stableAnchorSamples = delta <= 2 ? stableAnchorSamples + 1 : 0;
-              return stableAnchorSamples;
-            },
-            { intervals: [100] },
-          )
-          .toBeGreaterThanOrEqual(4);
-        if (direction === 'newer') {
-          await moveReadingPosition(scroll, 'newer');
-          const expectedNewest = bootstrapEnd - pageRecords * (7 - round) - 1;
-          await expect(scroll).toContainText(`HISTORY ${expectedNewest}`);
-        }
+          .poll(async () => {
+            return viewport.evaluate((root, anchor) => {
+              const scroll = root.querySelector<HTMLElement>(
+                '[data-web-shell-message-list]',
+              )!;
+              const row = [
+                ...root.querySelectorAll<HTMLElement>('[data-message-row-key]'),
+              ].find((row) => row.dataset.messageRowKey === anchor.rowKey);
+              return row
+                ? Math.abs(
+                    row.getBoundingClientRect().top -
+                      scroll.getBoundingClientRect().top -
+                      anchor.offset,
+                  )
+                : Number.MAX_VALUE;
+            }, anchor);
+          })
+          .toBeLessThanOrEqual(2);
       });
     }
-    await expect(
-      viewport.getByRole('button', { name: /第 \d+ 轮|Turn \d+/ }),
-    ).toHaveCount(0);
-    await expect(
-      viewport.locator('[data-web-shell-permission-option]'),
-    ).toHaveCount(0);
-    await page
-      .locator(
-        '[data-web-shell-permission-option][data-option-id="allow_once"]',
-      )
-      .first()
-      .click();
-    await expect
-      .poll(() => daemon.permissionRequests().length)
-      .toBeGreaterThan(0);
+    await expect(rail).toBeVisible();
     const anchor = await readingAnchor(viewport);
-    await daemon.sendEvent({
-      ...recordEvent(count + 3, 'BACKGROUND LIVE answer'),
-      id: count + 40,
+    await fixture.daemon.sendEvent({
+      ...recordEvent(fixture.count + 41, 'BACKGROUND LIVE answer'),
+      id: fixture.count + 100,
     });
     await page.waitForTimeout(250);
     expect(await readingAnchor(viewport)).toEqual(anchor);
-    await viewport
-      .getByRole('button', { name: /^(Return to latest|返回最新)$/ })
-      .first()
+    await expect(viewport).not.toContainText('BACKGROUND LIVE answer');
+    await page
+      .getByRole('button', { name: /Scroll to bottom|回到底部/ })
       .click();
     await expect(page.locator('[data-history-viewport="live"]')).toContainText(
       'BACKGROUND LIVE answer',

--- a/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
@@ -41,6 +41,7 @@ async function readingAnchor(viewport: Locator) {
     )!;
     return {
       source: row.dataset.sourceBlockIds!.split(',')[0],
+      rowKey: row.dataset.messageRowKey,
       offset: row.getBoundingClientRect().top - top,
     };
   });
@@ -75,7 +76,7 @@ async function moveReadingPosition(
 }
 
 for (const pageRecords of [16, 200]) {
-  test(`history viewport preserves the reading row across bounded ${pageRecords}-record pages`, async ({
+  test(`history viewport preserves the reading row across bounded ${pageRecords}-record pages @smoke`, async ({
     page,
     baseURL,
   }) => {
@@ -213,9 +214,11 @@ for (const pageRecords of [16, 200]) {
                     '[data-source-block-ids]',
                   ),
                 ].find((row) =>
-                  row.dataset.sourceBlockIds
-                    ?.split(',')
-                    .includes(anchor.source),
+                  anchor.rowKey
+                    ? row.dataset.messageRowKey === anchor.rowKey
+                    : row.dataset.sourceBlockIds
+                        ?.split(',')
+                        .includes(anchor.source),
                 );
                 return row
                   ? Math.abs(

--- a/packages/web-shell/client/hooks/useTranscriptViewport.ts
+++ b/packages/web-shell/client/hooks/useTranscriptViewport.ts
@@ -34,9 +34,20 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
   );
   const viewportId = useId();
   const intent = useRef(0);
-  const [view, setView] = useState<{ revision: number; rangeId: string }>();
+  const [view, setView] = useState<{
+    revision: number;
+    rangeId: string;
+    liveBoundary?: string;
+  }>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  const selecting = useRef(false);
+  const boundaryLoading = useRef(false);
+  const retryAction = useRef<
+    { ordinal: number } | { direction: 'older' | 'newer' } | undefined
+  >(undefined);
+  const [target, setTarget] = useState<{ blockId: string; token: number }>();
+  const pinnedPage = useRef<string | undefined>(undefined);
   const range =
     view?.revision === state.revision
       ? state.ranges.find((range) => range.id === view.rangeId)
@@ -44,6 +55,10 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
   const returnToLive = useCallback(() => {
     intent.current += 1;
     store.setViewportAnchor(viewportId);
+    pinnedPage.current = undefined;
+    selecting.current = false;
+    boundaryLoading.current = false;
+    setTarget(undefined);
     setView(undefined);
     setLoading(false);
     setError(false);
@@ -82,41 +97,113 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
       const pageId = range?.pageIds.find((id) =>
         state.pages.get(id)?.blocks.some((block) => block.id === sourceBlockId),
       );
-      if (pageId) store.setViewportAnchor(viewportId, pageId);
+      if (pageId) {
+        pinnedPage.current = pageId;
+        store.setViewportAnchor(viewportId, pageId);
+      }
     },
     [range?.pageIds, state.pages, store, viewportId],
   );
 
-  const load = useCallback(
-    async (direction: 'older' | 'newer') => {
-      if (loading) return;
+  const cancelSelection = useCallback(() => {
+    setTarget(undefined);
+    if (!selecting.current) return;
+    intent.current += 1;
+    selecting.current = false;
+    setLoading(false);
+    store.setViewportAnchor(viewportId, pinnedPage.current);
+  }, [store, viewportId]);
+
+  const selectOrdinal = useCallback(
+    async (ordinal: number) => {
+      retryAction.current = { ordinal };
       const token = ++intent.current;
+      boundaryLoading.current = false;
       const revision = state.revision;
-      const boundary = store.captureLiveBoundary();
-      const isCurrentIntent = () =>
-        intent.current === token &&
-        store.getViewportSnapshot().revision === revision;
       const request = {
         isCurrent: () =>
-          isCurrentIntent() &&
-          (range !== undefined || boundary.isCurrent()),
+          intent.current === token &&
+          store.getViewportSnapshot().revision === revision,
       };
+      selecting.current = true;
+      setTarget(undefined);
       setLoading(true);
       setError(false);
       try {
-        let rangeId = range?.id;
-        if (!range) {
-          if (!boundary.reachable || !boundary.beforeRecordId)
-            throw new Error('History boundary unavailable');
-          rangeId = await store.openBeforeLive(
-            boundary.beforeRecordId,
-            request,
-          );
+        const provisional =
+          navigation.provisionalTurns[ordinal - navigation.totalTurns];
+        const location = provisional?.blockId
+          ? { blockId: provisional.blockId, view: 'live' as const }
+          : await store.locateViewportOrdinal(ordinal, request, () =>
+              store.setViewportAnchor(viewportId),
+            );
+        if (!request.isCurrent()) return;
+        if (location.view === 'historical') {
+          if (
+            !location.rangeId ||
+            !store
+              .getViewportSnapshot()
+              .ranges.some((item) => item.id === location.rangeId)
+          )
+            throw new Error('History view expired');
+          pinnedPage.current = location.pageId;
+          store.setViewportAnchor(viewportId, location.pageId);
+          setView({ revision, rangeId: location.rangeId });
         } else {
-          const edge = range[direction];
-          if (edge.kind === 'cached') rangeId = edge.rangeId;
-          else await store.loadViewportBoundary(range.id, direction, request);
+          pinnedPage.current = undefined;
+          store.setViewportAnchor(viewportId);
+          setView(undefined);
         }
+        setTarget({ blockId: location.blockId, token });
+      } catch {
+        if (request.isCurrent()) {
+          store.setViewportAnchor(viewportId, pinnedPage.current);
+          setError(true);
+        }
+      } finally {
+        if (request.isCurrent()) {
+          selecting.current = false;
+          setLoading(false);
+        }
+      }
+    },
+    [
+      navigation.provisionalTurns,
+      navigation.totalTurns,
+      state.revision,
+      store,
+      viewportId,
+    ],
+  );
+
+  const continueLive = useCallback(
+    (blockId?: string) => {
+      returnToLive();
+      if (blockId) setTarget({ blockId, token: intent.current });
+    },
+    [returnToLive],
+  );
+
+  const load = useCallback(
+    async (direction: 'older' | 'newer') => {
+      if (loading || boundaryLoading.current || selecting.current || !range)
+        return;
+      boundaryLoading.current = true;
+      retryAction.current = { direction };
+      const token = ++intent.current;
+      const liveBoundary = store.captureLiveBoundary();
+      const revision = state.revision;
+      const isCurrentIntent = () =>
+        intent.current === token &&
+        store.getViewportSnapshot().revision === revision;
+      const request = { isCurrent: isCurrentIntent };
+      setLoading(true);
+      setError(false);
+      try {
+        let rangeId = range.id;
+        const edge = range[direction];
+        if (edge.kind === 'cached') rangeId = edge.rangeId;
+        else await store.loadViewportBoundary(range.id, direction, request);
         if (!request.isCurrent()) throw new Error('History view changed');
         const admitted = store
           .getViewportSnapshot()
@@ -130,20 +217,34 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
               : admitted.pageIds[0],
           );
         }
-        setView({ revision, rangeId: admitted.id });
+        setView((previous) => ({
+          revision,
+          rangeId: admitted.id,
+          liveBoundary:
+            direction === 'newer' && admitted.newer.kind === 'live'
+              ? liveBoundary.beforeRecordId
+              : previous?.liveBoundary,
+        }));
       } catch {
         if (isCurrentIntent()) setError(true);
       } finally {
-        if (intent.current === token) setLoading(false);
+        if (intent.current === token) {
+          boundaryLoading.current = false;
+          setLoading(false);
+        }
       }
     },
     [loading, range, state.revision, store, viewportId],
   );
 
   const liveBoundary = store.captureLiveBoundary();
-  const available =
-    navigation.mode === 'ready' || navigation.mode === 'loading';
   return {
+    navigation,
+    store,
+    target,
+    selectOrdinal,
+    cancelSelection,
+    continueLive,
     messages: range ? messages : liveMessages,
     toolSources,
     historical: !!range,
@@ -153,19 +254,20 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
     range,
     loading,
     error,
-    enabled: !!range || (available && !!liveBoundary.beforeRecordId),
-    canOpen:
-      available &&
-      state.connected &&
-      liveBoundary.reachable &&
-      !!liveBoundary.beforeRecordId,
     connected: state.connected,
     canContinueLive:
       !!range &&
-      'beforeRecordId' in range &&
-      !store.hasLiveOverlap(range.id) &&
       liveBoundary.reachable &&
-      liveBoundary.beforeRecordId !== range.beforeRecordId,
+      !!liveBoundary.beforeRecordId &&
+      (store.hasLiveOverlap(range.id) ||
+        liveBoundary.beforeRecordId === view?.liveBoundary),
+    retry: () => {
+      const action = retryAction.current;
+      if (action)
+        void ('ordinal' in action
+          ? selectOrdinal(action.ordinal)
+          : load(action.direction));
+    },
     pin,
     load,
     returnToLive,

--- a/packages/web-shell/client/hooks/useTranscriptViewport.ts
+++ b/packages/web-shell/client/hooks/useTranscriptViewport.ts
@@ -93,10 +93,12 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
       const token = ++intent.current;
       const revision = state.revision;
       const boundary = store.captureLiveBoundary();
+      const isCurrentIntent = () =>
+        intent.current === token &&
+        store.getViewportSnapshot().revision === revision;
       const request = {
         isCurrent: () =>
-          intent.current === token &&
-          store.getViewportSnapshot().revision === revision &&
+          isCurrentIntent() &&
           (range !== undefined || boundary.isCurrent()),
       };
       setLoading(true);
@@ -115,7 +117,7 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
           if (edge.kind === 'cached') rangeId = edge.rangeId;
           else await store.loadViewportBoundary(range.id, direction, request);
         }
-        if (!request.isCurrent()) return;
+        if (!request.isCurrent()) throw new Error('History view changed');
         const admitted = store
           .getViewportSnapshot()
           .ranges.find((range) => range.id === rangeId);
@@ -130,7 +132,7 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
         }
         setView({ revision, rangeId: admitted.id });
       } catch {
-        if (request.isCurrent()) setError(true);
+        if (isCurrentIntent()) setError(true);
       } finally {
         if (intent.current === token) setLoading(false);
       }

--- a/packages/web-shell/client/hooks/useTranscriptViewport.ts
+++ b/packages/web-shell/client/hooks/useTranscriptViewport.ts
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { useDaemonHistoryNavigationStore } from '../daemon/session/DaemonSessionProvider';
+import {
+  transcriptBlocksToLocalizedMessages,
+  type Translator,
+} from '../adapters/localizedMessages';
+import type { Message } from '../adapters/types';
+
+export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
+  const store = useDaemonHistoryNavigationStore();
+  const state = useSyncExternalStore(
+    store.subscribe,
+    store.getViewportSnapshot,
+    store.getViewportSnapshot,
+  );
+  const navigation = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+  const viewportId = useId();
+  const intent = useRef(0);
+  const [view, setView] = useState<{ revision: number; rangeId: string }>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const range =
+    view?.revision === state.revision
+      ? state.ranges.find((range) => range.id === view.rangeId)
+      : undefined;
+  const returnToLive = useCallback(() => {
+    intent.current += 1;
+    store.setViewportAnchor(viewportId);
+    setView(undefined);
+    setLoading(false);
+    setError(false);
+  }, [store, viewportId]);
+  useEffect(() => {
+    returnToLive();
+    return () => {
+      intent.current += 1;
+      store.setViewportAnchor(viewportId);
+    };
+  }, [state.revision, store, viewportId, returnToLive]);
+
+  const blocks = useMemo(
+    () =>
+      range?.pageIds.flatMap((id) => state.pages.get(id)?.blocks ?? []) ?? [],
+    [range?.pageIds, state.pages],
+  );
+  const messages = useMemo(
+    () =>
+      transcriptBlocksToLocalizedMessages(blocks, t, false, true).map(
+        (message) => {
+          if ('isStreaming' in message)
+            return { ...message, isStreaming: false };
+          return message;
+        },
+      ),
+    [blocks, t],
+  );
+  const toolSources = useMemo(() => {
+    const sources = new Map<string, string>();
+    for (const block of blocks) {
+      if (block.kind === 'tool' && !sources.has(block.toolCallId))
+        sources.set(block.toolCallId, block.id);
+    }
+    return sources;
+  }, [blocks]);
+  const pin = useCallback(
+    (sourceBlockId?: string) => {
+      const pageId = range?.pageIds.find((id) =>
+        state.pages.get(id)?.blocks.some((block) => block.id === sourceBlockId),
+      );
+      if (pageId) store.setViewportAnchor(viewportId, pageId);
+    },
+    [range?.pageIds, state.pages, store, viewportId],
+  );
+
+  const load = useCallback(
+    async (direction: 'older' | 'newer') => {
+      if (loading) return;
+      const token = ++intent.current;
+      const revision = state.revision;
+      const boundary = store.captureLiveBoundary();
+      const request = {
+        isCurrent: () =>
+          intent.current === token &&
+          store.getViewportSnapshot().revision === revision &&
+          (range !== undefined || boundary.isCurrent()),
+      };
+      setLoading(true);
+      setError(false);
+      try {
+        let rangeId = range?.id;
+        if (!range) {
+          if (!boundary.reachable || !boundary.beforeRecordId)
+            throw new Error('History boundary unavailable');
+          rangeId = await store.openBeforeLive(
+            boundary.beforeRecordId,
+            request,
+          );
+        } else {
+          const edge = range[direction];
+          if (edge.kind === 'cached') rangeId = edge.rangeId;
+          else await store.loadViewportBoundary(range.id, direction, request);
+        }
+        if (!request.isCurrent()) return;
+        const admitted = store
+          .getViewportSnapshot()
+          .ranges.find((range) => range.id === rangeId);
+        if (!admitted) throw new Error('History view expired');
+        if (range?.id !== admitted.id) {
+          store.setViewportAnchor(
+            viewportId,
+            direction === 'older'
+              ? admitted.pageIds.at(-1)
+              : admitted.pageIds[0],
+          );
+        }
+        setView({ revision, rangeId: admitted.id });
+      } catch {
+        if (request.isCurrent()) setError(true);
+      } finally {
+        if (intent.current === token) setLoading(false);
+      }
+    },
+    [loading, range, state.revision, store, viewportId],
+  );
+
+  const liveBoundary = store.captureLiveBoundary();
+  return {
+    messages: range ? messages : liveMessages,
+    toolSources,
+    historical: !!range,
+    viewKey: range
+      ? `${state.sessionId ?? ''}:${state.revision}:${range.id}`
+      : `${state.sessionId ?? ''}:live`,
+    range,
+    loading,
+    error,
+    enabled:
+      navigation.mode !== 'legacy' &&
+      (!!range || !!liveBoundary.beforeRecordId),
+    canOpen:
+      navigation.mode !== 'legacy' && state.connected && liveBoundary.reachable,
+    connected: state.connected,
+    canContinueLive:
+      !!range &&
+      'beforeRecordId' in range &&
+      !store.hasLiveOverlap(range.id) &&
+      liveBoundary.reachable &&
+      liveBoundary.beforeRecordId !== range.beforeRecordId,
+    pin,
+    load,
+    returnToLive,
+  };
+}

--- a/packages/web-shell/client/hooks/useTranscriptViewport.ts
+++ b/packages/web-shell/client/hooks/useTranscriptViewport.ts
@@ -63,13 +63,10 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
   );
   const messages = useMemo(
     () =>
-      transcriptBlocksToLocalizedMessages(blocks, t, false, true).map(
-        (message) => {
-          if ('isStreaming' in message)
-            return { ...message, isStreaming: false };
-          return message;
-        },
-      ),
+      transcriptBlocksToLocalizedMessages(blocks, t).map((message) => {
+        if ('isStreaming' in message) return { ...message, isStreaming: false };
+        return message;
+      }),
     [blocks, t],
   );
   const toolSources = useMemo(() => {
@@ -142,6 +139,8 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
   );
 
   const liveBoundary = store.captureLiveBoundary();
+  const available =
+    navigation.mode === 'ready' || navigation.mode === 'loading';
   return {
     messages: range ? messages : liveMessages,
     toolSources,
@@ -152,11 +151,12 @@ export function useTranscriptViewport(liveMessages: Message[], t: Translator) {
     range,
     loading,
     error,
-    enabled:
-      navigation.mode !== 'legacy' &&
-      (!!range || !!liveBoundary.beforeRecordId),
+    enabled: !!range || (available && !!liveBoundary.beforeRecordId),
     canOpen:
-      navigation.mode !== 'legacy' && state.connected && liveBoundary.reachable,
+      available &&
+      state.connected &&
+      liveBoundary.reachable &&
+      !!liveBoundary.beforeRecordId,
     connected: state.connected,
     canContinueLive:
       !!range &&

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1113,6 +1113,15 @@ const EN: Messages = {
   'editor.noHistory': 'No matching history',
   'editor.placeholder': 'Type a message or @ file path',
   'history.loadingEarlier': 'Loading earlier messages…',
+  'history.openEarlier': 'Open earlier history',
+  'history.loadEarlier': 'Load earlier',
+  'history.loadNewer': 'Load newer',
+  'history.returnLatest': 'Return to latest',
+  'history.viewUnavailable':
+    'History is temporarily unavailable while the session reconnects or repairs its transcript.',
+  'history.snapshotView': 'Historical snapshot · read-only',
+  'history.viewError':
+    'This section could not be loaded. Move the reading position and retry, or return to latest.',
   'history.capacityReached':
     'History display limit reached. Earlier messages remain saved.',
   'history.paginationError': 'Earlier history could not be loaded.',
@@ -4636,6 +4645,14 @@ const ZH: Messages = {
   'editor.noHistory': '没有匹配的历史记录',
   'editor.placeholder': '输入消息或 @ 文件路径',
   'history.loadingEarlier': '正在加载更早消息…',
+  'history.openEarlier': '打开更早历史',
+  'history.loadEarlier': '加载更早记录',
+  'history.loadNewer': '加载较新记录',
+  'history.returnLatest': '返回最新',
+  'history.viewUnavailable': '会话正在重连或修复记录，历史暂时不可用。',
+  'history.snapshotView': '历史快照 · 只读',
+  'history.viewError':
+    '暂时无法加载此段记录。请移动阅读位置后重试，或返回最新。',
   'history.capacityReached': '已达到历史显示上限，更早消息仍保存在会话中。',
   'history.paginationError': '无法加载更早的历史记录。',
   'history.retry': '重试',


### PR DESCRIPTION
## What this PR does

Adds bounded historical browsing and a session-wide turn navigation rail to Web Shell. Ordinary upward scrolling keeps its existing loading behavior. The left rail uses compact ticks; hovering or focusing a tick shows the indexed prompt and available preview, while clicking locates any historical turn and loads distant content on demand. The historical snapshot toolbar is removed. This implements Phase 2B and the agreed Phase 3 global rail from #10750; implementation and scoped frontend verification are complete, while merge and broader real-daemon acceptance remain separate milestones.

Historical browsing preserves the reading row while loading adjacent pages and recovering evicted gaps. Historical content remains isolated from live output, approvals and host callbacks, and the existing return-to-latest action restores the live view. The shared cache protects per-viewport reading pages within its existing limits. Unsupported daemons and cursor-only sessions retain their original pagination, and split panes retain their compact navigation policy.

## Why it's needed

The navigation foundation from #11054 does not itself expose all historical turns in the built-in UI. Explicit snapshot controls interrupt the familiar scrolling interaction. A compact all-history rail provides direct access without a permanent text sidebar or loading the entire transcript into memory.

## Reviewer Test Plan

### How to verify

1. Open a long session and scroll upward. Earlier messages should load through the original pagination path without a snapshot toolbar.
2. Hover or keyboard-focus a left-hand tick. A readable title and available content preview should appear immediately, and disappear on mouse leave or Escape. Hovering must not fetch transcript pages. Check that the rail is visible at a 738px chat width and hidden at 500px.
3. Browse a session with thousands of turns. The rail should render a bounded number of marks, load only needed index pages, and allow Home, End, arrows, Tab and Enter. Clicking a distant turn should load that target without loading all intervening history.
4. From a distant turn, scroll through at least six older pages and then toward newer content, moving the reading position between loads. Exercise both small and 200-record pages. The reading row should retain its offset as opposite-edge pages are evicted; reaching a changed live boundary should recover missing records, including when that boundary is an assistant or tool record.
5. Test delayed selections, session switching, return-to-latest, metadata errors and boundary retries. Stale navigation must not replace the current view; retries should preserve readable content and position. Receive live output while reading history, then return to latest to see it. Historical fragments must not expose live mutation controls.
6. Reconnect, rewind through the dialog, and branch with a history request delayed. Same-owner reconnect should retain the reading row; owner replacement and rewind should use the refreshed live view. Branching should open the child, and subsequent navigation must fetch child-session history. Releasing an old source response must not replace the resulting view.

### Evidence (Before & After)

Before: the original global CLI supported ordinary upward pagination, while the previous PR UI required explicit historical snapshot controls. The first all-history rail displayed a 160px-wide numbered text list, taking space from the transcript.

After: the local preview uses a 64px rail with 10×3px resting ticks and 16px hit rows, reusing the original hover expansion. A title and optional multi-line preview appear on hover/focus without animation or transcript requests. In the 738px browser fixture, the preview was fully opaque, unclipped and dismissed on a single mouse move; 500px hides the rail.

Validation: 129 focused component/store/page-table tests passed. Three repository browser cases passed, covering original upward loading and bounded 16-/200-record historical scrolling. An independent 13-case browser run passed before the presentation refinement; the final three presentation/navigation cases passed after it, covering hover dismissal, responsive layout, 5,000-turn virtualization, direct loaded/distant selection and keyboard entry. These runs overlap and are not additive. The full repository build and typecheck passed during implementation; the final affected-package build/typecheck, bundle, lint and formatting passed after the presentation refinement. Self-audit and independent follow-up review found no remaining actionable issues in this change.

Follow-up lifecycle verification at `02e975e9fa` passed eight distinct browser scenarios across an initial run and a targeted branch rerun, with zero browser page errors, plus 105 targeted unit tests. It covers same-owner reconnect, ring-eviction owner replacement, rewind, active-session and loaded-checkpoint branching, child-session navigation and delayed source responses. The browser uses actual controls and provider paths with deterministic HTTP/SSE fixtures; real daemon persistence and restart/failover remain unverified. The unit results overlap earlier runs and are not additive. Frozen historical fragments do not expose checkpoint Branch buttons; historical inspection was tested through the actual `/branch` command, and checkpoint branching through a normal loaded Assistant row.

Maintainer Linux verification: [wenshao’s report](https://github.com/QwenLM/qwen-code/pull/11208#issuecomment-5572237907) tested client head `b6998e7300` against a real daemon and a 1,200-turn persisted session, cold-loaded after killing and restarting the daemon. The report records 16/16 checks passing on four consecutive runs: bounded ticks and history windows, indexed previews, distant jumps, bidirectional paging with 0 px reading-row drift, live isolation, return to latest, responsive layout and keyboard navigation. Capability-withheld and anchor-mutation controls were included. The maintainer also reports three clean full Web Shell suite runs (6,380 tests each), typecheck, lint and formatting on Linux x86_64 / Node 22.22.2 / Chromium. This is maintainer-provided evidence, not a repeat run in the author’s macOS workspace. The backend was built from the unchanged merge base, and the clients ran from source through Vite. This covers real-daemon paging and restart-before-load, not reconnect during browsing, owner failover, or real rewind/branch operations.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested by maintainer at `b6998e7300` (linked report) |

### Environment (optional)

macOS arm64, Node.js 22.22.3, locally built workspace packages and CLI bundle. Browser verification used Chromium through Playwright against the built local frontend with deterministic HTTP/SSE fixtures, plus visual inspection of an actual persisted local session.

## Risk & Scope

- Main risk or tradeoff: historical selection uses a bounded isolated view; backward-only gap recovery can require multiple reads. Origin families share one cache budget and may retain overlapping records separately to preserve the existing contract. Narrow layouts and split panes keep their compact policy.
- Historical CI flake: the Ubuntu test job failed at `02e975e9fa` after test teardown with `requestAnimationFrame is not defined`; the [current-head Ubuntu job](https://github.com/QwenLM/qwen-code/actions/runs/34119154342/job/101733041990) passed at `b6998e7300`, whose changes are documentation only. The existing untracked 150 ms scroll timeout is also present at the merge base. Timer cleanup is deferred as a non-blocking follow-up; the green run does not prove the intermittent cause is fixed.
- Not validated / out of scope: real-daemon reconnect during browsing, owner failover, rewind/branch and stale-snapshot recovery; cursor-only sessions and split panes against a real daemon; every media/grouped-row combination, search, browser persistence and Windows local verification. The new Linux maintainer report covers real-daemon historical paging and restart-before-load. Ultra wide mode currently hides the global rail even at a wide container size; changing that inherited setting behavior is deferred, along with the unnecessary initial oldest-index-page fetch and unused historical-toolbar i18n keys.
- Breaking changes / migration notes: no intended public API break, daemon route, persistence migration or cross-package protocol change. Product changes remain within Web Shell; legacy public history hooks remain supported.

## Linked Issues

Related to #10750 and builds on merged #11054. This PR does not automatically close #10750.

<details>
<summary>中文说明</summary>

## What this PR does

为 Web Shell 增加有界历史浏览和覆盖整个会话的轮次导航。普通向上滚动保留原有加载行为。左侧使用短横杠；悬停或聚焦时显示索引中的提问和可用摘要，点击可定位任意历史轮次并按需加载远处内容。移除历史快照工具栏。这实现了 #10750 的 Phase 2B 和最终确认范围内的 Phase 3 全局导航；功能实现和限定范围的前端验证已完成，合并及更完整的真实 daemon 验收仍是独立里程碑。

加载相邻页面、恢复被淘汰的缺口时保留阅读行位置。历史内容与实时输出、审批和宿主回调隔离，原有返回最新操作恢复实时视图。共享缓存仍在原有上限内保护各视口的阅读页。不支持能力的 daemon 和仅 cursor 的会话保留原分页，分屏保留紧凑导航策略。

## Why it's needed

#11054 提供的导航基础本身没有在内置 UI 中开放全部历史轮次。显式快照操作打断了熟悉的滚动交互。紧凑的全历史导航提供直接访问能力，无须常驻文字侧栏，也不用把整个会话加载进内存。

## Reviewer Test Plan

### How to verify

1. 打开长会话并向上滚动。更早消息应通过原分页路径加载，不出现快照工具栏。
2. 悬停或用键盘聚焦左侧短横杠。立即显示可读标题和可用内容摘要，移开鼠标或按 Escape 后关闭。悬停不能请求 transcript 页面。确认聊天区域 738px 宽时显示导航，500px 时隐藏。
3. 浏览包含数千轮次的会话。导航仅渲染有限数量的横杠，按需获取索引页，支持 Home、End、方向键、Tab 和 Enter。点击远处轮次应直接加载目标，不加载所有中间历史。
4. 从远处轮次连续向前浏览至少六页，再向后浏览，并在加载之间移动阅读位置。覆盖小页和 200 条记录的页面。另一端页面被淘汰时，同一阅读行应保持偏移；实时边界变化后应补齐缺失记录，包括边界为助手或工具记录的情况。
5. 验证延迟定位、切换会话、返回最新、索引错误及边界重试。过期定位不能替换当前视图；重试保留可读内容和阅读位置。阅读历史期间接收实时输出，返回最新后应看到新增输出。历史片段不能展示实时修改控件。
6. 在历史请求延迟时重连、通过对话框回退并创建分支。同一连接对象重连应保留阅读行；连接对象更换和回退后应使用更新后的实时视图。分支应进入子会话，后续导航必须读取子会话历史。旧会话响应返回后不能替换当前视图。

### Evidence (Before & After)

之前：全局 CLI 支持普通向上分页，但 PR 原界面要求显式操作历史快照。最初的全历史导航为 160px 宽的带编号文字列表，占用聊天空间。

之后：本地预览使用 64px 导航栏，静态横杠为 10×3px、点击行高为 16px，复用原来的悬停伸长效果。悬停或聚焦显示标题及可选多行摘要，没有动画，也不会请求 transcript。在 738px 浏览器场景中，预览完全不透明、没有被裁切、单次移开鼠标即可关闭；500px 隐藏导航。

验证：129 项相关组件、store、页表单测通过。3 项仓库浏览器用例通过，覆盖原向上加载及有界 16/200 条记录历史滚动。独立的 13 项浏览器验证在样式收窄前通过；最终 3 项样式与导航场景在收窄后通过，覆盖悬停关闭、响应式布局、5,000 轮虚拟列表、已加载和远处轮次定位以及键盘入口。上述验证存在重叠，不能相加。实现期间全仓 build/typecheck 通过；样式调整后，最终相关包 build/typecheck、bundle、lint 和格式检查通过。自审及独立后续复核没有发现本次改动仍需处理的问题。

在 `02e975e9fa` 上补充了生命周期验证：首轮及定向分支复跑合计通过 8 个不同浏览器场景，浏览器页面错误为零，另有 105 项针对性单测通过。覆盖同一连接对象重连、事件缓存淘汰后的连接对象更换、回退、当前会话分支及已加载消息检查点分支、子会话导航和旧会话延迟响应。浏览器使用真实控件与 provider 路径，HTTP/SSE 使用确定性测试响应；真实 daemon 持久化及重启/故障切换仍未验证。单测结果与早先运行重叠，不能相加。冻结历史片段不提供检查点 Branch 按钮；历史阅读期间通过实际 `/branch` 命令验证，检查点分支则通过普通已加载 Assistant 行验证。

Maintainer Linux 验证：[wenshao 的报告](https://github.com/QwenLM/qwen-code/pull/11208#issuecomment-5572237907) 使用 `b6998e7300` 客户端连接真实 daemon，读取真实落盘的 1,200 轮会话，并在杀掉、重启 daemon 后冷加载。报告记录连续四轮 16/16 通过，覆盖有界横杠与历史窗口、索引摘要、远处定位、阅读行漂移 0 px 的双向分页、实时隔离、返回最新、响应式布局和键盘导航，同时包含移除能力及锚点变异的反向对照。Maintainer 还报告在 Linux x86_64 / Node 22.22.2 / Chromium 上三次完整 Web Shell 套件通过（每次 6,380 项），以及 typecheck、lint 和格式检查通过。这是 maintainer 提供的证据，并非作者在 macOS 工作区重新执行的结果。后端从未改动的 merge base 构建，客户端通过 Vite 运行源码。这覆盖真实 daemon 分页和加载前重启，不覆盖阅读期间重连、owner 故障切换或真实回退/分支操作。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ maintainer 在 `b6998e7300` 验证（见关联报告） |

### Environment (optional)

macOS arm64，Node.js 22.22.3，本地构建的工作区包和 CLI bundle。浏览器验证使用 Playwright Chromium、本地构建前端及确定性的 HTTP/SSE 测试响应，并目视检查真实持久化本地会话。

## Risk & Scope

- 主要风险或取舍：选择历史轮次使用有界隔离视图；只能向前读取的缺口恢复可能需要多次请求。各起点类型共用缓存预算，为保留原契约可能分别保留重叠记录。窄布局和分屏保持紧凑策略。
- 历史 CI 偶发失败：`02e975e9fa` 的 Ubuntu 测试在环境销毁后出现 `requestAnimationFrame is not defined`；仅包含文档变更的 `b6998e7300` 上，[当前提交的 Ubuntu 任务](https://github.com/QwenLM/qwen-code/actions/runs/34119154342/job/101733041990) 已通过。未追踪的 150 ms 滚动定时器在 merge base 中也已存在。定时器清理作为非阻塞后续项保留；本次通过不代表偶发成因已修复。
- 未验证或不包含：真实 daemon 下阅读期间重连、owner 故障切换、回退/分支及过期快照恢复；仅 cursor 会话和真实 daemon 分屏；全部媒体/分组行组合、搜索、浏览器持久化及 Windows 本地验证。新增 Linux maintainer 报告覆盖真实 daemon 历史分页和加载前重启。超宽模式目前即使容器足够宽也隐藏全局导航；调整这一继承的设置行为留待后续，初次打开多取最旧索引页及未使用的历史工具栏 i18n 键也作为后续项。
- 破坏性变更或迁移：没有预期的公开 API 破坏、新 daemon 路由、持久化迁移或跨包协议修改。产品改动限于 Web Shell，保留旧公开历史 hooks。

## Linked Issues

关联 #10750，基于已合入的 #11054。本 PR 不自动关闭 #10750。

</details>
