### PR TITLE
perf(web-shell): viewport-gate Shiki highlighting and skip offscreen render on the non-virtualized path (#6181)

### DIFF
--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -353,6 +353,7 @@ function mount(
     pendingApproval?: PermissionRequest | null;
     failedPromptMessageId?: string;
     onRetryFailedPrompt?: () => void;
+    virtualScrollThreshold?: number;
   } = {},
 ): HTMLElement {
   const container = document.createElement('div');
@@ -392,6 +393,7 @@ function mount(
                 onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
                 failedPromptMessageId={opts.failedPromptMessageId}
                 onRetryFailedPrompt={opts.onRetryFailedPrompt}
+                virtualScrollThreshold={opts.virtualScrollThreshold}
               />
             </TranscriptRenderModeProvider>
           </CompactModeContext.Provider>
@@ -4408,6 +4410,32 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(c.querySelectorAll(`.${styles.virtualRow}`).length).toBeGreaterThan(
       0,
     );
+  });
+
+  it('marks non-virtualized rows with content-visibility containment', () => {
+    const messages = [
+      userMsg('u1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(messages);
+
+    // Below the threshold every row mounts eagerly; each carries the
+    // content-visibility class so the engine skips offscreen layout/paint.
+    const rows = c.querySelectorAll('[data-web-shell-message-row]');
+    expect(rows.length).toBe(messages.length);
+    expect(c.querySelectorAll(`.${styles.nonVirtualRow}`).length).toBe(
+      rows.length,
+    );
+
+    // The virtualized path measures rows dynamically and must not opt in —
+    // a skipped (containment-sized) row would poison the size cache.
+    const virtual = mount([...messages], undefined, {
+      virtualScrollThreshold: 1,
+    });
+    expect(virtual.querySelectorAll(`.${styles.nonVirtualRow}`).length).toBe(0);
+    expect(virtual.querySelector(`.${styles.virtualSizer}`)).not.toBeNull();
   });
 
   it('renders the session timeline in the left gutter without expanding turns', async () => {

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -80,6 +80,23 @@
   transition: width 320ms ease;
 }
 
+/*
+ * The non-virtualized path mounts every row eagerly (below
+ * VIRTUAL_SCROLL_THRESHOLD — common on mobile, where the collapse rework
+ * shrank row counts). content-visibility: auto lets the engine skip layout
+ * and paint for rows outside the viewport while keeping them reachable by
+ * scroll-into-view and find-in-page; the `auto` prefix on
+ * contain-intrinsic-size makes the engine remember each row's real height
+ * once rendered, falling back to the ESTIMATE_MESSAGE-sized placeholder
+ * (80px, matching the virtualizer's own estimate) for never-rendered rows.
+ * Applied only here: virtualized rows are absolutely positioned and measured
+ * dynamically, and a skipped row there would poison the size cache.
+ */
+.nonVirtualRow {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 80px;
+}
+
 .loadingSkeleton {
   display: flex;
   flex-direction: column;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -5641,7 +5641,15 @@ export const MessageList = memo(
               <div
                 key={key}
                 data-index={index}
-                className={getRowClassName(item)}
+                // Offscreen rows keep their markup but skip layout/paint via
+                // CSS (see .nonVirtualRow) — the whole point of leaving the
+                // virtualizer off below the threshold is cheaper mounting,
+                // and this keeps long-but-not-virtual transcripts cheap to
+                // scroll on mobile (#6181).
+                className={joinClassNames(
+                  getRowClassName(item),
+                  styles.nonVirtualRow,
+                )}
                 data-message-row-key={String(key)}
                 data-source-block-ids={displayItemSourceBlockIds(item)}
                 data-web-shell-message-row

--- a/packages/web-shell/client/components/messages/Markdown.tsx
+++ b/packages/web-shell/client/components/messages/Markdown.tsx
@@ -16,6 +16,7 @@ import {
   writeClipboardText,
 } from '../../utils/clipboard';
 import { useCopiedFlash } from '../../hooks/useCopiedFlash';
+import { useInView } from '../../hooks/useInView';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import type { Components, Options } from 'react-markdown';
 import { isMarkdownFenceClosed } from '@datafe-open/markdown-chart';
@@ -477,6 +478,15 @@ function CodeBlock({
   const documentMode = useTranscriptRenderMode() === 'document';
   const [html, setHtml] = useState<string | null>(null);
   const [copied, flashCopied] = useCopiedFlash();
+  // Viewport gating for the settled highlight: switching back into a long
+  // session mounts every fence at once, and tokenizing all of them in the same
+  // commit is the jank #6181 describes. Blocks outside the (padded) viewport
+  // stay plain; scrolling near one re-runs the effect below and takes the
+  // normal cache → warm → cold path — for an already-highlighted block that is
+  // a synchronous cache hit.
+  const { ref: inViewRef, inView } = useInView<HTMLDivElement>({
+    rootMargin: '200px 0px',
+  });
 
   const { label, lang, resolvedLang } = resolveFenceLanguage(
     extractRawFenceLanguage(className),
@@ -486,6 +496,16 @@ function CodeBlock({
     appTheme === 'light' ? 'github-light-default' : 'github-dark-default';
 
   useEffect(() => {
+    // Offscreen blocks stay plain text: no size scan, no cache probe, no
+    // tokenization. The effect re-runs when the block crosses the padded
+    // viewport boundary (inView flips), so the highlight lands just before the
+    // block becomes visible. Setting null also drops any stale highlight from
+    // a previous incarnation of a reused CodeBlock instance.
+    if (!inView) {
+      setHtml(null);
+      return;
+    }
+
     // Stream code as plain text. Highlighting a growing fence on every chunk
     // repeatedly tokenizes its entire contents and can dominate rendering for
     // long responses; the settled render below highlights the final text once.
@@ -541,7 +561,7 @@ function CodeBlock({
     return () => {
       cancelled = true;
     };
-  }, [code, documentMode, lang, resolvedLang, shikiTheme, isStreaming]);
+  }, [code, documentMode, inView, lang, resolvedLang, shikiTheme, isStreaming]);
 
   const handleCopy = () => {
     void writeClipboardText(code)
@@ -560,7 +580,7 @@ function CodeBlock({
   }
 
   return (
-    <div className={styles.codeBlock}>
+    <div className={styles.codeBlock} ref={inViewRef}>
       <div className={styles.codeBlockHeader}>
         <span className={styles.codeBlockLang}>{label}</span>
         <button className={styles.codeBlockCopy} onClick={handleCopy}>

--- a/packages/web-shell/client/components/messages/Markdown.viewportHighlight.test.ts
+++ b/packages/web-shell/client/components/messages/Markdown.viewportHighlight.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Viewport gating for the settled Shiki highlight in CodeBlock: a fence that
+ * mounts outside the viewport must not tokenize (#6181 — switching back into
+ * a long session mounts every fence at once), and must highlight once it
+ * enters the viewport. jsdom has no IntersectionObserver, so these tests
+ * install a controllable stub; the last case verifies the fallback when the
+ * API is absent (the pre-gating behavior every other Markdown test relies on).
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getCachedHtml: vi.fn<(...args: unknown[]) => string | null>(() => null),
+  highlightToHtmlSync: vi.fn<(...args: unknown[]) => string | null>(),
+  getCodeHighlighter: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+  isTooLargeToHighlight: vi.fn<(...args: unknown[]) => boolean>(() => false),
+}));
+
+vi.mock('./codeHighlighter', () => ({
+  getCachedHtml: mocks.getCachedHtml,
+  highlightToHtmlSync: mocks.highlightToHtmlSync,
+  getCodeHighlighter: mocks.getCodeHighlighter,
+  isTooLargeToHighlight: mocks.isTooLargeToHighlight,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+class IntersectionObserverStub {
+  static instances: IntersectionObserverStub[] = [];
+  readonly callback: IntersectionObserverCallback;
+  readonly elements = new Set<Element>();
+  readonly options: IntersectionObserverInit | undefined;
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.callback = callback;
+    this.options = options;
+    IntersectionObserverStub.instances.push(this);
+  }
+
+  observe(element: Element): void {
+    this.elements.add(element);
+  }
+
+  unobserve(element: Element): void {
+    this.elements.delete(element);
+  }
+
+  disconnect(): void {
+    this.elements.clear();
+  }
+
+  /** Fires the observer callback for every observed element at once. */
+  trigger(isIntersecting: boolean): void {
+    if (this.elements.size === 0) return;
+    const entries = [...this.elements].map((target) => ({
+      target,
+      isIntersecting,
+      intersectionRatio: isIntersecting ? 1 : 0,
+    }));
+    this.callback(
+      entries as IntersectionObserverEntry[],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+const { Markdown } = await import('./Markdown');
+
+function renderMarkdown(content: string): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(createElement(Markdown, { content, isStreaming: false }));
+  });
+  return container;
+}
+
+beforeEach(() => {
+  mocks.getCachedHtml.mockReset().mockReturnValue(null);
+  mocks.isTooLargeToHighlight.mockReset().mockReturnValue(false);
+  // `typescript` is warm and highlights synchronously; every other language is
+  // cold (sync returns null → the effect takes the async load path).
+  mocks.highlightToHtmlSync
+    .mockReset()
+    .mockImplementation((code, lang) =>
+      lang === 'typescript' ? `<span data-hl>${String(code)}</span>` : null,
+    );
+  mocks.getCodeHighlighter.mockReset().mockReturnValue(new Promise(() => {}));
+  IntersectionObserverStub.instances.length = 0;
+});
+
+afterEach(() => {
+  for (const container of [...document.body.children]) container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('CodeBlock viewport-gated highlighting', () => {
+  it('does not highlight a settled block that is outside the viewport', () => {
+    vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+
+    const container = renderMarkdown('```ts\nconst aaa = 1;\n```');
+
+    // Still plain text: no highlighter call of any kind ran for the block.
+    expect(container.querySelector('[data-hl]')).toBeNull();
+    expect(mocks.highlightToHtmlSync).not.toHaveBeenCalled();
+    expect(mocks.getCachedHtml).not.toHaveBeenCalled();
+    expect(mocks.getCodeHighlighter).not.toHaveBeenCalled();
+    expect(container.querySelector('pre code')?.textContent).toContain(
+      'const aaa = 1;',
+    );
+  });
+
+  it('observes with a warm-up margin and highlights once the block enters view', () => {
+    vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+
+    const container = renderMarkdown('```ts\nconst bbb = 2;\n```');
+    expect(container.querySelector('[data-hl]')).toBeNull();
+
+    const observer = IntersectionObserverStub.instances.at(-1);
+    expect(observer).toBeDefined();
+    // The gate pre-warms: the observer margin extends past the viewport so the
+    // highlight lands before the block becomes visible.
+    expect(observer?.options?.rootMargin).toBe('200px 0px');
+    expect(observer?.elements.size).toBe(1);
+
+    act(() => observer!.trigger(true));
+
+    expect(container.querySelector('[data-hl]')?.textContent).toContain(
+      'const bbb = 2;',
+    );
+    expect(mocks.highlightToHtmlSync).toHaveBeenCalledWith(
+      'const bbb = 2;',
+      'typescript',
+      'github-dark-default',
+      true,
+    );
+  });
+
+  it('drops the highlight again when the block leaves the viewport', () => {
+    vi.stubGlobal('IntersectionObserver', IntersectionObserverStub);
+
+    const container = renderMarkdown('```ts\nconst ccc = 3;\n```');
+    const observer = IntersectionObserverStub.instances.at(-1)!;
+    act(() => observer.trigger(true));
+    expect(container.querySelector('[data-hl]')).not.toBeNull();
+
+    act(() => observer.trigger(false));
+
+    // Offscreen blocks revert to plain text, so a stale highlight can never
+    // outlive its code (the reused-instance regeneration case).
+    expect(container.querySelector('[data-hl]')).toBeNull();
+    expect(container.querySelector('pre code')?.textContent).toContain(
+      'const ccc = 3;',
+    );
+  });
+
+  it('highlights immediately when IntersectionObserver is unavailable', () => {
+    // No stub installed and jsdom ships no IntersectionObserver: the hook
+    // degrades to "in view" so highlighting behavior is unchanged.
+    expect(typeof IntersectionObserver).toBe('undefined');
+
+    const container = renderMarkdown('```ts\nconst ddd = 4;\n```');
+
+    expect(container.querySelector('[data-hl]')?.textContent).toContain(
+      'const ddd = 4;',
+    );
+    expect(mocks.highlightToHtmlSync).toHaveBeenCalled();
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.mobile-drawer-polling.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.mobile-drawer-polling.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { DaemonSessionSummary } from '@qwen-code/sdk/daemon';
+
+const {
+  connection,
+  workspace,
+  workspaceActions,
+  active,
+  useSessionCatalogPollingSpy,
+} = vi.hoisted(() => {
+  const active = {
+    sessions: [] as DaemonSessionSummary[],
+    loading: false,
+    error: null as Error | null,
+    reload: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    connection: {
+      status: 'connected' as const,
+      sessionId: null as string | null,
+      workspaceCwd: '/tmp/project',
+      capabilities: undefined as
+        | { qwenCodeVersion: string; features: string[] }
+        | undefined,
+    },
+    workspace: {
+      capabilities: undefined as
+        | { qwenCodeVersion: string; features: string[] }
+        | undefined,
+      client: {
+        workspaceByCwd: vi.fn(() => ({
+          listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+          workspaceGit: vi
+            .fn()
+            .mockResolvedValue({ v: 2, workspaceCwd: '', branch: null }),
+          listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+        })),
+      },
+      refreshCapabilities: vi.fn(),
+    },
+    workspaceActions: {
+      addWorkspace: vi.fn(),
+      removeWorkspace: vi.fn(),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+    },
+    active,
+    useSessionCatalogPollingSpy: vi.fn(),
+  };
+});
+
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
+  useConnection: () => connection,
+  useActions: () => ({ renameSession: vi.fn() }),
+  useWorkspace: () => workspace,
+  useWorkspaceActions: () => workspaceActions,
+  useSessions: () => active,
+  useChannels: () => ({
+    data: undefined,
+    catalog: [],
+    channels: {},
+    reload: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('../../session-catalog/session-catalog-hooks', () => ({
+  useWebShellSessions: () => ({
+    ...active,
+    data: active.sessions,
+    catalogQuery: {
+      routeKind: 'legacy',
+      workspaceCwd: connection.workspaceCwd,
+      options: {},
+    },
+  }),
+  useSessionCatalogController: () => ({
+    refreshQueries: vi.fn(),
+    invalidateWorkspace: vi.fn(),
+    refreshWorkspace: vi.fn(),
+    renamed: vi.fn(),
+    toggleSessionPinned: vi.fn(),
+  }),
+  useSessionCatalogPolling: useSessionCatalogPollingSpy,
+  useSessionCatalogQuery: () => ({
+    sessions: [],
+    loading: false,
+    reload: vi.fn().mockResolvedValue(undefined),
+  }),
+  useSessionCatalogQueries: () => [],
+}));
+
+const { I18nProvider } = await import('../../i18n');
+const { WebShellSidebar } = await import('./WebShellSidebar');
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+if (!globalThis.PointerEvent) {
+  globalThis.PointerEvent = MouseEvent as typeof PointerEvent;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+const capabilities = {
+  qwenCodeVersion: '1.2.3',
+  features: ['multi_workspace_sessions', 'workspace_session_metadata'],
+};
+
+function makeSession(
+  sessionId: string,
+  over: Partial<DaemonSessionSummary> = {},
+): DaemonSessionSummary {
+  return {
+    sessionId,
+    workspaceCwd: '/tmp/project',
+    displayName: `Session ${sessionId}`,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    clientCount: 0,
+    hasActivePrompt: false,
+    isArchived: false,
+    isPinned: false,
+    groupId: null,
+    color: null,
+    ...over,
+  } as DaemonSessionSummary;
+}
+
+/**
+ * jsdom ships no matchMedia, so useIsLargeScreen normally degrades to false
+ * (pre-gate behavior). These tests install the smallest stub needed to drive
+ * the mobile-drawer breakpoint explicitly.
+ */
+function installMatchMedia(mobile: boolean): void {
+  vi.stubGlobal(
+    'matchMedia',
+    (query: string): MediaQueryList =>
+      ({
+        matches: mobile && query === '(max-width: 760px)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  );
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+function renderSidebar(mobileOpen?: boolean): void {
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <WebShellSidebar
+          collapsed={false}
+          onCollapsedChange={() => {}}
+          onOpenSettings={() => {}}
+          onOpenDaemonStatus={() => {}}
+          onOpenScheduledTasks={() => {}}
+          onOpenWorkflows={() => {}}
+          onOpenGoals={() => {}}
+          onOpenSessions={() => {}}
+          onOpenSplitView={() => {}}
+          onNewSession={() => false}
+          onLoadSession={() => {}}
+          onError={() => {}}
+          {...(mobileOpen === undefined ? {} : { mobileOpen })}
+        />
+      </I18nProvider>,
+    );
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  connection.capabilities = capabilities;
+  workspace.capabilities = capabilities;
+  // A running session is what earns the 2s active cadence in the first
+  // place; every case below starts from it.
+  active.sessions = [makeSession('running', { hasActivePrompt: true })];
+  active.loading = false;
+  active.error = null;
+  useSessionCatalogPollingSpy.mockReset();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('WebShellSidebar mobile drawer polling gate (#6181)', () => {
+  it('keeps the active cadence while the mobile drawer is open', () => {
+    installMatchMedia(true);
+
+    renderSidebar(true);
+
+    expect(useSessionCatalogPollingSpy).toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      2_000,
+    );
+  });
+
+  it('degrades to the idle cadence when the mobile drawer is closed', () => {
+    installMatchMedia(true);
+
+    renderSidebar(false);
+
+    // The closed drawer hides the whole sidebar, so the running session's
+    // 2s cadence must fall back to the 30s idle cadence...
+    expect(useSessionCatalogPollingSpy).toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      30_000,
+    );
+    // ...never the active one.
+    expect(useSessionCatalogPollingSpy).not.toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      2_000,
+    );
+  });
+
+  it('never gates desktop-width viewports', () => {
+    installMatchMedia(false);
+
+    // mobileOpen defaults to false on desktop too — the gate must key on
+    // the viewport, not the prop alone.
+    renderSidebar();
+
+    expect(useSessionCatalogPollingSpy).toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      2_000,
+    );
+    expect(useSessionCatalogPollingSpy).not.toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      30_000,
+    );
+  });
+
+  it('keeps the pre-gate cadence when matchMedia is unavailable', () => {
+    // The vitest setup installs a matchMedia stub for jsdom; remove it to
+    // model environments with no matchMedia at all (SSR-style degradation).
+    // The hook must report "not mobile" and keep polling exactly as before.
+    vi.stubGlobal('matchMedia', undefined);
+    expect(typeof window.matchMedia).toBe('undefined');
+
+    renderSidebar();
+
+    expect(useSessionCatalogPollingSpy).toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      2_000,
+    );
+    expect(useSessionCatalogPollingSpy).not.toHaveBeenCalledWith(
+      workspace.client,
+      expect.anything(),
+      30_000,
+    );
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -132,6 +132,7 @@ import {
   SIDEBAR_SESSION_PREVIEW_LIMIT,
 } from '../../constants/sessions';
 import styles from './WebShellSidebar.module.css';
+import { useIsLargeScreen } from '../../hooks/useIsLargeScreen';
 import {
   useSessionCatalogController,
   useSessionCatalogPolling,
@@ -156,6 +157,9 @@ const SIDEBAR_COLLAPSE_DRAG_WIDTH =
   SIDEBAR_DRAG_VISUAL_MIN_WIDTH - SIDEBAR_COLLAPSE_DRAG_THRESHOLD;
 const ACTIVE_SESSION_POLL_INTERVAL_MS = 2000;
 const IDLE_SESSION_POLL_INTERVAL_MS = 30_000;
+// Mirrors the mobile drawer breakpoint App.tsx uses to switch the sidebar
+// between the inline rail and the overlay drawer.
+const MOBILE_DRAWER_QUERY = '(max-width: 760px)';
 const DIALOG_SESSION_LABEL_MAX_LENGTH = 96;
 const RECENT_SESSION_SECTION_ID = 'recent';
 const GROUP_MENU_WIDTH = 240;
@@ -2315,9 +2319,20 @@ export function WebShellSidebar({
             : 'sidebar.completedUnread',
       )
     : undefined;
+  // Mobile drawer gate (#6181): with the drawer closed the whole sidebar is
+  // translated off-canvas, so a 2s active cadence refetches data nobody can
+  // see — exactly the post-switch window that must stay smooth. Degrade to
+  // the idle cadence instead of pausing so collapsed status badges and the
+  // reopen snapshot stay eventually correct. Desktop never matches the
+  // mobile breakpoint, and where matchMedia is unavailable (SSR, jsdom) the
+  // hook reports false, keeping polling exactly as before.
+  const mobileDrawerHidden =
+    useIsLargeScreen(MOBILE_DRAWER_QUERY) && !mobileOpen;
   const sessionPollInterval =
     projectExpanded || hasRunningSession || selectedSessionSource === 'channel'
-      ? (hasRunningSession || selectedSessionSource === 'channel') && !error
+      ? (hasRunningSession || selectedSessionSource === 'channel') &&
+        !error &&
+        !mobileDrawerHidden
         ? ACTIVE_SESSION_POLL_INTERVAL_MS
         : IDLE_SESSION_POLL_INTERVAL_MS
       : undefined;

--- a/packages/web-shell/client/hooks/useInView.ts
+++ b/packages/web-shell/client/hooks/useInView.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+export interface UseInViewOptions {
+  /**
+   * Margin grown around the viewport before an element counts as visible, so
+   * nearby work (syntax highlighting, chart rendering) can start slightly
+   * before the element actually scrolls into view. Defaults to no margin.
+   */
+  rootMargin?: string;
+}
+
+export interface UseInViewResult<T extends Element> {
+  ref: RefObject<T | null>;
+  /** False until the element intersects the (padded) viewport. */
+  inView: boolean;
+}
+
+function supportsIntersectionObserver(): boolean {
+  return typeof IntersectionObserver !== 'undefined';
+}
+
+/**
+ * Tracks whether an element is inside the viewport via IntersectionObserver.
+ *
+ * Seeds `inView` from feature support rather than optimism: with a real
+ * observer the element is presumed offscreen until the first callback fires,
+ * which is what lets consumers defer work for below-the-fold content. Where
+ * the API is unavailable (SSR, jsdom), degrades to `true` so consumers keep
+ * their pre-gating behavior instead of never running at all.
+ */
+export function useInView<T extends Element>(
+  options: UseInViewOptions = {},
+): UseInViewResult<T> {
+  const { rootMargin } = options;
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(() => !supportsIntersectionObserver());
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || !supportsIntersectionObserver()) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) setInView(entry.isIntersecting);
+      },
+      { rootMargin },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [rootMargin]);
+
+  return { ref, inView };
+}


### PR DESCRIPTION
# perf(web-shell): viewport-gate Shiki highlighting and skip offscreen render on the non-virtualized path

> Fixes part of #6181 (rendering-layer items: Shiki settled-highlight viewport gating, `content-visibility` for the non-virtualized path, and the mobile-drawer polling gate)
> Branch: `perf/web-shell-render-viewport-6181` · base: `main` @ `92a8a8d17`
> Sibling PR (independent, no code dependency): serve-layer gzip — `perf/web-shell-gzip-transcript-6181`

## Problem / 问题

Three rendering-layer leftovers of the mobile session-switch jank tracked in #6181:

1. **Settled Shiki highlighting ignores the viewport.** `CodeBlock` already renders plain text while streaming and highlights once when settled, but that settled pass runs for **every** fence as soon as it mounts. Switching back into a long session mounts dozens/hundreds of code blocks in one commit, and each one synchronously probes the cache and tokenizes — offscreen blocks included. This is a main-thread burst exactly in the post-switch window #6181 describes.
2. **The non-virtualized path mounts eagerly with no containment.** Below `VIRTUAL_SCROLL_THRESHOLD` (200 rows) `MessageList` mounts every row outright. Since the collapse rework shrank visible row counts further, mobile sessions almost never reach the threshold, so long-but-not-virtual transcripts pay full layout/paint for offscreen rows. `content-visibility: auto` is already used elsewhere in the app (`ExtensionsManagerPage`) but not here.
3. **A closed mobile drawer does not pause session polling.** The sidebar stays mounted (translated off-canvas) after the drawer closes, so the 2s active-cadence catalog polling and its VDOM reconciliation keep running against data the user cannot see — during the exact animation window where smoothness matters.

对应 #6181 修复计划中渲染层剩余的三项：

1. **Shiki settled 高亮无视口门控**：流式期间已是纯文本、settled 后单次高亮，但 settled 高亮对所有 code block 无差别执行——切回大会话时全部 fence 在同一 commit 内同步 tokenize（含视口外的），正是 issue 描述的切换后主线程突发卡顿。
2. **非虚拟化路径无 containment**：低于 200 行门槛时 MessageList 全量挂载；折叠改造后行数更少、移动端更难达标，长而不虚拟的 transcript 为视口外行支付完整 layout/paint。`content-visibility: auto` 在应用其他处已有先例（ExtensionsManagerPage），此处未用。
3. **移动端抽屉关闭不降频轮询**：抽屉关闭后 sidebar 保持 mounted（CSS 移出画布），2s 活跃轮询与 reconcile 照跑——恰逢最需要流畅的动画窗口。

## Solution / 方案

### 1. `useInView` + settled-highlight gating (`Markdown.tsx`, new `hooks/useInView.ts`)

A small `useInView` hook (IntersectionObserver, seeded offscreen; **degrades to `inView: true` when the API is absent** — SSR/jsdom keep the pre-gating behavior). `CodeBlock` attaches it with a `200px 0px` prewarm margin:

- Offscreen blocks: `setHtml(null)` — no cache probe, no size scan, no tokenization. Plain text only.
- Crossing into the padded viewport re-runs the existing effect, which takes the normal **cache → warm → cold** path; a previously highlighted block is a synchronous cache hit, so the highlight lands just before the block becomes visible.
- Leaving the viewport again drops the highlight, so a stale highlight can never outlive its code on a reused `CodeBlock` instance.
- Streaming behavior is unchanged (plain text while streaming, as before).

新增 `useInView` hook（IntersectionObserver，初始按"不在视口"播种；**API 不可用时降级为恒在视口**，SSR/jsdom 行为与改动前完全一致）。`CodeBlock` 以 200px 预热边距接入：视口外的块不探测缓存、不扫描尺寸、不 tokenize，只渲纯文本；滚入预热区后走既有 cache → warm → cold 路径（已高亮过的块是同步缓存命中，高亮在可见前落位）；再次离开视口则丢弃高亮，杜绝复用实例上的陈旧高亮。流式行为不变。

### 2. `content-visibility: auto` on non-virtualized rows (`MessageList.tsx`, `.module.css`)

Rows below the threshold now carry `content-visibility: auto` + `contain-intrinsic-size: auto 80px` (80px matches the virtualizer's own row estimate; the `auto` prefix makes the engine remember each row's real height once rendered). The browser skips layout/paint for offscreen rows while keeping them reachable by scroll-into-view and find-in-page.

The **virtualized path explicitly opts out** — its rows are absolutely positioned and measured dynamically, and a containment-sized row would poison the size cache. This is why the class is applied only on the non-virtualizer branch, and the tests pin both halves of that contract.

非虚拟化行加 `content-visibility: auto` + `contain-intrinsic-size: auto 80px`（80px 与虚拟化器自己的行高估算一致；`auto` 前缀让引擎记住每行真实高度）。浏览器跳过视口外行的 layout/paint，同时滚动定位与页内查找仍可达。虚拟化路径显式不加——其行绝对定位且动态测量，被 containment 撑高的行会污染尺寸缓存；测试同时钉住"非虚拟化行必带、虚拟化行必不带"两个方向。

### 3. Mobile-drawer polling gate (`WebShellSidebar.tsx`)

The active-cadence condition (`(hasRunningSession || channel) && !error`) gains one term: `&& !mobileDrawerHidden`, where

```ts
const mobileDrawerHidden =
  useIsLargeScreen('(max-width: 760px)') && !mobileOpen;
```

- `(max-width: 760px)` mirrors the exact breakpoint `App.tsx` uses to switch the sidebar between the inline rail and the overlay drawer.
- Closed drawer → the 2s active cadence **degrades to the existing 30s idle cadence** (not a pause): collapsed status badges and the reopen snapshot stay eventually correct, and the very next poll after reopening is at most 30s stale instead of 2s — the same staleness budget the idle cadence already grants everywhere.
- **Desktop is untouched by construction**: a desktop viewport never matches the mobile breakpoint, so `mobileDrawerHidden` is always false there regardless of `mobileOpen` (which is permanently `false` on desktop — the drawer state only drives the mobile overlay).
- Where `matchMedia` is unavailable (SSR, jsdom), `useIsLargeScreen` reports false and polling behaves exactly as before — this degradation is itself covered by a test.
- The drawer-open cadence and the desktop collapsed rail are unchanged; channel-catalog grouping polling is out of scope here (it has its own error back-off and rides far fewer deployments).

活跃轮询条件增加一项 `!mobileDrawerHidden`（移动断点匹配且抽屉关闭）。关闭时 2s 退化为既有 30s idle 档而非完全暂停：折叠徽标与重开快照保持最终一致，重开后首次刷新最多滞后 30s——与 idle 档既有的陈旧预算相同。桌面端按构造不可能命中移动断点，行为不变；无 `matchMedia` 环境降级为不 gate（有专测）。抽屉打开期间与桌面折叠栏行为不变；channel catalog 分组轮询不在本 PR 范围。

## Tests / 测试

New:

- `packages/web-shell/client/components/messages/Markdown.viewportHighlight.test.ts` (4 tests, controllable IntersectionObserver stub):
  offscreen settled block never calls any highlighter API; entering view highlights via the sync path with the `200px 0px` prewarm margin observed; leaving view drops the highlight; absent IntersectionObserver falls back to immediate highlight.
- `packages/web-shell/client/components/MessageList.dom.test.tsx` (+1 test):
  below the threshold every row carries the `nonVirtualRow` class; with the threshold forced to 1 the virtualized path renders `.virtualSizer` and **zero** rows carry it.
- `packages/web-shell/client/components/sidebar/WebShellSidebar.mobile-drawer-polling.test.tsx` (4 tests, spy on `useSessionCatalogPolling` + matchMedia stub):
  drawer open on mobile viewport → 2s; drawer closed on mobile viewport → 30s and never 2s; desktop viewport with `mobileOpen` unset → 2s and never 30s (the gate must key on the viewport, not the prop alone); no `matchMedia` at all → 2s (pre-gate behavior).

Regression:

- Full `packages/web-shell` vitest suite: **281 files / 6371 tests passed** (includes all `Markdown*`, `MessageList*`, `codeHighlighter*`, and `WebShellSidebar.*` suites — 572 tests across the Markdown/MessageList group and 405 across the sidebar group).
- `npm run typecheck` (web-shell `tsc -p tsconfig.json --noEmit`) clean; prettier + eslint clean on all touched files.

新增测试 9 例：视口门控 4 例（stub 可控 IntersectionObserver：视口外零高亮调用、滚入预热边距内同步高亮、滚出丢弃、无 IO 降级立即高亮）；content-visibility 1 例（非虚拟化行全带 class、强制虚拟化时零行带且渲染 sizer）；抽屉 gate 4 例（移动+开=2s、移动+关=30s 且绝无 2s、桌面不误伤、无 matchMedia 不 gate）。回归：web-shell 全量 281 文件 6371 用例全过；typecheck、prettier、eslint 干净。

## Notes for reviewers / 审阅备注

- **Visual snapshots**: first-screen fences are inside the (padded) viewport, so screenshots should be unchanged; the prewarm margin means a block about to scroll in is already highlighted. If any `e2e/visuals` capture does diff, it would be a below-the-fold fence rendered plain until scrolled near — worth a look, not a functional regression.
- The three changes are behaviorally independent (different files, no shared state) but ship together as the "rendering tail" slice of the #6181 plan; splitting is trivial if reviewers prefer.
- Out of scope (other layers of #6181): serve-layer gzip (sibling PR), client-side session-switch caching, `rawOutput`/`details` duplication reduction.

Refs #6181