### PR TITLE
perf(web-shell): gzip serve responses for large transcript loads (#6181)

### DIFF
--- a/packages/cli/src/serve/gzip-response.test.ts
+++ b/packages/cli/src/serve/gzip-response.test.ts
@@ -1,0 +1,394 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express, { type Express } from 'express';
+import supertest from 'supertest';
+import { randomBytes } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import { acceptsGzip, gzipJsonResponses } from './gzip-response.js';
+
+/** A transcript-shaped payload comfortably past the 1 KiB threshold. */
+function largeJsonPayload(): Record<string, unknown> {
+  const events = Array.from({ length: 120 }, (_, i) => ({
+    id: i + 1,
+    v: 1,
+    type: 'session_update',
+    data: {
+      sessionId: 'session-large',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: {
+          type: 'text',
+          text: `assistant message chunk ${i} with repeated transcript prose `.repeat(
+            3,
+          ),
+        },
+      },
+    },
+  }));
+  return {
+    sessionId: 'session-large',
+    attached: true,
+    state: { phase: 'idle' },
+    compactedReplay: events,
+  };
+}
+
+function buildApp(
+  routes: (app: Express) => void,
+  middleware: express.RequestHandler = gzipJsonResponses(),
+): Express {
+  const app = express();
+  app.use(middleware);
+  routes(app);
+  return app;
+}
+
+describe('acceptsGzip', () => {
+  it.each([
+    ['gzip', true],
+    ['GZIP', true],
+    ['deflate, gzip', true],
+    ['gzip, deflate, br', true],
+    ['gzip;q=0.5', true],
+    ['gzip;q=1.0, br', true],
+    ['br', false],
+    ['deflate', false],
+    ['', false],
+    ['identity', false],
+    ['gzip;q=0', false],
+    ['gzip; q="0"', false],
+    ['gzip;q=0.000, deflate', false],
+    ['deflate, gzip; q=0', false],
+  ])('Accept-Encoding %j -> %s', (header, expected) => {
+    expect(acceptsGzip(header)).toBe(expected);
+  });
+
+  it('returns false for missing or non-string headers', () => {
+    expect(acceptsGzip(undefined)).toBe(false);
+    expect(acceptsGzip(['gzip'])).toBe(false);
+  });
+});
+
+describe('gzipJsonResponses middleware', () => {
+  it('compresses large JSON responses for gzip-capable clients', async () => {
+    const payload = largeJsonPayload();
+    const identity = Buffer.byteLength(JSON.stringify(payload));
+    const app = buildApp((a) => {
+      a.get('/session/:id/load', (_req, res) => {
+        res.status(200).json(payload);
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/session/large/load')
+      .set('Accept-Encoding', 'gzip, deflate, br');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(String(res.headers['vary']).toLowerCase()).toContain(
+      'accept-encoding',
+    );
+    // Transcript-shaped JSON must shrink dramatically; this also pins the
+    // compression win the PR claims. content-length carries the wire (gzip)
+    // byte count — superagent transparently decompresses it before exposing
+    // res.body, mirroring what browser fetch does for the Web Shell client.
+    expect(res.headers['content-length']).toBeDefined();
+    expect(Number(res.headers['content-length'])).toBeLessThan(identity / 2);
+    expect(res.body).toEqual(payload);
+  });
+
+  it('sends identity responses when the client does not offer gzip', async () => {
+    const payload = largeJsonPayload();
+    const app = buildApp((a) => {
+      a.get('/session/:id/load', (_req, res) => {
+        res.json(payload);
+      });
+    });
+
+    // `identity` (not "no header"): superagent always sends a default
+    // `Accept-Encoding: gzip, deflate`, so "no header" cannot be expressed.
+    for (const encoding of ['identity', 'deflate', 'br', 'gzip;q=0']) {
+      const res = await supertest(app)
+        .get('/session/large/load')
+        .set('Accept-Encoding', encoding);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-encoding']).toBeUndefined();
+      expect(res.body).toEqual(payload);
+    }
+  });
+
+  it('skips bodies below the threshold', async () => {
+    const app = buildApp((a) => {
+      a.get('/small', (_req, res) => {
+        res.json({ ok: true, note: 'tiny body' });
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/small')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.body).toEqual({ ok: true, note: 'tiny body' });
+  });
+
+  it('still advertises Vary: Accept-Encoding on small JSON pass-throughs', async () => {
+    const app = buildApp((a) => {
+      a.get('/small', (_req, res) => {
+        res.json({ ok: true });
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/small')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(String(res.headers['vary']).toLowerCase()).toContain(
+      'accept-encoding',
+    );
+  });
+
+  it('does not compress HEAD responses', async () => {
+    const app = buildApp((a) => {
+      a.head('/session/:id/load', (_req, res) => {
+        res.json(largeJsonPayload());
+      });
+    });
+
+    const res = await supertest(app)
+      .head('/session/large/load')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(String(res.headers['vary']).toLowerCase()).toContain(
+      'accept-encoding',
+    );
+  });
+
+  it('does not double-encode responses that already carry Content-Encoding', async () => {
+    const raw = Buffer.from(JSON.stringify({ pre: 'encoded' }));
+    const app = buildApp((a) => {
+      a.get('/pre-encoding', (_req, res) => {
+        res.setHeader('Content-Encoding', 'gzip');
+        res.send(gzipSync(raw));
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/pre-encoding')
+      .set('Accept-Encoding', 'gzip')
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    // Exactly the one pre-set value, no second encoding layered on top:
+    // superagent transparently inflates one gzip layer, and the result must
+    // be the original JSON — a double-encoded body would leave gzip bytes
+    // that fail JSON.parse.
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(JSON.parse(res.body.toString('utf8'))).toEqual({
+      pre: 'encoded',
+    });
+  });
+
+  it('leaves SSE / res.write streaming responses untouched', async () => {
+    const app = buildApp((a) => {
+      a.get('/events', (_req, res) => {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.flushHeaders?.();
+        res.write(`data: ${JSON.stringify('event '.repeat(512))}\n\n`);
+        res.end();
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/events')
+      .set('Accept-Encoding', 'gzip')
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.body.toString('utf8')).toContain('data: "event');
+  });
+
+  it('leaves attachment downloads untouched', async () => {
+    const body = JSON.stringify(largeJsonPayload());
+    const app = buildApp((a) => {
+      a.get('/export', (_req, res) => {
+        res
+          .status(200)
+          .set('Content-Type', 'application/json')
+          .set('Content-Disposition', 'attachment; filename="transcript.json"')
+          .send(body);
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/export')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(JSON.parse(res.text)).toEqual(largeJsonPayload());
+  });
+
+  it('leaves non-JSON (HTML) responses untouched', async () => {
+    const app = buildApp((a) => {
+      a.get('/html', (_req, res) => {
+        res
+          .status(200)
+          .set('Content-Type', 'text/html; charset=utf-8')
+          .send(`<html><body>${'x'.repeat(4096)}</body></html>`);
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/html')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    expect(res.text).toContain('<html>');
+  });
+
+  it('leaves 204/304 responses untouched', async () => {
+    const app = buildApp((a) => {
+      a.get('/no-content', (_req, res) => {
+        res.status(204).json({ never: 'sent' });
+      });
+      a.get('/not-modified', (_req, res) => {
+        res.status(304).json({ never: 'sent' });
+      });
+    });
+
+    for (const path of ['/no-content', '/not-modified']) {
+      const res = await supertest(app).get(path).set('Accept-Encoding', 'gzip');
+      expect([204, 304]).toContain(res.status);
+      expect(res.headers['content-encoding']).toBeUndefined();
+    }
+  });
+
+  it('drops the identity ETag on the compressed path', async () => {
+    const app = buildApp((a) => {
+      a.get('/etagged', (_req, res) => {
+        res.set('ETag', '"identity-tag"').json(largeJsonPayload());
+      });
+    });
+
+    const identityRes = await supertest(app)
+      .get('/etagged')
+      .set('Accept-Encoding', 'identity');
+    expect(identityRes.headers['etag']).toBe('"identity-tag"');
+
+    const gzipRes = await supertest(app)
+      .get('/etagged')
+      .set('Accept-Encoding', 'gzip');
+    expect(gzipRes.headers['content-encoding']).toBe('gzip');
+    expect(gzipRes.headers['etag']).toBeUndefined();
+  });
+
+  it('compresses Buffer bodies sent via res.send with a JSON content type', async () => {
+    const payload = largeJsonPayload();
+    const app = buildApp((a) => {
+      a.get('/buffered', (_req, res) => {
+        res.set('Content-Type', 'application/json; charset=utf-8');
+        res.send(Buffer.from(JSON.stringify(payload)));
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/buffered')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(res.body).toEqual(payload);
+  });
+
+  it('never sends a compressed representation larger than identity', async () => {
+    // Random base64 carries ~6 bits of entropy per character: wrapped in JSON
+    // it stays past the threshold while barely compressing, and the middleware
+    // must prefer whichever representation is actually smaller.
+    const blob = randomBytes(6144).toString('base64');
+    const app = buildApp((a) => {
+      a.get('/random', (_req, res) => {
+        res.json({ blob });
+      });
+    });
+
+    const identity = Buffer.byteLength(JSON.stringify({ blob }));
+    const res = await supertest(app)
+      .get('/random')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    if (res.headers['content-encoding'] === 'gzip') {
+      expect(Number(res.headers['content-length'])).toBeLessThan(identity);
+      expect(res.body).toEqual({ blob });
+    } else {
+      expect(res.headers['content-encoding']).toBeUndefined();
+      expect(res.body).toEqual({ blob });
+    }
+  });
+
+  it('honors a custom threshold option', async () => {
+    // 240 bytes of highly repetitive text: below the 1 KiB default (skipped)
+    // but above a custom threshold of 8, and compressible enough that the
+    // gzip result beats identity so the compressed path is taken.
+    const app = buildApp(
+      (a) => {
+        a.get('/tiniest', (_req, res) => {
+          res.json({ blob: 'a'.repeat(232) });
+        });
+      },
+      gzipJsonResponses({ threshold: 8 }),
+    );
+
+    const defaultThresholdRes = await supertest(app)
+      .get('/tiniest')
+      .set('Accept-Encoding', 'identity');
+    expect(defaultThresholdRes.headers['content-encoding']).toBeUndefined();
+
+    const res = await supertest(app)
+      .get('/tiniest')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(res.body).toEqual({ blob: 'a'.repeat(232) });
+  });
+
+  it('keeps error-status JSON bodies functional', async () => {
+    const message = 'x'.repeat(2048);
+    const app = buildApp((a) => {
+      a.get('/fails', (_req, res) => {
+        res.status(400).json({ error: message, code: 'bad_request' });
+      });
+    });
+
+    const res = await supertest(app)
+      .get('/fails')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.status).toBe(400);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(res.body).toEqual({ error: message, code: 'bad_request' });
+  });
+});

--- a/packages/cli/src/serve/gzip-response.ts
+++ b/packages/cli/src/serve/gzip-response.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RequestHandler, Response } from 'express';
+import { constants as zlibConstants, gzip } from 'node:zlib';
+
+/**
+ * Responses smaller than this skip compression: the gzip header/trailer (≈23
+ * bytes) plus a compression pass cost more than the bytes they save on tiny
+ * JSON payloads. Matches the 1 KiB default of the widely-deployed `compression`
+ * middleware so behavior is familiar to reviewers.
+ */
+export const GZIP_MIN_RESPONSE_BYTES = 1024;
+
+export interface GzipJsonResponsesOptions {
+  /** Bodies shorter than this many bytes are sent as identity. */
+  threshold?: number;
+}
+
+/**
+ * Parse an `Accept-Encoding` header and report whether `gzip` is acceptable.
+ *
+ * Tokens are `coding[;q=weight]` separated by commas (RFC 9110 §12.5.3).
+ * `gzip;q=0` (or `q=0.000`) explicitly disables gzip and must be honored even
+ * when the literal "gzip" substring is present, which is why a plain substring
+ * check is not enough. Unlisted weights default to 1 (acceptable).
+ */
+export function acceptsGzip(headerValue: unknown): boolean {
+  if (typeof headerValue !== 'string' || headerValue.length === 0) return false;
+  for (const rawToken of headerValue.split(',')) {
+    const parts = rawToken.trim().split(';');
+    const coding = parts[0]?.trim().toLowerCase();
+    if (coding !== 'gzip') continue;
+    for (const param of parts.slice(1)) {
+      const eq = param.indexOf('=');
+      if (eq === -1) continue;
+      const key = param.slice(0, eq).trim().toLowerCase();
+      const value = param
+        .slice(eq + 1)
+        .trim()
+        .replace(/^"|"$/g, '');
+      if (key === 'q' && Number.parseFloat(value) === 0) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function isJsonContentType(contentType: unknown): boolean {
+  if (typeof contentType !== 'string') return false;
+  // Covers `application/json` and `application/json; charset=utf-8` — the only
+  // shapes Express's res.json emits.
+  return contentType.toLowerCase().startsWith('application/json');
+}
+
+/** 204/304 (and any 1xx) responses have no body to compress. */
+function isNoBodyStatus(statusCode: number): boolean {
+  return (
+    statusCode === 204 ||
+    statusCode === 304 ||
+    (statusCode >= 100 && statusCode < 200)
+  );
+}
+
+/**
+ * Attachment (Content-Disposition) and range (Content-Range) responses must be
+ * delivered byte-exact: the filename handling, partial-content math, and
+ * client-side download progress all assume the identity representation.
+ */
+function hasByteExactSemantics(res: Response): boolean {
+  return (
+    res.getHeader('Content-Disposition') !== undefined ||
+    res.getHeader('Content-Range') !== undefined
+  );
+}
+
+function coerceResponseBody(body: unknown): Buffer | undefined {
+  if (typeof body === 'string') return Buffer.from(body);
+  if (Buffer.isBuffer(body)) return body;
+  // Express 5 routes other shapes (objects, numbers) through res.json, which
+  // re-enters res.send with the serialized string; nothing to do here.
+  return undefined;
+}
+
+/**
+ * Compress JSON API responses with gzip when the client asks for it (#6181).
+ *
+ * Web Shell session loads return multi-megabyte transcript JSON. On mobile /
+ * bandwidth-constrained clients the uncompressed transfer is the dominant cost
+ * of switching sessions, so the serve layer now negotiates gzip like any other
+ * HTTP server. Browser `fetch` decompresses transparently — the client needs
+ * no changes.
+ *
+ * Scope is deliberately narrow to keep the blast radius small:
+ * - Mounted AFTER authentication and the rate limiter: 401/403/429 bodies are
+ *   tiny and must not spend CPU on unauthenticated callers.
+ * - Wraps `res.send` (the funnel Express's `res.json` flows through). SSE
+ *   streams, `res.write`/`res.end` chunked responses, `res.sendFile`, and the
+ *   Web Shell static/SPA mounts never pass through it and are untouched.
+ * - Only `application/json` bodies at or above `threshold` bytes.
+ * - Skips HEAD, no-body statuses, responses that already carry a
+ *   `Content-Encoding`, and attachment/range downloads (byte-exact semantics).
+ * - Compression runs on the async `zlib.gzip` callback path so the daemon's
+ *   event loop keeps serving SSE frames while a large transcript is on the
+ *   wire. Level stays at `Z_DEFAULT_COMPRESSION` (= 6): transcript JSON is
+ *   highly repetitive text where level 6 captures nearly all of the win;
+ *   higher levels cost noticeably more CPU on a local single-user daemon for
+ *   marginal size savings.
+ *
+ * Every response that flows through the wrapper gets `Vary: Accept-Encoding`
+ * so caches never reuse one client's identity/gzip representation for another.
+ * On the compressed path the `ETag` set by Express is dropped instead of being
+ * recomputed over the gzip bytes: one resource now legitimately has two
+ * representations, and entity tags that ignore the encoding would collide.
+ */
+export function gzipJsonResponses(
+  options: GzipJsonResponsesOptions = {},
+): RequestHandler {
+  const threshold =
+    options.threshold !== undefined && options.threshold >= 0
+      ? options.threshold
+      : GZIP_MIN_RESPONSE_BYTES;
+  return function gzipJsonResponsesMiddleware(req, res, next) {
+    if (!acceptsGzip(req.headers['accept-encoding'])) {
+      // This client never negotiates gzip; leave its responses untouched
+      // (zero per-request overhead, no Vary noise).
+      next();
+      return;
+    }
+    const originalSend = res.send.bind(res);
+    res.send = function gzipAwareSend(body: unknown) {
+      res.append('Vary', 'Accept-Encoding');
+      const passthrough = (): Response => originalSend(body);
+      const payload = coerceResponseBody(body);
+      if (
+        req.method === 'HEAD' ||
+        res.headersSent ||
+        res.writableEnded ||
+        isNoBodyStatus(res.statusCode) ||
+        res.getHeader('Content-Encoding') !== undefined ||
+        hasByteExactSemantics(res) ||
+        !isJsonContentType(res.getHeader('Content-Type')) ||
+        payload === undefined ||
+        payload.byteLength < threshold
+      ) {
+        return passthrough();
+      }
+      // Z_DEFAULT_COMPRESSION keeps the CPU/size balance the zlib authors
+      // tuned for text payloads (see the doc comment above).
+      gzip(
+        payload,
+        { level: zlibConstants.Z_DEFAULT_COMPRESSION },
+        (error, compressed) => {
+          if (error || res.headersSent || res.writableEnded) {
+            // Another writer already won the race; only recover when the
+            // response is still open, otherwise stay silent to avoid a
+            // double-send ERR_HTTP_HEADERS_SENT.
+            if (!res.headersSent && !res.writableEnded) originalSend(body);
+            return;
+          }
+          if (compressed.byteLength >= payload.byteLength) {
+            // Incompressible payload — the identity body is smaller.
+            originalSend(body);
+            return;
+          }
+          res.removeHeader('ETag');
+          res.setHeader('Content-Encoding', 'gzip');
+          res.setHeader('Content-Length', String(compressed.byteLength));
+          res.end(compressed);
+        },
+      );
+      // res.send/res.json are chainable; the body is flushed asynchronously
+      // by the gzip callback.
+      return res;
+    };
+    next();
+  };
+}

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -14884,6 +14884,84 @@ describe('createServeApp', () => {
   });
 
   describe('POST /session/:id/load and /resume', () => {
+    it('gzip-compresses large load responses when the client negotiates it (#6181)', async () => {
+      // Transcript-shaped replay: highly repetitive JSON past the 1 KiB
+      // compression threshold, like a real multi-megabyte session load.
+      const compactedReplay = Array.from({ length: 200 }, (_, i) => ({
+        id: i + 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'gzip-large',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: 'assistant message chunk with repeated transcript prose '.repeat(
+                4,
+              ),
+            },
+          },
+        },
+      }));
+      const bridge = fakeBridge({
+        loadImpl: async (req) => ({
+          sessionId: req.sessionId,
+          workspaceCwd: req.workspaceCwd,
+          attached: false,
+          clientId: req.clientId ?? 'client-load',
+          state: {},
+          hasActivePrompt: false,
+          compactedReplay,
+        }),
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge },
+      );
+
+      // `Accept-Encoding: identity` is set explicitly: superagent injects a
+      // default `Accept-Encoding: gzip, deflate` when the header is absent,
+      // which would negotiate compression on the "uncompressed" control
+      // request.
+      const identityRes = await request(app)
+        .post('/session/gzip-large/load')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('Accept-Encoding', 'identity')
+        .send({});
+      expect(identityRes.status).toBe(200);
+      expect(identityRes.headers['content-encoding']).toBeUndefined();
+      const identityBytes = Buffer.byteLength(JSON.stringify(identityRes.body));
+
+      const gzipRes = await request(app)
+        .post('/session/gzip-large/load')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('Accept-Encoding', 'gzip, deflate, br')
+        .send({})
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (chunk) => chunks.push(chunk));
+          response.on('end', () => callback(null, Buffer.concat(chunks)));
+        });
+      expect(gzipRes.status).toBe(200);
+      expect(gzipRes.headers['content-encoding']).toBe('gzip');
+      expect(String(gzipRes.headers['vary']).toLowerCase()).toContain(
+        'accept-encoding',
+      );
+      // superagent transparently inflates the gzip layer before the parse
+      // callback runs, so res.body is the decoded JSON bytes; the wire size
+      // is carried by the rewritten Content-Length header.
+      expect(gzipRes.body.byteLength).toBe(identityBytes);
+      expect(Number(gzipRes.headers['content-length'])).toBeLessThan(
+        identityBytes / 2,
+      );
+      expect(JSON.parse(gzipRes.body.toString('utf8'))).toEqual(
+        identityRes.body,
+      );
+    });
+
     it('reports resume as unsupported for virtual subagent sessions', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -43,6 +43,7 @@ import {
   MutableOriginAllowlist,
   parseAllowOriginPatterns,
 } from './auth.js';
+import { gzipJsonResponses } from './gzip-response.js';
 import { isLoopbackBind } from './loopback-binds.js';
 import {
   CredentialStore,
@@ -2122,6 +2123,14 @@ export function createServeApp(
   }
 
   installJsonBodyParser(app);
+
+  // Gzip JSON API responses for clients that negotiate it (#6181). Mounted
+  // after authenticate + rate limiter on purpose: auth/rate-limit rejections
+  // are tiny bodies from (possibly unauthenticated) callers and must not pay
+  // a compression tax. Web Shell session loads stream multi-megabyte
+  // transcript JSON — the wrapper compresses those while leaving SSE, static
+  // assets, and attachment downloads untouched (see gzip-response.ts).
+  app.use(gzipJsonResponses());
 
   // Mutation-route gate factory. Trusted primary loopback requests have
   // operator authority; strict routes otherwise require verified credentials.


### PR DESCRIPTION
# perf(web-shell): gzip serve responses for large transcript loads

> Fixes part of #6181 (serve-layer item: "load 响应加 gzip" / add gzip to load responses)
> Branch: `perf/web-shell-gzip-transcript-6181` · base: `main` @ `92a8a8d17`

## Problem / 问题

Web Shell session loads (`POST /session/:id/load`) return the full transcript replay as a single JSON document — typically 1–5 MB for long sessions. The serve layer had **no response compression at all** (middleware chain is CORS → host → traceId → auth → rateLimiter; no `Content-Encoding` anywhere in the repo), so mobile / bandwidth-constrained clients pay the full uncompressed transfer on every session switch. This is one of the remaining root-cause layers of the mobile session-switch jank tracked in #6181.

Web Shell 的 session load（`POST /session/:id/load`）把整段 transcript 回放作为单个 JSON 返回，长会话通常 1–5 MB。serve 层此前**完全没有任何响应压缩**（中间件链为 CORS → host → traceId → auth → rateLimiter，全仓无 `Content-Encoding` 输出），移动端/弱网客户端每次切换会话都要裸传全量数据。这是 #6181 移动端切会话卡顿剩余根因层中的服务端一项。

## Solution / 方案

Add a dependency-free `gzipJsonResponses()` middleware (`packages/cli/src/serve/gzip-response.ts`) built on `node:zlib`, mounted in `server.ts` **after auth + rate limiter, before route registration**:

新增零依赖的 `gzipJsonResponses()` 中间件（基于 `node:zlib`），挂载在 `server.ts` 中 **auth + rate limiter 之后、路由注册之前**：

- Compress only when the client negotiates gzip via `Accept-Encoding` (full RFC 9110 token/q-value parsing — `gzip;q=0` is honored, so a plain substring check is not used).
- Only `application/json` bodies **≥ 1 KiB** (the `compression` middleware's default threshold — the gzip header/trailer costs more than it saves below that).
- Explicitly skips: SSE / streamed `res.write` responses, attachment (`Content-Disposition`) and range (`Content-Range`) downloads (byte-exact semantics), HEAD, 204/304/1xx, and responses that already carry a `Content-Encoding`.
- Falls back to identity when the gzip output is not smaller than the input (incompressible payloads).
- Sets `Content-Encoding: gzip`, rewrites `Content-Length` to the compressed size, appends `Vary: Accept-Encoding` on every gzip-capable response (cache correctness), and drops the identity `ETag` on the compressed path (one resource now legitimately has two representations).
- Compression runs on the **async `zlib.gzip` callback path** (`Z_DEFAULT_COMPRESSION` level 6) so the daemon's event loop keeps serving SSE frames while a large transcript is being compressed — no `gzipSync` blocking.

Design choices / 设计取舍:

- **No new dependency.** The repo has no `compression` package; a ~90-line middleware reading like the rest of `serve/` keeps the dependency surface unchanged. (If maintainers prefer the standard `compression` middleware, the tests here would transfer almost verbatim.)
- **Mounted after auth.** 401/403/429 bodies are tiny and must not spend CPU on unauthenticated callers.
- **Client needs zero changes.** Browser `fetch` + `res.json()` decompresses transparently; the SDK/CLI clients that do not send `Accept-Encoding: gzip` keep getting identity responses.

## Measured impact / 实测效果

Real-HTTP probe (express + this middleware, transcript-shaped replay JSON with realistic prose/code/tool-output diversity, deterministic PRNG), `curl --raw`:

| Payload | Identity | Gzip (wire) | Ratio | Saved |
|---|---|---|---|---|
| 1.42 MB session load | 1,486,587 B | 235,430 B | 15.8% | **84.2%** |
| 4.73 MB session load | 4,955,284 B | 776,866 B | 15.7% | **84.3%** |

- Response headers verified: `Content-Encoding: gzip`, `Vary: Accept-Encoding`, `Content-Length` = compressed size; gunzip round-trips to the exact original JSON.
- Loopback CPU cost: ~5.5 ms per 4.7 MB compression (identity 1.4 ms/req vs gzip 6.9 ms/req). On Fast 3G (~1 Mbps) the same response drops from ~40 s to ~6.3 s of transfer — the CPU cost is negligible by comparison, and the async path keeps SSE unaffected.

真实 HTTP 探针（express + 本中间件、形状贴近真实的 transcript 回放 JSON）实测：1.42 MB → 235 KB（省 84.2%）、4.73 MB → 777 KB（省 84.3%）；响应头三项齐全，gunzip 可无损还原；回环压缩 CPU 开销约 5.5 ms/4.7 MB，Fast 3G 下传输时间从约 40 s 降到约 6.3 s，且异步压缩不阻塞 SSE。

## Tests / 测试

- `packages/cli/src/serve/gzip-response.test.ts` (new, 30 tests):
  - `acceptsGzip` parsing matrix: 16 header shapes (`gzip`, `GZIP`, `gzip;q=0`, quoted q-values, mixed codings, absent/non-string headers …).
  - Middleware behavior: compresses large JSON; identity when gzip not offered / below threshold; `Vary` on pass-throughs; HEAD skipped; no double-encode; SSE and `res.write` streaming untouched; attachments untouched; non-JSON untouched; 204/304 untouched; ETag dropped on compressed path; Buffer bodies; incompressible-payload fallback; custom threshold; error-status JSON still functional.
- `packages/cli/src/serve/server.test.ts`: new integration test in the `POST /session/:id/load and /resume` group — real `createServeApp` + fake bridge, asserts `content-encoding`/`vary`/rewritten `content-length` and byte-exact JSON equivalence after decompression.
- Regression: full `server.test.ts` **1227/1227 passed**; `routes/session-prompt-terminals.test.ts` 5/5; repo-root `npm run typecheck` clean; prettier/eslint clean on touched files.

测试覆盖：中间件单测 30 例（协商解析 16 例矩阵 + 行为 14 例：压/不压各情形、SSE/下载/HEAD/预编码跳过、不可压回退、ETag/Vary 语义、gunzip 还原等价）；server 集成测试 1 例（真实 app + load 路径）；全量 `server.test.ts` 回归 1227/1227；根 typecheck 通过；prettier/eslint 干净。

## Notes for reviewers / 审阅备注

- Out of scope here (follow-up layers of #6181): client-side session-switch caching, Shiki viewport gating, non-virtualized `content-visibility`, and the `rawOutput`/`details` duplication reduction.
- Two `tsc` errors that appear in a fresh checkout (`BundledSkillLoader.ts` / `SkillCommandLoader.ts` importing `applySkillSideEffects`) are pre-existing on `main` until `@qwen-code/qwen-code-core` is rebuilt (`npm run build -w @qwen-code/qwen-code-core`); they are unrelated to this change and disappear after the rebuild.

Refs #6181