### PR TITLE
fix(core): retry statusless SSE throttling errors

### DIFF
--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -17,6 +17,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import {
   formatVisionBridgeNoticeDisplay,
+  createNotStartedToolErrorResponse,
   LlmEventType,
   isVisionBridgeNoticeDisplay,
   ToolErrorType,
@@ -616,9 +617,31 @@ export abstract class BaseJsonOutputAdapter {
    */
   restartAttempt(
     preserveText: boolean,
-    _discardedToolCalls: ToolCallRequestInfo[],
+    discardedToolCalls: ToolCallRequestInfo[],
   ): void {
     if (preserveText) {
+      const discardedIds = new Set(
+        discardedToolCalls.map((request) => request.callId),
+      );
+      if (discardedIds.size > 0) {
+        const state = this.mainAgentMessageState;
+        const retainedBlocks: ContentBlock[] = [];
+        const retainedOpenBlocks = new Set<number>();
+        for (const [index, block] of state.blocks.entries()) {
+          if (block.type === 'tool_use' && discardedIds.has(block.id)) {
+            continue;
+          }
+          const retainedIndex = retainedBlocks.length;
+          retainedBlocks.push(block);
+          if (state.openBlocks.has(index)) {
+            retainedOpenBlocks.add(retainedIndex);
+          }
+        }
+        state.blocks = retainedBlocks;
+        state.openBlocks = retainedOpenBlocks;
+        state.currentBlockType = retainedBlocks.at(-1)?.type ?? null;
+        state.messageStarted = retainedBlocks.length > 0;
+      }
       return;
     }
     this.startAssistantMessageInternal(this.mainAgentMessageState);
@@ -630,23 +653,10 @@ export abstract class BaseJsonOutputAdapter {
     const message =
       'Skipped because the provider attempt was retried before execution.';
     for (const request of discardedToolCalls) {
-      const error = new Error(message);
-      this.emitToolResult(request, {
-        callId: request.callId,
-        responseParts: [
-          {
-            functionResponse: {
-              id: request.callId,
-              name: request.name,
-              response: { error: message },
-            },
-          },
-        ],
-        resultDisplay: message,
-        error,
-        errorType: ToolErrorType.EXECUTION_FAILED,
-        executionStatus: 'not_started',
-      });
+      this.emitToolResult(
+        request,
+        createNotStartedToolErrorResponse(request, message),
+      );
     }
   }
 

--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -118,6 +118,10 @@ export interface MessageEmitter {
  */
 export interface JsonOutputAdapterInterface extends MessageEmitter {
   startAssistantMessage(): void;
+  restartAttempt(
+    preserveText: boolean,
+    discardedToolCalls: ToolCallRequestInfo[],
+  ): void;
   processEvent(event: ServerLlmStreamEvent): void;
   finalizeAssistantMessage(): CLIAssistantMessage;
   emitResult(options: ResultOptions): void;
@@ -602,6 +606,48 @@ export abstract class BaseJsonOutputAdapter {
    */
   startAssistantMessage(): void {
     this.startAssistantMessageInternal(this.mainAgentMessageState);
+  }
+
+  /**
+   * Starts a replacement provider attempt. Continuation retries keep the
+   * already-delivered text; fresh retries and fallbacks discard the pending
+   * assistant state. Streaming adapters override this to pair any tool_use
+   * frames that are already on the wire before resetting.
+   */
+  restartAttempt(
+    preserveText: boolean,
+    _discardedToolCalls: ToolCallRequestInfo[],
+  ): void {
+    if (preserveText) {
+      return;
+    }
+    this.startAssistantMessageInternal(this.mainAgentMessageState);
+  }
+
+  protected emitDiscardedAttemptToolResults(
+    discardedToolCalls: ToolCallRequestInfo[],
+  ): void {
+    const message =
+      'Skipped because the provider attempt was retried before execution.';
+    for (const request of discardedToolCalls) {
+      const error = new Error(message);
+      this.emitToolResult(request, {
+        callId: request.callId,
+        responseParts: [
+          {
+            functionResponse: {
+              id: request.callId,
+              name: request.name,
+              response: { error: message },
+            },
+          },
+        ],
+        resultDisplay: message,
+        error,
+        errorType: ToolErrorType.EXECUTION_FAILED,
+        executionStatus: 'not_started',
+      });
+    }
   }
 
   /**

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '@qwen-code/qwen-code-core';
+import type { Config, ToolCallRequestInfo } from '@qwen-code/qwen-code-core';
 import type { CLIAssistantMessage, CLIMessage } from '../types.js';
 import {
   BaseJsonOutputAdapter,
@@ -23,6 +23,8 @@ export class JsonOutputAdapter
   implements JsonOutputAdapterInterface
 {
   private readonly messages: CLIMessage[] = [];
+  private attemptMessageCheckpoint = 0;
+  private lastAssistantMessageAtAttemptStart: CLIAssistantMessage | null = null;
 
   constructor(config: Config) {
     super(config);
@@ -50,6 +52,32 @@ export class JsonOutputAdapter
    */
   protected shouldEmitStreamEvents(): boolean {
     return false;
+  }
+
+  override startAssistantMessage(): void {
+    this.attemptMessageCheckpoint = this.messages.length;
+    this.lastAssistantMessageAtAttemptStart = this.lastAssistantMessage;
+    super.startAssistantMessage();
+  }
+
+  override restartAttempt(
+    preserveText: boolean,
+    discardedToolCalls: ToolCallRequestInfo[],
+  ): void {
+    if (!preserveText) {
+      // Keep system/control metadata (notably model_fallback), but retract
+      // assistant messages produced by the abandoned provider attempt.
+      const retained = this.messages
+        .slice(this.attemptMessageCheckpoint)
+        .filter((message) => message.type !== 'assistant');
+      this.messages.splice(
+        this.attemptMessageCheckpoint,
+        this.messages.length - this.attemptMessageCheckpoint,
+        ...retained,
+      );
+      this.lastAssistantMessage = this.lastAssistantMessageAtAttemptStart;
+    }
+    super.restartAttempt(preserveText, discardedToolCalls);
   }
 
   finalizeAssistantMessage(): CLIAssistantMessage {

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
@@ -64,7 +64,33 @@ export class JsonOutputAdapter
     preserveText: boolean,
     discardedToolCalls: ToolCallRequestInfo[],
   ): void {
-    if (!preserveText) {
+    if (preserveText) {
+      const discardedIds = new Set(
+        discardedToolCalls.map((request) => request.callId),
+      );
+      if (discardedIds.size > 0) {
+        const retained = this.messages
+          .slice(this.attemptMessageCheckpoint)
+          .filter(
+            (message) =>
+              message.type !== 'assistant' ||
+              !message.message.content.some(
+                (block) =>
+                  block.type === 'tool_use' && discardedIds.has(block.id),
+              ),
+          );
+        this.messages.splice(
+          this.attemptMessageCheckpoint,
+          this.messages.length - this.attemptMessageCheckpoint,
+          ...retained,
+        );
+        this.lastAssistantMessage =
+          this.messages.findLast(
+            (message): message is CLIAssistantMessage =>
+              message.type === 'assistant',
+          ) ?? this.lastAssistantMessageAtAttemptStart;
+      }
+    } else {
       // Keep system/control metadata (notably model_fallback), but retract
       // assistant messages produced by the abandoned provider attempt.
       const retained = this.messages

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
@@ -95,6 +95,26 @@ export class StreamJsonOutputAdapter
     super.startAssistantMessage();
   }
 
+  override restartAttempt(
+    preserveText: boolean,
+    discardedToolCalls: ToolCallRequestInfo[],
+  ): void {
+    if (preserveText) {
+      return;
+    }
+    // Stream frames cannot be retracted. Close the abandoned assistant first,
+    // then pair every flushed tool_use with a synthetic not-started result so
+    // transcript replay remains valid before the replacement attempt begins.
+    if (
+      this.mainAgentMessageState.messageStarted &&
+      !this.mainAgentMessageState.finalized
+    ) {
+      this.finalizeAssistantMessage();
+    }
+    this.emitDiscardedAttemptToolResults(discardedToolCalls);
+    super.restartAttempt(false, discardedToolCalls);
+  }
+
   finalizeAssistantMessage(): CLIAssistantMessage {
     const message = this.finalizeAssistantMessageInternal(
       this.mainAgentMessageState,

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.ts
@@ -99,7 +99,7 @@ export class StreamJsonOutputAdapter
     preserveText: boolean,
     discardedToolCalls: ToolCallRequestInfo[],
   ): void {
-    if (preserveText) {
+    if (preserveText && discardedToolCalls.length === 0) {
       return;
     }
     // Stream frames cannot be retracted. Close the abandoned assistant first,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -643,6 +643,7 @@ describe('runNonInteractive', () => {
                 maxRetries: 10,
                 delayMs: 60_000,
                 skipDelay: vi.fn(),
+                ...(drain ? { message: 'Too many requests' } : {}),
               },
             },
             {
@@ -684,7 +685,7 @@ describe('runNonInteractive', () => {
         drain ? 3 : 2,
       );
       expect(processStderrSpy).toHaveBeenCalledWith(
-        'Retrying in 60s (attempt 1/10)\n',
+        `Retrying in 60s (attempt 1/10)${drain ? ': Too many requests' : ''}\n`,
       );
 
       const stdout = processStdoutSpy.mock.calls
@@ -716,6 +717,31 @@ describe('runNonInteractive', () => {
       } else {
         expect(discardedUses).toHaveLength(1);
         expect(discardedResults).toHaveLength(1);
+        const discardedUseFrame = messages.findIndex(
+          (message: {
+            type?: string;
+            message?: { content?: Array<{ type?: string; id?: string }> };
+          }) =>
+            message.type === 'assistant' &&
+            message.message?.content?.some(
+              (block) =>
+                block.type === 'tool_use' && block.id === 'discarded-tool',
+            ),
+        );
+        const discardedResultFrame = messages.findIndex(
+          (message: {
+            message?: {
+              content?: Array<{ type?: string; tool_use_id?: string }>;
+            };
+          }) =>
+            message.message?.content?.some(
+              (block) =>
+                block.type === 'tool_result' &&
+                block.tool_use_id === 'discarded-tool',
+            ),
+        );
+        expect(discardedUseFrame).toBeGreaterThanOrEqual(0);
+        expect(discardedResultFrame).toBeGreaterThan(discardedUseFrame);
       }
       expect(stdout).toContain('accepted attempt');
       expect(blocks).toEqual(
@@ -730,10 +756,18 @@ describe('runNonInteractive', () => {
     },
   );
 
-  it.each([false, true])(
-    'preserves delivered text across a continuation Retry (drain=%s)',
-    async (drain) => {
-      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+  it.each([
+    [OutputFormat.JSON, false],
+    [OutputFormat.JSON, true],
+    [OutputFormat.STREAM_JSON, false],
+    [OutputFormat.STREAM_JSON, true],
+  ] as const)(
+    'preserves delivered text across a continuation Retry in %s (drain=%s)',
+    async (format, drain) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(format);
+      if (format === OutputFormat.STREAM_JSON) {
+        vi.mocked(mockConfig.getIncludePartialMessages).mockReturnValue(true);
+      }
       setupMetricsMock();
       const finished: ServerLlmStreamEvent = {
         type: LlmEventType.Finished,
@@ -770,10 +804,120 @@ describe('runNonInteractive', () => {
       ).resolves.toBe(0);
 
       expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
-      const messages = JSON.parse(
-        processStdoutSpy.mock.calls.map((call) => String(call[0])).join(''),
-      );
+      const stdout = processStdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join('');
+      const messages =
+        format === OutputFormat.JSON
+          ? JSON.parse(stdout)
+          : stdout
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line));
       expect(JSON.stringify(messages)).toContain('prefix suffix');
+      if (format === OutputFormat.STREAM_JSON) {
+        const assistantMessages = messages.filter(
+          (message: { type?: string; message?: { content?: unknown[] } }) =>
+            message.type === 'assistant' &&
+            message.message?.content?.some(
+              (block: { type?: string }) => block.type === 'text',
+            ),
+        );
+        expect(assistantMessages).toHaveLength(1);
+        expect(
+          messages.find(
+            (message: { type?: string }) => message.type === 'result',
+          )?.result,
+        ).toContain('prefix suffix');
+      }
+    },
+  );
+
+  it.each([OutputFormat.JSON, OutputFormat.STREAM_JSON])(
+    'preserves continuation text while discarding a pending recovery tool in %s',
+    async (format) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(format);
+      setupMetricsMock();
+      mockLlmClient.sendMessageStream.mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: LlmEventType.Content, value: 'prefix-answer ' },
+          {
+            type: LlmEventType.ToolCallRequest,
+            value: {
+              callId: 'recovery-tool',
+              name: 'test-tool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'continuation-tool',
+            },
+          },
+          { type: LlmEventType.Retry, isContinuation: true },
+          { type: LlmEventType.Content, value: 'suffix' },
+          {
+            type: LlmEventType.Finished,
+            value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+          },
+        ]),
+      );
+
+      await expect(
+        runNonInteractive(
+          mockConfig,
+          mockSettings,
+          'test',
+          'continuation-tool',
+        ),
+      ).resolves.toBe(0);
+
+      expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+      const stdout = processStdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join('');
+      const messages =
+        format === OutputFormat.JSON
+          ? JSON.parse(stdout)
+          : stdout
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line));
+      const assistantText = messages
+        .filter((message: { type?: string }) => message.type === 'assistant')
+        .flatMap(
+          (message: { message?: { content?: Array<{ text?: string }> } }) =>
+            message.message?.content ?? [],
+        )
+        .map((block: { text?: string }) => block.text ?? '')
+        .join('');
+      expect(assistantText).toContain('prefix-answer suffix');
+      if (format === OutputFormat.JSON) {
+        expect(JSON.stringify(messages)).not.toContain('recovery-tool');
+      } else {
+        const useFrame = messages.findIndex(
+          (message: {
+            type?: string;
+            message?: { content?: Array<{ type?: string; id?: string }> };
+          }) =>
+            message.type === 'assistant' &&
+            message.message?.content?.some(
+              (block) =>
+                block.type === 'tool_use' && block.id === 'recovery-tool',
+            ),
+        );
+        const resultFrame = messages.findIndex(
+          (message: {
+            message?: {
+              content?: Array<{ type?: string; tool_use_id?: string }>;
+            };
+          }) =>
+            message.message?.content?.some(
+              (block) =>
+                block.type === 'tool_result' &&
+                block.tool_use_id === 'recovery-tool',
+            ),
+        );
+        expect(useFrame).toBeGreaterThanOrEqual(0);
+        expect(resultFrame).toBeGreaterThan(useFrame);
+      }
     },
   );
 
@@ -847,7 +991,131 @@ describe('runNonInteractive', () => {
         }),
       ]),
     );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      'Falling back from primary to fallback (1 buffered tool call(s) discarded).\n',
+    );
   });
+
+  it('retains every model fallback marker across repeated JSON attempt resets', async () => {
+    vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+    setupMetricsMock();
+    mockLlmClient.sendMessageStream.mockReturnValueOnce(
+      createStreamFromEvents([
+        { type: LlmEventType.Content, value: 'abandoned primary' },
+        {
+          type: LlmEventType.ModelFallback,
+          fromModel: 'primary',
+          toModel: 'fallback-a',
+          fallbackIndex: 0,
+        },
+        { type: LlmEventType.Content, value: 'abandoned fallback-a' },
+        {
+          type: LlmEventType.ModelFallback,
+          fromModel: 'fallback-a',
+          toModel: 'fallback-b',
+          fallbackIndex: 1,
+        },
+        { type: LlmEventType.Content, value: 'final answer' },
+        {
+          type: LlmEventType.Finished,
+          value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+        },
+      ]),
+    );
+
+    await expect(
+      runNonInteractive(mockConfig, mockSettings, 'test', 'two-fallbacks'),
+    ).resolves.toBe(0);
+
+    const messages = JSON.parse(
+      processStdoutSpy.mock.calls.map((call) => String(call[0])).join(''),
+    );
+    const fallbacks = messages.filter(
+      (message: { type?: string; subtype?: string }) =>
+        message.type === 'system' && message.subtype === 'model_fallback',
+    );
+    expect(fallbacks).toHaveLength(2);
+    expect(
+      messages.filter(
+        (message: { type?: string; subtype?: string }) =>
+          message.type === 'system' && message.subtype === 'retry',
+      ),
+    ).toHaveLength(2);
+    expect(fallbacks).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromModel: 'primary',
+          toModel: 'fallback-a',
+        }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromModel: 'fallback-a',
+          toModel: 'fallback-b',
+        }),
+      }),
+    ]);
+    const output = JSON.stringify(messages);
+    expect(output).not.toContain('abandoned primary');
+    expect(output).not.toContain('abandoned fallback-a');
+    expect(output).toContain('final answer');
+  });
+
+  it.each([OutputFormat.JSON, OutputFormat.STREAM_JSON])(
+    'emits a structured marker for a bare Retry in %s',
+    async (format) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(format);
+      setupMetricsMock();
+      mockLlmClient.sendMessageStream.mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: LlmEventType.Content, value: 'abandoned answer' },
+          { type: LlmEventType.Retry },
+          { type: LlmEventType.Content, value: 'final answer' },
+          {
+            type: LlmEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          },
+        ]),
+      );
+
+      await expect(
+        runNonInteractive(mockConfig, mockSettings, 'test', 'bare-retry'),
+      ).resolves.toBe(0);
+
+      const stdout = processStdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join('');
+      const messages =
+        format === OutputFormat.JSON
+          ? JSON.parse(stdout)
+          : stdout
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line));
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'system',
+            subtype: 'retry',
+            data: expect.objectContaining({
+              discardedToolCalls: 0,
+              preserveText: false,
+            }),
+          }),
+        ]),
+      );
+      const stderr = processStderrSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join('');
+      expect(stderr).toContain(
+        'Retrying provider attempt (0 buffered tool call(s) discarded).',
+      );
+      expect(stderr).not.toContain('undefined');
+    },
+  );
 
   function mockFinishedGoalWorker(): void {
     vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
@@ -8078,6 +8346,44 @@ describe('runNonInteractive', () => {
         errorMessage: 'model did not produce structured output',
         errorType: 'structured_output_missing',
       });
+    });
+
+    it('reports only the accepted attempt in the structured-output preview', async () => {
+      (mockConfig.getJsonSchema as Mock).mockReturnValue({ type: 'object' });
+      (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.JSON);
+      setupMetricsMock();
+      mockLlmClient.sendMessageStream.mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: LlmEventType.Content, value: 'abandoned prose' },
+          { type: LlmEventType.Retry },
+          { type: LlmEventType.Content, value: 'accepted prose' },
+          {
+            type: LlmEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          },
+        ]),
+      );
+
+      await expect(
+        runNonInteractive(
+          mockConfig,
+          mockSettings,
+          'Should call structured_output',
+          'prompt-id-preview-retry',
+        ),
+      ).resolves.toBe(1);
+
+      const messages = JSON.parse(
+        processStdoutSpy.mock.calls.map((call) => String(call[0])).join(''),
+      );
+      const result = messages.find(
+        (message: { type?: string }) => message.type === 'result',
+      );
+      expect(result.error.message).toContain('accepted prose');
+      expect(result.error.message).not.toContain('abandoned prose');
     });
 
     it('synthesises tool_result for suppressed sibling calls when structured_output fails validation', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -590,6 +590,68 @@ describe('runNonInteractive', () => {
     }
   }
 
+  it.each([false, true])(
+    'discards failed-attempt tool requests on Retry (drain=%s)',
+    async (drain) => {
+      setupMetricsMock();
+      const finished: ServerLlmStreamEvent = {
+        type: LlmEventType.Finished,
+        value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+      };
+      if (drain) {
+        mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+          if (cb)
+            cb(
+              'Monitor ready',
+              '<task-notification>ready</task-notification>',
+              {
+                monitorId: 'mon_retry',
+                toolUseId: 'tool_monitor',
+                status: 'running',
+                eventCount: 1,
+              },
+            );
+        });
+        mockLlmClient.sendMessageStream.mockReturnValueOnce(
+          createStreamFromEvents([finished]),
+        );
+      }
+      mockLlmClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents([
+            {
+              type: LlmEventType.ToolCallRequest,
+              value: {
+                callId: 'discarded-tool',
+                name: 'test-tool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: 'retry-tools',
+              },
+            },
+            { type: LlmEventType.Retry },
+            { type: LlmEventType.Content, value: 'Recovered without tools' },
+            finished,
+          ]),
+        )
+        .mockImplementation(() => createStreamFromEvents([finished]));
+      mockCoreExecuteToolCall.mockResolvedValue({
+        responseParts: [{ text: 'unexpected tool execution' }],
+      });
+      const exitCode = await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'test',
+        'retry-tools',
+      );
+      expect(exitCode).toBe(0);
+      expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+      expect(mockLlmClient.sendMessageStream).toHaveBeenCalledTimes(
+        drain ? 2 : 1,
+      );
+    },
+  );
+
   function mockFinishedGoalWorker(): void {
     vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
     mockLlmClient.sendMessageStream.mockImplementation(() =>

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -590,9 +590,15 @@ describe('runNonInteractive', () => {
     }
   }
 
-  it.each([false, true])(
-    'discards failed-attempt tool requests on Retry (drain=%s)',
-    async (drain) => {
+  it.each([
+    [OutputFormat.JSON, false],
+    [OutputFormat.JSON, true],
+    [OutputFormat.STREAM_JSON, false],
+    [OutputFormat.STREAM_JSON, true],
+  ] as const)(
+    'repairs discarded Retry tools and executes only the accepted attempt in %s (drain=%s)',
+    async (format, drain) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(format);
       setupMetricsMock();
       const finished: ServerLlmStreamEvent = {
         type: LlmEventType.Finished,
@@ -619,6 +625,7 @@ describe('runNonInteractive', () => {
       mockLlmClient.sendMessageStream
         .mockReturnValueOnce(
           createStreamFromEvents([
+            { type: LlmEventType.Content, value: 'abandoned attempt' },
             {
               type: LlmEventType.ToolCallRequest,
               value: {
@@ -629,14 +636,37 @@ describe('runNonInteractive', () => {
                 prompt_id: 'retry-tools',
               },
             },
-            { type: LlmEventType.Retry },
-            { type: LlmEventType.Content, value: 'Recovered without tools' },
+            {
+              type: LlmEventType.Retry,
+              retryInfo: {
+                attempt: 1,
+                maxRetries: 10,
+                delayMs: 60_000,
+                skipDelay: vi.fn(),
+              },
+            },
+            {
+              type: LlmEventType.ToolCallRequest,
+              value: {
+                callId: 'kept-tool',
+                name: 'test-tool',
+                args: { accepted: true },
+                isClientInitiated: false,
+                prompt_id: 'retry-tools',
+              },
+            },
+            { type: LlmEventType.Content, value: 'accepted attempt' },
             finished,
           ]),
         )
         .mockImplementation(() => createStreamFromEvents([finished]));
       mockCoreExecuteToolCall.mockResolvedValue({
-        responseParts: [{ text: 'unexpected tool execution' }],
+        callId: 'kept-tool',
+        responseParts: [{ text: 'accepted tool execution' }],
+        resultDisplay: 'accepted',
+        error: undefined,
+        errorType: undefined,
+        executionStatus: 'success',
       });
       const exitCode = await runNonInteractive(
         mockConfig,
@@ -645,12 +675,179 @@ describe('runNonInteractive', () => {
         'retry-tools',
       );
       expect(exitCode).toBe(0);
-      expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledOnce();
+      expect(mockCoreExecuteToolCall.mock.calls[0][1]).toMatchObject({
+        callId: 'kept-tool',
+        args: { accepted: true },
+      });
       expect(mockLlmClient.sendMessageStream).toHaveBeenCalledTimes(
-        drain ? 2 : 1,
+        drain ? 3 : 2,
+      );
+      expect(processStderrSpy).toHaveBeenCalledWith(
+        'Retrying in 60s (attempt 1/10)\n',
+      );
+
+      const stdout = processStdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join('');
+      const messages =
+        format === OutputFormat.JSON
+          ? JSON.parse(stdout)
+          : stdout
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line));
+      const blocks = messages.flatMap(
+        (message: { message?: { content?: unknown[] } }) =>
+          message.message?.content ?? [],
+      ) as Array<{ type?: string; id?: string; tool_use_id?: string }>;
+      const discardedUses = blocks.filter(
+        (block) => block.type === 'tool_use' && block.id === 'discarded-tool',
+      );
+      const discardedResults = blocks.filter(
+        (block) =>
+          block.type === 'tool_result' &&
+          block.tool_use_id === 'discarded-tool',
+      );
+      if (format === OutputFormat.JSON) {
+        expect(discardedUses).toEqual([]);
+        expect(discardedResults).toEqual([]);
+        expect(stdout).not.toContain('abandoned attempt');
+      } else {
+        expect(discardedUses).toHaveLength(1);
+        expect(discardedResults).toHaveLength(1);
+      }
+      expect(stdout).toContain('accepted attempt');
+      expect(blocks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'tool_use', id: 'kept-tool' }),
+          expect.objectContaining({
+            type: 'tool_result',
+            tool_use_id: 'kept-tool',
+          }),
+        ]),
       );
     },
   );
+
+  it.each([false, true])(
+    'preserves delivered text across a continuation Retry (drain=%s)',
+    async (drain) => {
+      vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+      setupMetricsMock();
+      const finished: ServerLlmStreamEvent = {
+        type: LlmEventType.Finished,
+        value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+      };
+      if (drain) {
+        mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+          cb?.(
+            'Monitor ready',
+            '<task-notification>ready</task-notification>',
+            {
+              monitorId: 'mon_continuation',
+              toolUseId: 'tool_monitor',
+              status: 'running',
+              eventCount: 1,
+            },
+          );
+        });
+        mockLlmClient.sendMessageStream.mockReturnValueOnce(
+          createStreamFromEvents([finished]),
+        );
+      }
+      mockLlmClient.sendMessageStream.mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: LlmEventType.Content, value: 'prefix ' },
+          { type: LlmEventType.Retry, isContinuation: true },
+          { type: LlmEventType.Content, value: 'suffix' },
+          finished,
+        ]),
+      );
+
+      await expect(
+        runNonInteractive(mockConfig, mockSettings, 'test', 'continuation'),
+      ).resolves.toBe(0);
+
+      expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
+      const messages = JSON.parse(
+        processStdoutSpy.mock.calls.map((call) => String(call[0])).join(''),
+      );
+      expect(JSON.stringify(messages)).toContain('prefix suffix');
+    },
+  );
+
+  it('repairs a discarded tool when a drain attempt falls back models', async () => {
+    vi.mocked(mockConfig.getOutputFormat).mockReturnValue(OutputFormat.JSON);
+    setupMetricsMock();
+    const finished: ServerLlmStreamEvent = {
+      type: LlmEventType.Finished,
+      value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+    };
+    mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+      cb?.('Monitor ready', '<task-notification>ready</task-notification>', {
+        monitorId: 'mon_fallback',
+        toolUseId: 'tool_monitor',
+        status: 'running',
+        eventCount: 1,
+      });
+    });
+    const request = (callId: string): ServerLlmStreamEvent => ({
+      type: LlmEventType.ToolCallRequest,
+      value: {
+        callId,
+        name: 'test-tool',
+        args: {},
+        isClientInitiated: false,
+        prompt_id: 'fallback-tools',
+      },
+    });
+    mockLlmClient.sendMessageStream
+      .mockReturnValueOnce(createStreamFromEvents([finished]))
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          request('discarded-tool'),
+          {
+            type: LlmEventType.ModelFallback,
+            fromModel: 'primary',
+            toModel: 'fallback',
+            fallbackIndex: 0,
+          },
+          request('kept-tool'),
+          finished,
+        ]),
+      )
+      .mockReturnValueOnce(createStreamFromEvents([finished]));
+    mockCoreExecuteToolCall.mockResolvedValue({
+      callId: 'kept-tool',
+      responseParts: [{ text: 'accepted' }],
+      resultDisplay: 'accepted',
+      error: undefined,
+      errorType: undefined,
+      executionStatus: 'success',
+    });
+
+    await expect(
+      runNonInteractive(mockConfig, mockSettings, 'test', 'fallback-tools'),
+    ).resolves.toBe(0);
+
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledOnce();
+    expect(mockCoreExecuteToolCall.mock.calls[0][1]).toMatchObject({
+      callId: 'kept-tool',
+    });
+    const messages = JSON.parse(
+      processStdoutSpy.mock.calls.map((call) => String(call[0])).join(''),
+    );
+    expect(JSON.stringify(messages)).not.toContain('discarded-tool');
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'system',
+          subtype: 'model_fallback',
+        }),
+      ]),
+    );
+  });
 
   function mockFinishedGoalWorker(): void {
     vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -18,6 +18,7 @@ import type {
   ToolCallRequestInfo,
   ToolCallResponseInfo,
   RuntimeContentGeneratorView,
+  ServerLlmStreamEvent,
 } from '@qwen-code/qwen-code-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import { isInlineModelOverrideAllowed } from './utils/acpModelUtils.js';

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -1705,6 +1705,19 @@ export async function runNonInteractive(
         return 1;
       };
 
+      const emitRetryProgress = (event: ServerLlmStreamEvent): void => {
+        if (event.type !== LlmEventType.Retry || !event.retryInfo) {
+          return;
+        }
+        const { attempt, maxRetries, delayMs, message } = event.retryInfo;
+        const delaySeconds = Math.ceil(delayMs / 1000);
+        process.stderr.write(
+          `Retrying in ${delaySeconds}s (attempt ${attempt}/${maxRetries})${
+            message ? `: ${message}` : ''
+          }\n`,
+        );
+      };
+
       /**
        * Shared per-turn tool-call dispatch for the main-turn loop and
        * `drainBatch`. Both call sites used to reproduce ~120 lines of
@@ -2378,6 +2391,7 @@ export async function runNonInteractive(
         );
 
         const toolCallRequests: ToolCallRequestInfo[] = [];
+        const attemptPreviewLength = plainTextPreview.length;
         const apiStartTime = Date.now();
         const responseStream = llmClient.sendMessageStream(
           currentMessages[0]?.parts || [],
@@ -2441,16 +2455,29 @@ export async function runNonInteractive(
             adapter.finalizeAssistantMessage();
             await routeAbort();
           }
-          // Use adapter for all event processing
-          adapter.processEvent(event);
-          if (event.type === LlmEventType.ToolCallRequest) {
-            toolCallRequests.push(event.value);
-          }
           if (
             event.type === LlmEventType.Retry ||
             event.type === LlmEventType.ModelFallback
           ) {
-            toolCallRequests.length = 0;
+            const discardedToolCalls = toolCallRequests.splice(0);
+            const preserveText =
+              event.type === LlmEventType.Retry &&
+              event.isContinuation === true &&
+              discardedToolCalls.length === 0;
+            adapter.restartAttempt(preserveText, discardedToolCalls);
+            if (!preserveText) {
+              plainTextPreview = plainTextPreview.slice(
+                0,
+                attemptPreviewLength,
+              );
+            }
+            emitRetryProgress(event);
+          }
+          // Process fallback metadata only after the abandoned attempt has
+          // been reset, so batch adapters do not roll the system event back.
+          adapter.processEvent(event);
+          if (event.type === LlmEventType.ToolCallRequest) {
+            toolCallRequests.push(event.value);
           }
           if (
             event.type === LlmEventType.Content &&
@@ -2772,15 +2799,21 @@ export async function runNonInteractive(
                   finalizeOneShotMonitors();
                   await routeAbort();
                 }
-                adapter.processEvent(event);
-                if (event.type === LlmEventType.ToolCallRequest) {
-                  itemToolCallRequests.push(event.value);
-                }
                 if (
                   event.type === LlmEventType.Retry ||
                   event.type === LlmEventType.ModelFallback
                 ) {
-                  itemToolCallRequests.length = 0;
+                  const discardedToolCalls = itemToolCallRequests.splice(0);
+                  const preserveText =
+                    event.type === LlmEventType.Retry &&
+                    event.isContinuation === true &&
+                    discardedToolCalls.length === 0;
+                  adapter.restartAttempt(preserveText, discardedToolCalls);
+                  emitRetryProgress(event);
+                }
+                adapter.processEvent(event);
+                if (event.type === LlmEventType.ToolCallRequest) {
+                  itemToolCallRequests.push(event.value);
                 }
                 if (event.type === LlmEventType.LoopDetected) {
                   if (!loopDetected) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -2446,7 +2446,10 @@ export async function runNonInteractive(
           if (event.type === LlmEventType.ToolCallRequest) {
             toolCallRequests.push(event.value);
           }
-          if (event.type === LlmEventType.ModelFallback) {
+          if (
+            event.type === LlmEventType.Retry ||
+            event.type === LlmEventType.ModelFallback
+          ) {
             toolCallRequests.length = 0;
           }
           if (
@@ -2772,6 +2775,12 @@ export async function runNonInteractive(
                 adapter.processEvent(event);
                 if (event.type === LlmEventType.ToolCallRequest) {
                   itemToolCallRequests.push(event.value);
+                }
+                if (
+                  event.type === LlmEventType.Retry ||
+                  event.type === LlmEventType.ModelFallback
+                ) {
+                  itemToolCallRequests.length = 0;
                 }
                 if (event.type === LlmEventType.LoopDetected) {
                   if (!loopDetected) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -1706,8 +1706,24 @@ export async function runNonInteractive(
         return 1;
       };
 
-      const emitRetryProgress = (event: ServerLlmStreamEvent): void => {
-        if (event.type !== LlmEventType.Retry || !event.retryInfo) {
+      const emitRetryProgress = (
+        event: ServerLlmStreamEvent,
+        discardedToolCallCount: number,
+        preserveText: boolean,
+      ): void => {
+        if (event.type === LlmEventType.ModelFallback) {
+          process.stderr.write(
+            `Falling back from ${event.fromModel} to ${event.toModel} (${discardedToolCallCount} buffered tool call(s) discarded).\n`,
+          );
+          return;
+        }
+        if (event.type !== LlmEventType.Retry) return;
+        if (!event.retryInfo) {
+          process.stderr.write(
+            `Retrying provider attempt (${discardedToolCallCount} buffered tool call(s) discarded${
+              preserveText ? '; preserving delivered text' : ''
+            }).\n`,
+          );
           return;
         }
         const { attempt, maxRetries, delayMs, message } = event.retryInfo;
@@ -1717,6 +1733,42 @@ export async function runNonInteractive(
             message ? `: ${message}` : ''
           }\n`,
         );
+      };
+
+      const discardAbandonedAttempt = (
+        event: ServerLlmStreamEvent,
+        pendingRequests: ToolCallRequestInfo[],
+        onDiscardText?: () => void,
+      ): void => {
+        if (
+          event.type !== LlmEventType.Retry &&
+          event.type !== LlmEventType.ModelFallback
+        ) {
+          return;
+        }
+        const discardedToolCalls = pendingRequests.splice(0);
+        const preserveText =
+          event.type === LlmEventType.Retry && event.isContinuation === true;
+        adapter.restartAttempt(preserveText, discardedToolCalls);
+        if (!preserveText) {
+          onDiscardText?.();
+        }
+        const retryInfo =
+          event.type === LlmEventType.Retry ? event.retryInfo : undefined;
+        adapter.emitSystemMessage('retry', {
+          reason:
+            event.type === LlmEventType.Retry ? 'retry' : 'model_fallback',
+          ...(retryInfo
+            ? {
+                attempt: retryInfo.attempt,
+                maxRetries: retryInfo.maxRetries,
+                delayMs: retryInfo.delayMs,
+              }
+            : {}),
+          discardedToolCalls: discardedToolCalls.length,
+          preserveText,
+        });
+        emitRetryProgress(event, discardedToolCalls.length, preserveText);
       };
 
       /**
@@ -2456,24 +2508,9 @@ export async function runNonInteractive(
             adapter.finalizeAssistantMessage();
             await routeAbort();
           }
-          if (
-            event.type === LlmEventType.Retry ||
-            event.type === LlmEventType.ModelFallback
-          ) {
-            const discardedToolCalls = toolCallRequests.splice(0);
-            const preserveText =
-              event.type === LlmEventType.Retry &&
-              event.isContinuation === true &&
-              discardedToolCalls.length === 0;
-            adapter.restartAttempt(preserveText, discardedToolCalls);
-            if (!preserveText) {
-              plainTextPreview = plainTextPreview.slice(
-                0,
-                attemptPreviewLength,
-              );
-            }
-            emitRetryProgress(event);
-          }
+          discardAbandonedAttempt(event, toolCallRequests, () => {
+            plainTextPreview = plainTextPreview.slice(0, attemptPreviewLength);
+          });
           // Process fallback metadata only after the abandoned attempt has
           // been reset, so batch adapters do not roll the system event back.
           adapter.processEvent(event);
@@ -2800,18 +2837,7 @@ export async function runNonInteractive(
                   finalizeOneShotMonitors();
                   await routeAbort();
                 }
-                if (
-                  event.type === LlmEventType.Retry ||
-                  event.type === LlmEventType.ModelFallback
-                ) {
-                  const discardedToolCalls = itemToolCallRequests.splice(0);
-                  const preserveText =
-                    event.type === LlmEventType.Retry &&
-                    event.isContinuation === true &&
-                    discardedToolCalls.length === 0;
-                  adapter.restartAttempt(preserveText, discardedToolCalls);
-                  emitRetryProgress(event);
-                }
+                discardAbandonedAttempt(event, itemToolCallRequests);
                 adapter.processEvent(event);
                 if (event.type === LlmEventType.ToolCallRequest) {
                   itemToolCallRequests.push(event.value);

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GenerateContentParameters } from '@google/genai';
 import { FinishReason, GenerateContentResponse } from '@google/genai';
 import type { ContentGeneratorConfig } from '../contentGenerator.js';
+import { isRateLimitError } from '../../utils/rateLimit.js';
 import {
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   DEFAULT_STREAM_MAX_LIFETIME_MS,
@@ -3337,12 +3338,13 @@ describe('AnthropicContentGenerator', () => {
   });
 
   describe('generateContentStream', () => {
-    const collectGeneratedStream = async () => {
+    const collectGeneratedStream = async (baseUrl?: string) => {
       const { AnthropicContentGenerator } = await importGenerator();
       const generator = new AnthropicContentGenerator(
         {
           model: 'claude-test',
           apiKey: 'test-key',
+          baseUrl,
           timeout: 10_000,
           maxRetries: 2,
           samplingParams: { max_tokens: 100 },
@@ -3363,6 +3365,95 @@ describe('AnthropicContentGenerator', () => {
       }
       return { chunks, error };
     };
+
+    it.each([
+      [
+        'api_error',
+        'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+        429,
+      ],
+      ['api_error', 'Streaming error: 404: Model not found.', undefined],
+      ['api_error', 'Streaming error: 404: Account quota exceeded.', undefined],
+      [
+        'authentication_error',
+        'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+        undefined,
+      ],
+      [
+        'api_error',
+        'Invalid prompt containing Rate limit exceeded on Anthropic API.',
+        undefined,
+      ],
+    ])(
+      'normalizes actual SDK SSE %s / %s to status %s',
+      async (type, message, status) => {
+        const { default: ActualAnthropic } =
+          await vi.importActual<typeof import('@anthropic-ai/sdk')>(
+            '@anthropic-ai/sdk',
+          );
+        const client = new ActualAnthropic({
+          apiKey: 'test-key',
+          maxRetries: 0,
+          fetch: vi
+            .fn()
+            .mockResolvedValue(
+              new Response(
+                `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type, message } })}\n\n`,
+                {
+                  status: 200,
+                  headers: { 'content-type': 'text/event-stream' },
+                },
+              ),
+            ),
+        });
+        const stream = await client.messages.create({
+          model: 'test-model',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'test' }],
+          stream: true,
+        });
+        anthropicState.createImpl.mockResolvedValue(stream);
+        const { chunks, error } = await collectGeneratedStream(
+          'https://anthropic-proxy.example.test',
+        );
+        expect(chunks).toEqual([]);
+        expect(error).toBeInstanceOf(Error);
+        expect((error as { status?: number }).status).toBe(status);
+        expect(isRateLimitError(error)).toBe(status === 429);
+        if (status === 429) {
+          expect(error).toHaveProperty('cause', expect.any(Error));
+          expect((error as Error).cause).not.toHaveProperty('status', 429);
+        }
+      },
+    );
+
+    it.each([401, 404])(
+      'preserves explicit status %s on stream errors',
+      async (status) => {
+        const original = Object.assign(
+          new Error(
+            JSON.stringify({
+              type: 'error',
+              error: {
+                type: 'api_error',
+                message:
+                  'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+              },
+            }),
+          ),
+          { status },
+        );
+        anthropicState.createImpl.mockResolvedValue(
+          (async function* () {
+            throw original;
+            yield {};
+          })(),
+        );
+        const { error } = await collectGeneratedStream();
+        expect(error).toBe(original);
+        expect(isRateLimitError(error)).toBe(false);
+      },
+    );
 
     it.each([
       {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -54,6 +54,7 @@ import { setToolCallPreparations } from '../tool-call-preparation.js';
 import { InvalidStreamError } from '../invalid-stream-error.js';
 import { parseToolCallArguments } from '../tool-call-arguments.js';
 import { classifyRetryError } from '../../utils/retryErrorClassification.js';
+import { getErrorStatus } from '../../utils/errors.js';
 import { buildSessionAwareFetch } from '../outbound-session-id.js';
 import { isRetryableStreamTransportError } from '../stream-transport-retry.js';
 import {
@@ -65,6 +66,34 @@ import {
 } from '../../telemetry/gen-ai-request.js';
 
 const debugLogger = createDebugLogger('ANTHROPIC');
+
+function normalizeStreamError(error: unknown): unknown {
+  const redacted = redactProxyError(error);
+  if (!(redacted instanceof Error) || getErrorStatus(redacted) !== undefined) {
+    return redacted;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(redacted.message) as {
+      error?: { type?: unknown; message?: unknown };
+    } | null;
+  } catch {
+    return redacted;
+  }
+  if (
+    payload?.error?.type === 'api_error' &&
+    typeof payload.error.message === 'string' &&
+    /^Streaming error: 404: Rate limit exceeded on Anthropic API\.?$/i.test(
+      payload.error.message.trim(),
+    )
+  ) {
+    // The gateway's 404 is message text inside a successful SSE response.
+    return Object.assign(new Error(redacted.message, { cause: redacted }), {
+      status: 429,
+    });
+  }
+  return redacted;
+}
 
 /**
  * Hostname-only DeepSeek anthropic-compatible detector. Returns true ONLY
@@ -1205,7 +1234,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
         yield event;
       }
     } catch (error) {
-      throw redactProxyError(error);
+      throw normalizeStreamError(error);
     }
   }
 

--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -11455,6 +11455,75 @@ describe('LlmChat', async () => {
       }
     });
 
+    it('retries the statusless Anthropic SSE throttle and completes the next attempt', async () => {
+      vi.useFakeTimers();
+      try {
+        const error = new Error(
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'invalid_request_error',
+              message: JSON.stringify({
+                message:
+                  'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
+              }),
+            },
+          }),
+        );
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw error;
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Recovered from SSE throttle' }],
+                    },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'sse-throttle',
+        );
+        const iterator = stream[Symbol.asyncIterator]();
+        const retry = await iterator.next();
+        expect(retry.value.type).toBe(StreamEventType.RETRY);
+        expect(retry.value.retryInfo.delayMs).toBeGreaterThan(0);
+        const next = iterator.next();
+        await vi.advanceTimersByTimeAsync(retry.value.retryInfo.delayMs);
+        const events = [(await next).value];
+        for (;;) {
+          const event = await iterator.next();
+          if (event.done) break;
+          events.push(event.value);
+        }
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Recovered from SSE throttle',
+          ),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should use Retry-After delay for streamed rate-limit errors', async () => {
       vi.useFakeTimers();
 

--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -11455,83 +11455,74 @@ describe('LlmChat', async () => {
       }
     });
 
-    it.each([
-      {
-        type: 'invalid_request_error',
-        message: JSON.stringify({
-          message:
-            'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
-        }),
-      },
-      {
-        type: 'api_error',
-        message: 'Streaming error: 404: Rate limit exceeded on Anthropic API.',
-      },
-    ])(
-      'retries the statusless SSE $type throttle and completes the next attempt',
-      async (providerError) => {
-        vi.useFakeTimers();
-        try {
-          const error = new Error(
-            JSON.stringify({
-              type: 'error',
-              error: providerError,
-            }),
-          );
-          vi.mocked(mockContentGenerator.generateContentStream)
-            .mockResolvedValueOnce(
-              (async function* () {
-                throw error;
-                yield {} as GenerateContentResponse;
-              })(),
-            )
-            .mockResolvedValueOnce(
-              (async function* () {
-                yield {
-                  candidates: [
-                    {
-                      content: {
-                        parts: [{ text: 'Recovered from SSE throttle' }],
-                      },
-                      finishReason: 'STOP',
+    it('retries the statusless Anthropic SSE throttle and completes the next attempt', async () => {
+      vi.useFakeTimers();
+      try {
+        const error = new Error(
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'invalid_request_error',
+              message: JSON.stringify({
+                message:
+                  'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
+              }),
+            },
+          }),
+        );
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw error;
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Recovered from SSE throttle' }],
                     },
-                  ],
-                } as unknown as GenerateContentResponse;
-              })(),
-            );
-          const stream = await chat.sendMessageStream(
-            'test-model',
-            { message: 'test' },
-            'sse-throttle',
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
           );
-          const iterator = stream[Symbol.asyncIterator]();
-          const retry = await iterator.next();
-          expect(retry.value.type).toBe(StreamEventType.RETRY);
-          expect(retry.value.retryInfo.delayMs).toBeGreaterThan(0);
-          const next = iterator.next();
-          await vi.advanceTimersByTimeAsync(retry.value.retryInfo.delayMs);
-          const events = [(await next).value];
-          for (;;) {
-            const event = await iterator.next();
-            if (event.done) break;
-            events.push(event.value);
-          }
-          expect(
-            mockContentGenerator.generateContentStream,
-          ).toHaveBeenCalledTimes(2);
-          expect(
-            events.some(
-              (event) =>
-                event.type === StreamEventType.CHUNK &&
-                event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
-                  'Recovered from SSE throttle',
-            ),
-          ).toBe(true);
-        } finally {
-          vi.useRealTimers();
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'sse-throttle',
+        );
+        const iterator = stream[Symbol.asyncIterator]();
+        const retry = await iterator.next();
+        expect(retry.value.type).toBe(StreamEventType.RETRY);
+        expect(retry.value.retryInfo.delayMs).toBeGreaterThan(0);
+        const next = iterator.next();
+        await vi.advanceTimersByTimeAsync(retry.value.retryInfo.delayMs);
+        const events = [(await next).value];
+        for (;;) {
+          const event = await iterator.next();
+          if (event.done) break;
+          events.push(event.value);
         }
-      },
-    );
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Recovered from SSE throttle',
+          ),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
 
     it('should use Retry-After delay for streamed rate-limit errors', async () => {
       vi.useFakeTimers();

--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -11455,74 +11455,83 @@ describe('LlmChat', async () => {
       }
     });
 
-    it('retries the statusless Anthropic SSE throttle and completes the next attempt', async () => {
-      vi.useFakeTimers();
-      try {
-        const error = new Error(
-          JSON.stringify({
-            type: 'error',
-            error: {
-              type: 'invalid_request_error',
-              message: JSON.stringify({
-                message:
-                  'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
-              }),
-            },
-          }),
-        );
-        vi.mocked(mockContentGenerator.generateContentStream)
-          .mockResolvedValueOnce(
-            (async function* () {
-              throw error;
-              yield {} as GenerateContentResponse;
-            })(),
-          )
-          .mockResolvedValueOnce(
-            (async function* () {
-              yield {
-                candidates: [
-                  {
-                    content: {
-                      parts: [{ text: 'Recovered from SSE throttle' }],
-                    },
-                    finishReason: 'STOP',
-                  },
-                ],
-              } as unknown as GenerateContentResponse;
-            })(),
+    it.each([
+      {
+        type: 'invalid_request_error',
+        message: JSON.stringify({
+          message:
+            'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
+        }),
+      },
+      {
+        type: 'api_error',
+        message: 'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+      },
+    ])(
+      'retries the statusless SSE $type throttle and completes the next attempt',
+      async (providerError) => {
+        vi.useFakeTimers();
+        try {
+          const error = new Error(
+            JSON.stringify({
+              type: 'error',
+              error: providerError,
+            }),
           );
-        const stream = await chat.sendMessageStream(
-          'test-model',
-          { message: 'test' },
-          'sse-throttle',
-        );
-        const iterator = stream[Symbol.asyncIterator]();
-        const retry = await iterator.next();
-        expect(retry.value.type).toBe(StreamEventType.RETRY);
-        expect(retry.value.retryInfo.delayMs).toBeGreaterThan(0);
-        const next = iterator.next();
-        await vi.advanceTimersByTimeAsync(retry.value.retryInfo.delayMs);
-        const events = [(await next).value];
-        for (;;) {
-          const event = await iterator.next();
-          if (event.done) break;
-          events.push(event.value);
+          vi.mocked(mockContentGenerator.generateContentStream)
+            .mockResolvedValueOnce(
+              (async function* () {
+                throw error;
+                yield {} as GenerateContentResponse;
+              })(),
+            )
+            .mockResolvedValueOnce(
+              (async function* () {
+                yield {
+                  candidates: [
+                    {
+                      content: {
+                        parts: [{ text: 'Recovered from SSE throttle' }],
+                      },
+                      finishReason: 'STOP',
+                    },
+                  ],
+                } as unknown as GenerateContentResponse;
+              })(),
+            );
+          const stream = await chat.sendMessageStream(
+            'test-model',
+            { message: 'test' },
+            'sse-throttle',
+          );
+          const iterator = stream[Symbol.asyncIterator]();
+          const retry = await iterator.next();
+          expect(retry.value.type).toBe(StreamEventType.RETRY);
+          expect(retry.value.retryInfo.delayMs).toBeGreaterThan(0);
+          const next = iterator.next();
+          await vi.advanceTimersByTimeAsync(retry.value.retryInfo.delayMs);
+          const events = [(await next).value];
+          for (;;) {
+            const event = await iterator.next();
+            if (event.done) break;
+            events.push(event.value);
+          }
+          expect(
+            mockContentGenerator.generateContentStream,
+          ).toHaveBeenCalledTimes(2);
+          expect(
+            events.some(
+              (event) =>
+                event.type === StreamEventType.CHUNK &&
+                event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                  'Recovered from SSE throttle',
+            ),
+          ).toBe(true);
+        } finally {
+          vi.useRealTimers();
         }
-        expect(
-          mockContentGenerator.generateContentStream,
-        ).toHaveBeenCalledTimes(2);
-        expect(
-          events.some(
-            (event) =>
-              event.type === StreamEventType.CHUNK &&
-              event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
-                'Recovered from SSE throttle',
-          ),
-        ).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
+      },
+    );
 
     it('should use Retry-After delay for streamed rate-limit errors', async () => {
       vi.useFakeTimers();

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -243,6 +243,14 @@ export function createDuplicateProviderToolCallResponse(
 ): ToolCallResponseInfo {
   const providerCallId = request.providerCallId ?? request.callId;
   const message = duplicateProviderToolCallMessage(providerCallId);
+  return createNotStartedToolErrorResponse(request, message);
+}
+
+export function createNotStartedToolErrorResponse(
+  request: ToolCallRequestInfo,
+  message: string,
+  errorType: ToolErrorType = ToolErrorType.EXECUTION_FAILED,
+): ToolCallResponseInfo {
   return {
     callId: request.callId,
     responseParts: [
@@ -256,7 +264,7 @@ export function createDuplicateProviderToolCallResponse(
     ],
     resultDisplay: message,
     error: new Error(message),
-    errorType: ToolErrorType.EXECUTION_FAILED,
+    errorType,
     executionStatus: 'not_started',
   };
 }

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -96,7 +96,7 @@ describe('isRateLimitError — statusless provider errors', () => {
     [
       'api_error',
       'Streaming error: 404: Rate limit exceeded on Anthropic API.',
-      true,
+      false,
     ],
     ['api_error', 'Streaming error: 404: Model not found.', false],
     ['api_error', 'Streaming error: 404: Account quota exceeded.', false],

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -94,6 +94,18 @@ describe('isRateLimitError — statusless provider errors', () => {
 
   it.each([
     ['invalid_request_error', throttleMessage, true],
+    [
+      'invalid_request_error',
+      'Too many requests, please wait before trying again.',
+      true,
+    ],
+    [
+      'invalid_request_error',
+      JSON.stringify({
+        message: 'Too many requests are not permitted for this key',
+      }),
+      false,
+    ],
     ['rate_limit_error', 'Rate limit reached', true],
     ['overloaded_error', 'Overloaded', true],
     ['invalid_request_error', 'Invalid messages parameter', false],

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
 import {
   getRateLimitErrorDetails,
   getRateLimitRetryDelayMs,
@@ -82,6 +83,86 @@ describe('isRateLimitError — detection paths', () => {
     expect(isRateLimitError(null)).toBe(false);
     expect(isRateLimitError(undefined)).toBe(false);
     expect(isRateLimitError('500')).toBe(false);
+  });
+});
+
+describe('isRateLimitError — statusless provider errors', () => {
+  const throttleMessage = JSON.stringify({
+    message:
+      'Too many requests, please wait before trying again. You have sent too many requests.  Wait before trying again.',
+  });
+
+  it.each([
+    ['invalid_request_error', throttleMessage, true],
+    ['rate_limit_error', 'Rate limit reached', true],
+    ['overloaded_error', 'Overloaded', true],
+    ['invalid_request_error', 'Invalid messages parameter', false],
+    ['authentication_error', throttleMessage, false],
+    ['billing_error', throttleMessage, false],
+    ['invalid_request_error', 'Please try again with a valid model', false],
+    [
+      'invalid_request_error',
+      'Invalid prompt containing Too many requests',
+      false,
+    ],
+  ])(
+    'detects actual SDK SSE %s / %s as %s',
+    async (type, message, expected) => {
+      const response = new Response(
+        `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type, message } })}\n\n`,
+        { status: 200, headers: { 'content-type': 'text/event-stream' } },
+      );
+      let error: unknown;
+      try {
+        const client = new Anthropic({
+          apiKey: 'test-key',
+          maxRetries: 0,
+          fetch: vi.fn().mockResolvedValue(response),
+        });
+        const stream = await client.messages.create({
+          model: 'test-model',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'test' }],
+          stream: true,
+        });
+        for await (const _chunk of stream) {
+          // This response contains only an error event.
+        }
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toHaveProperty('status', 429);
+      expect(isRateLimitError(error)).toBe(expected);
+    },
+  );
+
+  it.each(['rate_limit_error', 'overloaded_error'])(
+    'detects structured %s without a status',
+    (type) => {
+      expect(
+        isRateLimitError({
+          error: { type, message: 'Temporarily unavailable' },
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it('keeps explicit non-retryable numeric status authoritative', () => {
+    expect(
+      isRateLimitError({
+        status: 401,
+        error: { type: 'rate_limit_error', message: throttleMessage },
+      }),
+    ).toBe(false);
+  });
+
+  it('does not retry an unstructured message just because it mentions throttling', () => {
+    expect(
+      isRateLimitError(
+        new Error('Too many requests, please wait before trying again.'),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -93,6 +93,23 @@ describe('isRateLimitError — statusless provider errors', () => {
   });
 
   it.each([
+    [
+      'api_error',
+      'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+      true,
+    ],
+    ['api_error', 'Streaming error: 404: Model not found.', false],
+    ['api_error', 'Streaming error: 404: Account quota exceeded.', false],
+    [
+      'api_error',
+      'Invalid prompt containing Rate limit exceeded on Anthropic API.',
+      false,
+    ],
+    [
+      'authentication_error',
+      'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+      false,
+    ],
     ['invalid_request_error', throttleMessage, true],
     [
       'invalid_request_error',
@@ -165,6 +182,16 @@ describe('isRateLimitError — statusless provider errors', () => {
       isRateLimitError({
         status: 401,
         error: { type: 'rate_limit_error', message: throttleMessage },
+      }),
+    ).toBe(false);
+    expect(
+      isRateLimitError({
+        status: 404,
+        error: {
+          type: 'api_error',
+          message:
+            'Streaming error: 404: Rate limit exceeded on Anthropic API.',
+        },
       }),
     ).toBe(false);
   });

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -288,6 +288,26 @@ describe('rate-limit retry diagnostics', () => {
     });
   });
 
+  it('decodes statusless SSE throttle details for diagnostics', () => {
+    const providerMessage =
+      'Too many requests, please wait before trying again. You have sent too many requests. Wait before trying again.';
+    const error = new Error(
+      JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'invalid_request_error',
+          message: JSON.stringify({ message: providerMessage }),
+        },
+      }),
+    );
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      providerCode: 'invalid_request_error',
+      providerMessage,
+      transport: 'unknown',
+    });
+  });
+
   it('should extract request id from top-level nested JSON error messages', () => {
     const error = new Error(
       '{"request_id":"req-123","error":{"code":"429","message":"Throttling: TPM limit reached"}}',

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -62,10 +62,9 @@ export function isRateLimitError(
 
 function isStatuslessThrottle(error: unknown): boolean {
   for (const payload of [error, ...getJsonPayloads(error)]) {
-    if (typeof payload !== 'object' || payload === null) continue;
-    const nested = (payload as { error?: unknown }).error;
-    const source = nested ?? payload;
-    if (typeof source !== 'object' || source === null) continue;
+    const selected = providerErrorSource(payload);
+    if (!selected) continue;
+    const { source } = selected;
     const { type, message } = source as { type?: unknown; message?: unknown };
     if (type === 'rate_limit_error' || type === 'overloaded_error') return true;
     if (type !== 'invalid_request_error' || typeof message !== 'string')
@@ -73,12 +72,7 @@ function isStatuslessThrottle(error: unknown): boolean {
 
     // Some gateways put a temporary throttle inside invalid_request_error,
     // with another JSON-encoded message instead of a numeric status.
-    let detail: unknown = message;
-    try {
-      detail = (JSON.parse(message) as { message?: unknown })?.message;
-    } catch {
-      // The provider message can also be plain text.
-    }
+    const detail = decodeProviderMessage(message)?.['message'] ?? message;
     if (
       typeof detail === 'string' &&
       /^too many requests\b/i.test(detail.trim()) &&
@@ -88,6 +82,33 @@ function isStatuslessThrottle(error: unknown): boolean {
     }
   }
   return false;
+}
+
+type ProviderErrorSource = Record<string, unknown>;
+
+function providerErrorSource(
+  payload: unknown,
+): { source: ProviderErrorSource; direct: ProviderErrorSource } | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const direct = payload as ProviderErrorSource;
+  const nested = direct['error'];
+  const source =
+    typeof nested === 'object' && nested !== null
+      ? (nested as ProviderErrorSource)
+      : direct;
+  return { source, direct };
+}
+
+function decodeProviderMessage(message: string): ProviderErrorSource | null {
+  try {
+    const selected = providerErrorSource(JSON.parse(message) as unknown);
+    if (!selected || typeof selected.source['message'] !== 'string') {
+      return null;
+    }
+    return { ...selected.direct, ...selected.source };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -109,8 +130,8 @@ export function getRateLimitErrorDetails(
 
   return {
     ...(statusCode !== undefined ? { statusCode } : {}),
-    ...(payload?.code !== undefined
-      ? { providerCode: String(payload.code) }
+    ...(payload?.code !== undefined || payload?.type !== undefined
+      ? { providerCode: String(payload.code ?? payload.type) }
       : {}),
     ...(payload?.message !== undefined
       ? { providerMessage: payload.message }
@@ -201,61 +222,75 @@ function getErrorCode(error: unknown): number | null {
 
 interface ProviderErrorPayload {
   code?: string | number;
+  type?: string;
   message?: string;
   requestId?: string;
 }
 
 function getProviderErrorPayload(error: unknown): ProviderErrorPayload | null {
   for (const payload of getJsonPayloads(error)) {
-    if (typeof payload !== 'object' || payload === null) continue;
-
-    const direct = payload as {
-      code?: unknown;
-      message?: unknown;
-      request_id?: unknown;
-      requestId?: unknown;
-    };
-    const nestedError = (payload as { error?: unknown }).error;
-    const nested =
-      typeof nestedError === 'object' && nestedError !== null
-        ? (nestedError as {
-            code?: unknown;
-            message?: unknown;
-            request_id?: unknown;
-            requestId?: unknown;
-          })
-        : undefined;
-    const source = nested ?? direct;
+    const selected = providerErrorSource(payload);
+    if (!selected) continue;
+    const { source, direct } = selected;
+    const decoded =
+      typeof source['message'] === 'string'
+        ? decodeProviderMessage(source['message'])
+        : null;
     const code =
-      typeof source.code === 'string' || typeof source.code === 'number'
-        ? source.code
-        : undefined;
+      typeof source['code'] === 'string' || typeof source['code'] === 'number'
+        ? source['code']
+        : typeof decoded?.['code'] === 'string' ||
+            typeof decoded?.['code'] === 'number'
+          ? decoded['code']
+          : undefined;
+    const type =
+      typeof source['type'] === 'string'
+        ? source['type']
+        : typeof decoded?.['type'] === 'string'
+          ? decoded['type']
+          : undefined;
     const message =
-      typeof source.message === 'string' ? source.message : undefined;
+      typeof decoded?.['message'] === 'string'
+        ? decoded['message']
+        : typeof source['message'] === 'string'
+          ? source['message']
+          : undefined;
     const requestId =
-      typeof source.request_id === 'string'
-        ? source.request_id
-        : typeof source.requestId === 'string'
-          ? source.requestId
-          : typeof direct.request_id === 'string'
-            ? direct.request_id
-            : typeof direct.requestId === 'string'
-              ? direct.requestId
-              : undefined;
+      typeof source['request_id'] === 'string'
+        ? source['request_id']
+        : typeof source['requestId'] === 'string'
+          ? source['requestId']
+          : typeof direct['request_id'] === 'string'
+            ? direct['request_id']
+            : typeof direct['requestId'] === 'string'
+              ? direct['requestId']
+              : typeof decoded?.['request_id'] === 'string'
+                ? decoded['request_id']
+                : typeof decoded?.['requestId'] === 'string'
+                  ? decoded['requestId']
+                  : undefined;
 
     if (
       code !== undefined ||
+      type !== undefined ||
       message !== undefined ||
       requestId !== undefined
     ) {
-      return { code, message, requestId };
+      return { code, type, message, requestId };
     }
   }
 
   if (isApiError(error)) {
+    const decoded = decodeProviderMessage(error.error.message);
     return {
       code: error.error.code,
-      message: error.error.message,
+      ...(typeof decoded?.['type'] === 'string'
+        ? { type: decoded['type'] }
+        : {}),
+      message:
+        typeof decoded?.['message'] === 'string'
+          ? decoded['message']
+          : error.error.message,
     };
   }
 

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -67,15 +67,6 @@ function isStatuslessThrottle(error: unknown): boolean {
     const { source } = selected;
     const { type, message } = source as { type?: unknown; message?: unknown };
     if (type === 'rate_limit_error' || type === 'overloaded_error') return true;
-    if (
-      type === 'api_error' &&
-      typeof message === 'string' &&
-      /^Streaming error: 404: Rate limit exceeded on Anthropic API\.?$/i.test(
-        message.trim(),
-      )
-    ) {
-      return true;
-    }
     if (type !== 'invalid_request_error' || typeof message !== 'string')
       continue;
 

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -54,9 +54,39 @@ export function isRateLimitError(
   extraCodes?: readonly number[],
 ): boolean {
   const code = getErrorCode(error);
-  if (code === null) return false;
+  if (code === null) return isStatuslessThrottle(error);
   if (RATE_LIMIT_ERROR_CODES.has(code)) return true;
   if (extraCodes && extraCodes.includes(code)) return true;
+  return false;
+}
+
+function isStatuslessThrottle(error: unknown): boolean {
+  for (const payload of [error, ...getJsonPayloads(error)]) {
+    if (typeof payload !== 'object' || payload === null) continue;
+    const nested = (payload as { error?: unknown }).error;
+    const source = nested ?? payload;
+    if (typeof source !== 'object' || source === null) continue;
+    const { type, message } = source as { type?: unknown; message?: unknown };
+    if (type === 'rate_limit_error' || type === 'overloaded_error') return true;
+    if (type !== 'invalid_request_error' || typeof message !== 'string')
+      continue;
+
+    // Some gateways put a temporary throttle inside invalid_request_error,
+    // with another JSON-encoded message instead of a numeric status.
+    let detail: unknown = message;
+    try {
+      detail = (JSON.parse(message) as { message?: unknown })?.message;
+    } catch {
+      // The provider message can also be plain text.
+    }
+    if (
+      typeof detail === 'string' &&
+      /^too many requests\b/i.test(detail.trim()) &&
+      /\b(?:wait|try(?:ing)? again)\b/i.test(detail)
+    ) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -68,6 +68,15 @@ function isStatuslessThrottle(error: unknown): boolean {
     if (typeof source !== 'object' || source === null) continue;
     const { type, message } = source as { type?: unknown; message?: unknown };
     if (type === 'rate_limit_error' || type === 'overloaded_error') return true;
+    if (
+      type === 'api_error' &&
+      typeof message === 'string' &&
+      /^Streaming error: 404: Rate limit exceeded on Anthropic API\.?$/i.test(
+        message.trim(),
+      )
+    ) {
+      return true;
+    }
     if (type !== 'invalid_request_error' || typeof message !== 'string')
       continue;
 


### PR DESCRIPTION
## What this PR does

Retries temporary throttling reported inside an Anthropic-compatible SSE stream without a numeric status. This covers standard `rate_limit_error` / `overloaded_error` types, an `invalid_request_error` containing a nested JSON “Too many requests…wait” message, and the observed `api_error` message `Streaming error: 404: Rate limit exceeded on Anthropic API.` Recovery uses the existing retry budget and backoff. The AP-specific `api_error` compatibility rule is confined to the Anthropic streaming adapter (including compatible proxy endpoints). It normalizes the observed statusless error to an internal 429 while preserving its redacted cause. Other protocols do not recognize this raw message as a rate limit.

Headless main and notification-drain turns also discard pending tool requests when a retry or model fallback discards an attempt, so tools buffered from a failed attempt cannot execute after recovery.

## Why it's needed

An endpoint can accept a stream with HTTP 200 and report throttling afterward. The locked SDK wraps these errors without a numeric status, so Qwen Code previously propagated them instead of retrying. The `404` in the observed compatibility message is text inside an SSE payload, not a real HTTP 404 response. Real numeric status codes retain their existing precedence.

## Reviewer Test Plan

### How to verify

Use a localhost Anthropic-compatible endpoint that returns one of the supported SSE throttles on its first messages request and a valid success stream on its second. Confirm that the CLI waits under its retry policy, makes the second request, prints the successful answer, and exits successfully. Return an ordinary model-not-found error as a control and confirm that only one request is sent. In headless main and notification-drain turns, emit a tool request followed by Retry and a successful text response; confirm that the discarded tool is never executed.

Automated regressions use the real Anthropic SDK to parse mocked HTTP 200 SSE responses, exercise chat-level retry and recovery, and verify tool execution in both headless paths. Negative cases cover ordinary 404/model errors, account-quota text, authentication errors, misleading prompt text, and explicit non-retryable numeric status codes.

### Evidence (Before & After)

- Original PR validation: 571 core tests and 142 CLI tests passed; one existing CLI test was skipped. The original nested-message throttle recovered through the built CLI after two requests, while the ordinary invalid-request control made one request.
- AP compatibility regression: the exact new payload still returned `retryable=false` at PR commit `77c3959f`. A regression using the actual SDK failed before the supplement and passed afterward. The global CLI reproduction also stopped after one request.
- Supplement validation: 579 core tests, full build/bundle, repository typecheck, changed-file ESLint, Prettier, and diff checks passed. Built CLI verification of the exact AP payload waited 60 seconds, made exactly two requests, returned `Recovered successfully.`, and exited successfully (60,262 ms total). Happy-path and ordinary-404 controls each made one request. Independent review found no actionable issues.

- Final protocol-scoped validation: 751 core tests and 155 CLI tests passed (one existing CLI test skipped); full build, refreshed core/CLI builds, bundle, repository typecheck, ESLint, Prettier, and diff checks passed. The built CLI recovered from the exact Anthropic AP throttle after 60 seconds and two requests (60,399 ms total). OpenAI receiving the identical error made one request without retrying; Anthropic ordinary-404 and both protocols' happy-path controls also passed. Independent review found no actionable issues.

### Tested on

| OS | Status |
| :---: | :---: |
| macOS | Tested |
| Windows | Not tested |
| Linux | Not tested |

All API tests use isolated configuration, a local mock endpoint, and a dummy key; no real model requests are made.

## Risk & Scope

Message-based compatibility recognition is limited to the observed structured error forms. The added `api_error` case matches the complete streaming-throttle message; it does not make arbitrary 404s or messages mentioning rate limits retryable. Retry counts and delay policy are unchanged. The normalized error follows existing 429 handling, including model fallback after retry exhaustion when configured and eligible.

Live provider recovery, upstream quota causes, Windows/Linux execution, SDK upgrades, and the separately observed ordinary-error exit-status reporting issue are outside scope. A no-retry control is not proof that an ordinary error's exit status is reported correctly.

## Linked Issues

Fixes #11215. Related to #9005; this does not resolve that broader issue in full.

<details>
<summary>中文说明</summary>

接口可能先返回 HTTP 200，随后在 SSE 流里报告限流。SDK 包装后没有数字状态码，原有重试判断会漏掉这些错误。本 PR 补充识别标准限流类型，以及两种已观察到的网关包装：`invalid_request_error` 内嵌 “Too many requests…wait”，和 `api_error` 内的 `Streaming error: 404: Rate limit exceeded on Anthropic API.`。

识别后沿用现有重试预算和退避策略，并清空失败尝试中尚未执行的工具请求。普通 404、鉴权错误和额度错误不会因为这项兼容处理而一律重试；明确的数字状态码仍优先。

此次补充用真实 SDK 解析模拟 SSE 错误，先在原 PR 上复现失败，再验证修复。真实服务恢复能力和 Windows 运行尚未验证；此 PR 不改变上游服务配额，也不保证持续限流下任务一定完成。

</details>
