### PR TITLE
fix(ci): give web-shell E2E Smoke the ECS timeout allowance its siblings have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,7 +1286,15 @@ jobs:
         needs.test.outputs.ci_profile == 'full'
       }}
     runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
-    timeout-minutes: 20
+    # Routed like test's and lint's, so it needs their allowance too — it was
+    # the last job on the pool still priced flat, and one commit lost it twice:
+    # on hk3-9 `npm ci` alone ran 19m46s of the 20 and never finished, and on
+    # hk4-23 install took 10m33s against 4m53s on hk5-2, leaving the browser
+    # smoke 8m15s before the job died against 2m29s warm. Both phases 2-3x is
+    # the pool, not the diff: the same job passed on the previous commit, which
+    # touches no web-shell file. Hosted runners keep 20 for the reason lint's
+    # copy gives — a genuine hang there should not burn the ECS allowance.
+    timeout-minutes: '${{ fromJSON(contains(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'', ''ecs-qwen'') && ''40'' || ''20'') }}'
     permissions:
       contents: 'read'
     steps:

--- a/scripts/tests/ci-platform-lanes.test.js
+++ b/scripts/tests/ci-platform-lanes.test.js
@@ -102,6 +102,23 @@ it('keeps lint_and_static sized for cold-cache pool runs', () => {
   expect(timeoutMinutesOn('lint_and_static', '')).toBe(45);
 });
 
+it('keeps web_shell_e2e_smoke above its build-plus-browser budget on ECS', () => {
+  // Both numbers are measured, not predicted. This was the last lane on the
+  // pool still priced flat, and one commit lost it twice at 20: on hk3-9
+  // `npm ci` alone ran 19m46s of the budget and never finished, and on hk4-23
+  // install took 10m33s against 4m53s on hk5-2, leaving the browser smoke
+  // 8m15s before the job died against 2m29s warm. The smoke phase is a vite
+  // dev server plus a headless browser and touches no npm cache, so both
+  // phases running 2-3x is the pool rather than the dependencies. The healthy
+  // path is 8-10 minutes: a flat 20 only ever tolerated a 2x slowdown.
+  expect(timeoutMinutesOn('web_shell_e2e_smoke', ECS_RUNNER)).toBe(40);
+});
+
+it('keeps web_shell_e2e_smoke on its pre-contention ceiling when hosted', () => {
+  expect(timeoutMinutesOn('web_shell_e2e_smoke', HOSTED_RUNNER)).toBe(20);
+  expect(timeoutMinutesOn('web_shell_e2e_smoke', '')).toBe(20);
+});
+
 // One helper for both "an <event> run reaches exactly these jobs" invariants.
 //
 // It decides by EVALUATING each gate for the event, not by looking for tokens


### PR DESCRIPTION
## What this PR does

Four CI lanes route to the self-hosted runner pool through the same expression, so any of them can land on a contended host. Three of the four already widen their job timeout when that happens and keep the tighter ceiling on hosted runners, and one of those three carries a comment explaining the reasoning: pool contention, with hosted runners held to the tighter ceiling so a genuine hang there does not burn the self-hosted allowance.

The lane that runs a browser smoke test against the web shell was the fourth, and the only one still priced flat. This gives it the same treatment — the same 2× widening its siblings use — and extends the existing guard that evaluates each lane's real timeout expression under both routings so that it covers this lane too. That guard already existed for precisely this regression and pinned only the other three.

## Why it's needed

The lane was killed twice on a single commit that changes nothing it tests. On one host the dependency install alone ran 19m46s of the 20-minute budget and never finished; on another, install took 10m33s against 4m53s for the same job on a healthy host, which left the browser phase 8m15s before the job died against 2m29s when warm.

Both phases running 2–3× slower is the pool, not the dependencies. A cold package cache would explain a slow install but cannot explain the browser phase, which is a dev server plus a headless browser and touches no package cache at all. The healthy path costs 8–10 minutes of the 20, so a flat ceiling only ever tolerated a 2× slowdown — which is exactly what the contended hosts deliver, and the per-host medians already measured in #10879 say which attempts were going to die before they started.

The failure also hides itself. A job killed by its own timeout reports the same conclusion as one pre-empted externally, so triage rubrics that map that conclusion to "infrastructure flake, rerun" rerun it straight into the same wall. I did exactly that once before reading the per-step timings.

## Reviewer Test Plan

### How to verify

The guard is the interesting part, because it evaluates the real workflow expression under both routings rather than pinning a bare number — so a regression to an unconditional ceiling fails instead of reading as a passing constant.

```console
$ npx vitest run scripts/tests/ci-platform-lanes.test.js
 ✓ scripts/tests/ci-platform-lanes.test.js (39 tests) 16ms
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

That is 39 where main has 37; the two new cases assert the self-hosted routing resolves to 40 and that both hosted routings (an explicit hosted runner, and a missing output, which is the hosted fallback) still resolve to 20.

The four lanes now agree on shape — masking the two numeric literals leaves exactly one distinct expression across all four:

| Lane | Self-hosted | Hosted |
| --- | --- | --- |
| shared Linux test | 120 | 60 |
| lint & static | 90 | 45 |
| **browser smoke (this PR)** | **20 → 40** | **20 (unchanged)** |
| no-AK integration gate | 60 | 30 |

Three mutants were applied and all three are killed by exactly the intended test: reverting the lane to a flat 20, reducing the self-hosted allowance to 30 (under the measured worst case), and raising it to a flat 120 — the last also fails the hosted-ceiling case, which is the point of asserting both routings rather than one.

The wider workflow-property suite was run too: `scripts/tests/no-ak-integration-ci.test.js`, `workflow-size.test.js`, `capture-tmux-ci.test.js` and `ci-flaky-rerun-workflow.test.js` together, 241 passed. Prettier and ESLint clean on both changed files. `actionlint` is not installed locally, so instead of guessing I confirmed the new expression is byte-identical in form to two siblings that already pass it (127 characters each, one distinct shape across all four after masking the numbers).

### Evidence (Before & After)

N/A — CI configuration only, no user-visible or TUI surface. The measurements behind the change are in #11209, including the per-step timings for both failed attempts and the two healthy comparison runs.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

The lane itself only runs on Linux. macOS and Windows are unaffected: this changes one job's timeout expression and adds assertions about it.

### Environment (optional)

Local `vitest` run against the repository's own workflow files. No CLI runtime, daemon, or network involved — the guard parses and evaluates the workflow text.

## Risk & Scope

- Main risk or tradeoff: a genuinely hung browser smoke test on a self-hosted host now burns 40 minutes instead of 20 before being killed. Hosted runners are unchanged at 20, which is the same tradeoff the three sibling lanes already accepted and the same reason their comment gives for keeping the hosted ceiling tight.
- Not validated / out of scope: the pool contention itself, which is #10879 — that issue reduces the contention, this one stops one lane from being the only one with no allowance for whatever remains, and it would still fail on a loaded host after #10879 lands while its siblings would not. Also out of scope: this lane pays a full monorepo rebuild before running one browser test, because the default checkout clean wipes the reused workspace's build outputs and the install then rebuilds them. Preserving or caching those outputs would give back most of the budget on every run, but it carries stale-artifact risk and belongs in its own discussion.
- Breaking changes / migration notes: none. No runtime code is touched, and no lane's hosted ceiling changes.

## Linked Issues

Fixes #11209

Related: #10879 (why the pool is unevenly loaded — complementary, not a duplicate)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

有四条 CI 通道通过同一个表达式路由到 self-hosted runner 池，所以它们都可能落到争用的机器上。其中三条已经在落到该池时放宽自己的 job 超时、并在 hosted runner 上保持较紧的上限，而这三条里有一条还写了注释说明理由：池子有争用，hosted runner 保持较紧上限，这样在那边真的挂住时不会烧掉 self-hosted 的余量。

跑 web shell 浏览器 smoke 测试的那条通道是第四条，也是唯一一条仍然写死的。本 PR 给它同样的处理 —— 与它的兄弟通道相同的 2 倍放宽 —— 并且扩展了那个已有的守卫：该守卫会在两种路由下分别求值每条通道的真实超时表达式，此前只钉住了另外三条。那个守卫正是为这类回归而存在的。

## 为什么需要

这条通道在一个完全没有改动它所测内容的 commit 上被杀了两次。在一台机器上，光依赖安装就跑了 20 分钟预算里的 19m46s 且从未完成；在另一台上，安装花了 10m33s，而同一个 job 在健康机器上是 4m53s，于是浏览器阶段只跑到 8m15s 就随 job 一起死了，而热态下它是 2m29s。

两个阶段都慢 2–3 倍，是池子的问题，不是依赖的问题。冷的包缓存能解释安装慢，但解释不了浏览器阶段 —— 那是一个 dev server 加一个无头浏览器，完全不碰包缓存。健康路径要占掉 20 分钟里的 8–10 分钟，所以写死的上限从来只容得下 2 倍的劣化 —— 而这恰好就是争用机器给出的幅度；#10879 里已经测得的各机器中位数，在尝试开始之前就已经说明了哪几次会死。

这个失败还会自我隐藏。被自己的超时杀掉的 job，报的结论与被外部抢占的 job 相同，所以那些把该结论映射为「基础设施 flake，重跑」的分诊规则会把它直接重跑进同一堵墙。我在去读各步骤起止时间之前，自己就正好这么干过一次。

## 评审测试计划

### 如何验证

守卫是这里值得看的部分，因为它在两种路由下分别求值真实的 workflow 表达式，而不是钉住一个裸数字 —— 所以退化成无条件上限时会失败，而不是看起来像一个通过的常量。

```console
$ npx vitest run scripts/tests/ci-platform-lanes.test.js
 ✓ scripts/tests/ci-platform-lanes.test.js (39 tests) 16ms
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

main 上是 37 条，这里是 39 条；新增的两个用例分别断言 self-hosted 路由解析为 40，以及两种 hosted 路由（显式的 hosted runner，以及输出缺失的情况，后者就是 hosted 兜底）仍解析为 20。

四条通道现在形状一致 —— 把两个数字字面量遮掉后，四条里只剩一个不同的表达式：

| 通道 | Self-hosted | Hosted |
| --- | --- | --- |
| 共享 Linux test | 120 | 60 |
| lint & static | 90 | 45 |
| **浏览器 smoke（本 PR）** | **20 → 40** | **20（不变）** |
| no-AK integration gate | 60 | 30 |

施加了三个突变体，三个都被恰好对应的那个测试杀死：把该通道退回写死的 20、把 self-hosted 余量降到 30（低于实测最坏情况）、以及把它抬成写死的 120 —— 最后一个还会让 hosted 上限那个用例失败，这正是断言两种路由而不是只断言一种的意义。

也跑了更大范围的 workflow 属性测试：`scripts/tests/no-ak-integration-ci.test.js`、`workflow-size.test.js`、`capture-tmux-ci.test.js` 与 `ci-flaky-rerun-workflow.test.js` 合计 241 条通过。两个改动文件上 Prettier 与 ESLint 均干净。本地没有安装 `actionlint`，所以我没有靠猜，而是确认了新表达式在形式上与两个已经通过它的兄弟逐字节同形（各 127 字符，遮掉数字后四条只有一个形状）。

### 证据（改动前后）

N/A —— 仅 CI 配置，没有用户可见或 TUI 界面。本改动背后的实测数据在 #11209 里，包含两次失败尝试的逐步起止时间，以及两次健康的对照运行。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

该通道本身只在 Linux 上跑。macOS 与 Windows 不受影响：本改动只修改了一个 job 的超时表达式，并新增了关于它的断言。

### 环境（可选）

在本地用 `vitest` 针对仓库自身的 workflow 文件运行。不涉及 CLI 运行时、守护进程或网络 —— 守卫只是解析并求值 workflow 文本。

## 风险与范围

- 主要风险或取舍：在 self-hosted 机器上真的挂住的浏览器 smoke 测试，现在要烧 40 分钟而不是 20 分钟才会被杀。hosted runner 保持 20 不变，这与三条兄弟通道已经接受的取舍相同，理由也与它们注释里给出的相同。
- 未验证 / 范围外：池子的争用本身，那是 #10879 —— 那个 issue 降低争用，本 PR 则是让一条通道不再是唯一对剩余争用没有余量的通道；即使 #10879 落地，它在负载高的机器上仍会失败，而它的兄弟不会。同样在范围外：这条通道为了跑一个浏览器测试要先付出一次完整的 monorepo 重建，因为默认的 checkout clean 会清掉复用 workspace 里的构建产物，随后安装再把它们重建一遍。保留或缓存这些产物能在每次运行都还回大部分预算，但它有产物陈旧的风险，应该单独讨论。
- 破坏性变更 / 迁移说明：无。没有触碰任何运行时代码，也没有任何通道的 hosted 上限发生变化。

## 关联 Issue

Fixes #11209

相关：#10879（池子为什么负载不均 —— 互补，不是重复）

</details>
