### PR TITLE
fix(cli): stop bootstrap help/version intercepts from swallowing a subcommand's free-text argument (#11193)

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -127,6 +127,78 @@ describe('resolveBootstrapRoute', () => {
     expect(resolveBootstrapRoute(['mcp', '--help'])).toBe('mcp');
   });
 
+  it('does not let the answer payload trigger a bootstrap intercept', () => {
+    // The free-text tail of `sessions answer <session>` must not reach the
+    // interceptors as flag tokens: each of these printed help/version and
+    // exited 0, telling the driving script the answer was delivered when
+    // it was not (issue #11193). The separator fences the payload off, so
+    // the argv routes to the full parser instead.
+    expect(
+      resolveBootstrapRoute([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'please',
+        '--help',
+        'me',
+      ]),
+    ).toBe('default');
+    expect(
+      resolveBootstrapRoute([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'yes',
+        'please',
+        'help',
+      ]),
+    ).toBe('default');
+    expect(
+      resolveBootstrapRoute([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'please',
+        '--version',
+        'now',
+      ]),
+    ).toBe('default');
+    // A user-supplied separator already fenced the payload; the route must
+    // not change (and the separator must not be doubled).
+    expect(
+      resolveBootstrapRoute([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        '--',
+        'please',
+        '--version',
+        'now',
+      ]),
+    ).toBe('default');
+  });
+
+  it('keeps the intercepts for every other command and shape', () => {
+    // The fence is scoped to the answer payload: version tokens elsewhere
+    // keep the fail-closed intercept (issue #11193's guardrail — demoting
+    // those executes subcommands).
+    expect(resolveBootstrapRoute(['sessions', 'list', '-v'])).toBe('version');
+    expect(resolveBootstrapRoute(['sessions', 'ps', '--version'])).toBe(
+      'version',
+    );
+    expect(
+      resolveBootstrapRoute(['mcp', 'remove', 'victim', '-v', 'help']),
+    ).toBe('version');
+    // `qwen sessions answer --help` (no id) and a bare `--help` payload
+    // keep routing to the parser, which shows the command's help.
+    expect(resolveBootstrapRoute(['sessions', 'answer', '--help'])).toBe(
+      'default',
+    );
+    expect(
+      resolveBootstrapRoute(['sessions', 'answer', '0f8e1c42', '--help']),
+    ).toBe('default');
+  });
+
   it('keeps bundled entrypoint paths out of the route detection', async () => {
     expect(resolveBootstrapRoute(['/repo/dist/cli.js', '--help'])).toBe('help');
     expect(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import {
 } from './config/top-level-options.js';
 import { clearInheritedPeerMessagingEnv } from './peerMessaging/env.js';
 import { normalizeServeFastPathArgv } from './utils/serve-fast-path-argv.js';
+import { insertSessionAnswerSeparator } from './utils/session-answer-argv.js';
 import { initStartupProfiler } from './utils/startupProfiler.js';
 import { initCpuProfiler } from './utils/cpuProfiler.js';
 import {
@@ -322,7 +323,16 @@ function normalizeMcpFastPathArgv(argv: readonly string[]): readonly string[] {
 export function resolveBootstrapRoute(
   rawArgv: readonly string[],
 ): BootstrapRoute {
-  const argv = normalizeServeFastPathArgv(rawArgv);
+  // Fence the `sessions answer <session> <free text...>` payload off from
+  // the scans below before they run: an answer that quotes `--help`,
+  // `--version` or ends in a bare `help` would otherwise be swallowed by
+  // an intercept that prints help/version and exits 0, telling the driving
+  // script the answer was delivered when it was not (issue #11193). After
+  // the separator every later token is positional data to these scans by
+  // construction, so no intercept fires on the payload.
+  const argv = insertSessionAnswerSeparator(
+    normalizeServeFastPathArgv(rawArgv),
+  );
 
   // Base-parity version intercept (structural close). Base printed the
   // version for any `-v`/`--version` token its hasFlag scan reached, no

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -318,6 +318,65 @@ describe('parseArguments', () => {
     }
   });
 
+  it('does not let a sessions-answer payload quote help into the help intercept', async () => {
+    // Issue #11193: a free-text answer that quotes `--help` (or ends in a
+    // bare `help`) made the root parser print the usage block and exit 0,
+    // so the driving script read success while the answer was never
+    // delivered. The separator fences the payload off, so the parse takes
+    // the strict unknown-command failure instead — loud, non-zero. (The
+    // yargs parser holds the test runner's process.exit stub, so the
+    // rejection message itself carries the exit code it asked for.)
+    const swallowArgv = [
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      'please',
+      '--help',
+      'me',
+    ];
+    const bareHelpArgv = [
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      'yes',
+      'please',
+      'help',
+    ];
+    for (const answerArgv of [swallowArgv, bareHelpArgv]) {
+      process.argv = ['node', 'script.js', ...answerArgv];
+      await expect(parseArguments()).rejects.toThrow(
+        'process.exit unexpectedly called with "1"',
+      );
+    }
+  });
+
+  it('keeps a bare --help answer showing help rather than delivering it', async () => {
+    // The carve-out the answer command's positional documents: a payload
+    // that is exactly `--help` keeps reaching the parser as the help
+    // flag, so it still shows help (exit 0) instead of answering with the
+    // literal text `--help`.
+    process.argv = [
+      'node',
+      'script.js',
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      '--help',
+    ];
+    const output: string[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation((...args) => {
+      output.push(args.join(' '));
+    });
+    try {
+      await expect(parseArguments()).rejects.toThrow(
+        'process.exit unexpectedly called with "0"',
+      );
+      expect(output.join('')).toContain('qwen sessions');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   it('should throw an error when both --prompt and --prompt-interactive are used together', async () => {
     process.argv = [
       'node',

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -71,6 +71,7 @@ import { randomUUID } from 'node:crypto';
 import stripJsonComments from 'strip-json-comments';
 
 import { resolvePath } from '../utils/resolvePath.js';
+import { insertSessionAnswerSeparator } from '../utils/session-answer-argv.js';
 import {
   TOP_LEVEL_GLOBAL_OPTIONS,
   DEFAULT_COMMAND,
@@ -578,6 +579,15 @@ export async function parseArguments(): Promise<CliArgs> {
   ) {
     rawArgv = rawArgv.slice(1);
   }
+
+  // Fence the free-text answer payload off from the root parse: a quoted
+  // `--help`/`--version` (or a bare trailing `help`) inside `qwen sessions
+  // answer <session> <text...>` would otherwise print the usage block or
+  // strip the token from the text and exit 0, so the answer is silently
+  // never delivered (issue #11193). After the separator the payload is
+  // positional data to this parse; the answer command splices the first
+  // `--` back out of its raw-args tail, so the text arrives verbatim.
+  rawArgv = insertSessionAnswerSeparator(rawArgv);
 
   const yargsInstance = yargs(rawArgv)
     .locale('en')

--- a/packages/cli/src/utils/session-answer-argv.test.ts
+++ b/packages/cli/src/utils/session-answer-argv.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { insertSessionAnswerSeparator } from './session-answer-argv.js';
+
+describe('insertSessionAnswerSeparator', () => {
+  it('inserts -- between the session id and a free-text payload', () => {
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'yes, go ahead',
+      ]),
+    ).toEqual(['sessions', 'answer', '0f8e1c42', '--', 'yes, go ahead']);
+  });
+
+  it('fences a payload that quotes help/version tokens', () => {
+    // The three shapes from issue #11193's reproduction table.
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'please',
+        '--help',
+        'me',
+      ]),
+    ).toEqual([
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      '--',
+      'please',
+      '--help',
+      'me',
+    ]);
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'yes',
+        'please',
+        'help',
+      ]),
+    ).toEqual([
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      '--',
+      'yes',
+      'please',
+      'help',
+    ]);
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        'please',
+        '--version',
+        'now',
+      ]),
+    ).toEqual([
+      'sessions',
+      'answer',
+      '0f8e1c42',
+      '--',
+      'please',
+      '--version',
+      'now',
+    ]);
+  });
+
+  it('does not touch other commands or unprefixed argv', () => {
+    const untouched: string[][] = [
+      ['--help'],
+      ['--version'],
+      ['sessions', 'list'],
+      ['sessions', 'ps', '--json'],
+      ['mcp', 'remove', 'victim', '-v', 'help'],
+      ['peek', '0f8e1c42'],
+      ['answer', '0f8e1c42', 'yes'],
+    ];
+    for (const argv of untouched) {
+      expect(insertSessionAnswerSeparator(argv)).toEqual(argv);
+    }
+  });
+
+  it('keeps a missing or flag-like session id for the parser to reject', () => {
+    expect(insertSessionAnswerSeparator(['sessions', 'answer'])).toEqual([
+      'sessions',
+      'answer',
+    ]);
+    // `qwen sessions answer --help` (no id) still routes to the command's
+    // help; the demandOption error for a missing id is yargs' to raise.
+    expect(
+      insertSessionAnswerSeparator(['sessions', 'answer', '--help']),
+    ).toEqual(['sessions', 'answer', '--help']);
+    expect(insertSessionAnswerSeparator(['sessions', 'answer', '-v'])).toEqual([
+      'sessions',
+      'answer',
+      '-v',
+    ]);
+  });
+
+  it('keeps a bare --help payload showing help (the documented carve-out)', () => {
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        '--help',
+      ]),
+    ).toEqual(['sessions', 'answer', '0f8e1c42', '--help']);
+    expect(
+      insertSessionAnswerSeparator(['sessions', 'answer', '0f8e1c42', '-h']),
+    ).toEqual(['sessions', 'answer', '0f8e1c42', '-h']);
+    // Only the bare form: `--help` with a sibling token is answer text.
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        '--help',
+        'me',
+      ]),
+    ).toEqual(['sessions', 'answer', '0f8e1c42', '--', '--help', 'me']);
+  });
+
+  it('does not double a user-supplied separator', () => {
+    expect(
+      insertSessionAnswerSeparator([
+        'sessions',
+        'answer',
+        '0f8e1c42',
+        '--',
+        '--force',
+      ]),
+    ).toEqual(['sessions', 'answer', '0f8e1c42', '--', '--force']);
+  });
+
+  it('leaves an id with no payload alone', () => {
+    expect(
+      insertSessionAnswerSeparator(['sessions', 'answer', '0f8e1c42']),
+    ).toEqual(['sessions', 'answer', '0f8e1c42']);
+  });
+
+  it('returns a new array only when it inserts', () => {
+    const untouched = ['sessions', 'answer', '0f8e1c42'];
+    expect(insertSessionAnswerSeparator(untouched)).toBe(untouched);
+    const fenced = insertSessionAnswerSeparator([...untouched, 'yes']);
+    expect(fenced).not.toBe(untouched);
+    expect(untouched).toEqual(['sessions', 'answer', '0f8e1c42']);
+  });
+});

--- a/packages/cli/src/utils/session-answer-argv.ts
+++ b/packages/cli/src/utils/session-answer-argv.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fence off the free-text payload of `qwen sessions answer <session>` from
+ * every flag scan that runs before and during the yargs parse.
+ *
+ * `sessions answer` is the one command whose positional tail is arbitrary
+ * user prose, so a token like `--help`, `--version` or the bare word
+ * `help` inside the answer is indistinguishable from the flag it spells.
+ * Three interceptors act on exactly that spelling before any command
+ * handler can see it: the bootstrap version scan (`hasVersionToken` in
+ * cli.ts) prints the version and exits 0, and the root parser's
+ * `.help()`/`.version()` registrations (config.ts) print the usage block
+ * or strip the token out of the text — all with exit 0, so a script
+ * driving a background session reads success while the answer was never
+ * delivered.
+ *
+ * Inserting a single `--` right after the session id closes every one of
+ * those paths at once: tokens after `--` are positional data to yargs and
+ * to both bootstrap scans, which stop at the separator by construction.
+ * The command's own tail recovery (the raw-args tail in the `answer`
+ * command) splices the first `--` back out, so the delivered text is the
+ * argv verbatim — the separator is scaffolding, not payload.
+ *
+ * The match is a strict argv prefix rather than a positional scan: `sessions`
+ * as the first token can only be the command (nothing before it can hold a
+ * value slot), so there is no value-slot model to get wrong here. A
+ * flag-shifted shape (`qwen --debug sessions answer …`) is left to the argv
+ * scan consolidation that issue #11065 owns.
+ *
+ * Carve-outs that keep the command's documented surface intact:
+ * - `<session>` must be a real positional. `qwen sessions answer --help`
+ *   (no id) keeps routing to the command's help, and a missing id is the
+ *   parser's demandOption error to raise, not ours.
+ * - A payload that is exactly `--help` (or `-h`) keeps showing the
+ *   command's help — the bare-`--help` carve-out the positional's describe
+ *   and control-commands tests promise.
+ * - A user-supplied separator is never doubled: the tail recovery splices
+ *   only the first `--`, so a second one would leak into the answer text.
+ */
+export function insertSessionAnswerSeparator(
+  argv: readonly string[],
+): string[] {
+  if (argv[0] !== 'sessions' || argv[1] !== 'answer') {
+    return argv as string[];
+  }
+  const session = argv[2];
+  if (session === undefined || session.startsWith('-')) {
+    return argv as string[];
+  }
+  // No payload after the id: nothing to fence off.
+  if (argv.length < 4) {
+    return argv as string[];
+  }
+  if (argv[3] === '--') {
+    return argv as string[];
+  }
+  // The bare-`--help` carve-out: `answer <session> --help` shows help.
+  if (argv.length === 4 && (argv[3] === '--help' || argv[3] === '-h')) {
+    return argv as string[];
+  }
+  return [...argv.slice(0, 3), '--', ...argv.slice(3)];
+}


### PR DESCRIPTION
## What this PR does

This PR stops the bootstrap help/version intercepts from silently swallowing the free-text payload of `qwen sessions answer <session> <answer...>`. When the answer text quotes `--help`, `-h`, `--version`/`-v`, or ends in a bare `help`, the CLI used to print the usage block or the version and exit 0, so a script driving a background session (`qwen sessions answer <id> ... || fail`) read success while the answer was never delivered.

The fix inserts a single `--` separator between the session id and the answer payload, in the two places that rewrite raw argv before yargs parses it: the bootstrap route scan (`resolveBootstrapRoute` in `cli.ts`) and `parseArguments()` in `config.ts` (next to the existing entry-point-token rewrite). After the separator, every later token is positional data by construction — to the `hasVersionToken`/`hasFlag` bootstrap scans, which stop at `--`, and to the yargs parse, which cannot turn post-`--` tokens into flags or command matches. A new shared helper (`insertSessionAnswerSeparator`) implements the insertion once and is applied identically at both layers.

The carve-outs the issue demands are preserved and pinned by tests: a payload that is exactly `--help` (or `-h`) still shows the command's help instead of being delivered as the literal text `--help`; `qwen sessions answer --help` (no id) still routes to help; a user-supplied `--` is never doubled; and the fail-closed version intercept for every other command (`qwen sessions list -v`, `qwen mcp remove x -v help`, ...) is untouched — `sessions`-prefixed argv with a real `answer <id>` payload is the only shape that changes.

Note on timing: the `sessions answer` subcommand itself lands with #10949, which does not touch `cli.ts` or `config.ts`. This PR fixes the pre-existing bootstrap/root-argv half the issue was filed against, so it can merge independently and in any order. On today's `main` (without #10949) the three swallow shapes now fail loudly with the strict unknown-command error and exit 1 instead of printing help/version and exiting 0; once #10949 lands, the same argv delivers the answer verbatim — its `rawAnswerTail` cuts the text from the raw args and splices the first `--` back out, so the injected separator is scaffolding that never reaches the answer text.

## Why it's needed

Issue #11193: the bootstrap layer runs its argv scans before any subcommand parses, and `sessions answer` is the first command whose positional argument is arbitrary user prose. Any answer that happens to contain a help/version token was consumed by an intercept that prints and exits 0 — the failure path is loud (`--debug` on a nonexistent flag exits 1 on stderr) while the swallow path is silent, which is the worst combination for scripted use. The issue's guardrail is that the intercepts must stay for every other command (demoting them executes subcommands — `qwen mcp remove victim -v help` would delete the server), so the fix carves the payload out at the argv layer instead of weakening any scan, exactly the "insert a single `--` after `sessions answer <session>`" shape the issue proposes.

## Reviewer Test Plan

### How to verify

Regression tests go through the real entry routes the issue names — `resolveBootstrapRoute` and `parseArguments` — not just internal helpers:

- `packages/cli/src/utils/session-answer-argv.test.ts` — the insertion matrix: the three reproduction shapes get fenced; other commands, missing/flag-like session ids, a bare `--help` payload, an existing `--`, and an id with no payload are left untouched.
- `packages/cli/src/cli.test.ts` (`resolveBootstrapRoute`) — the three reproduction argvs route to `'default'` instead of `'version'`/being swallowed, while `sessions list -v`, `mcp remove victim -v help`, `sessions answer --help` and the bare-`--help` payload keep their intercept/help behavior.
- `packages/cli/src/config/config.test.ts` (`parseArguments`, real parse with mocked `process.argv`) — the `--help`-quoting and bare-`help` answers now take the strict unknown-command failure (exit 1) instead of the help intercept (exit 0); the bare `--help` payload still shows help and exits 0.

Against a built CLI (`npm run build`, then `node packages/cli/dist/index.js ... </dev/null`), each row of the issue's reproduction table:

| command | before | after |
| --- | --- | --- |
| `qwen sessions answer <id> please --help me` | usage block on stdout, exit 0 | strict unknown-command error on stderr, exit 1 (delivers `please --help me` once #10949 lands) |
| `qwen sessions answer <id> yes please help` | usage block on stdout, exit 0 | strict unknown-command error on stderr, exit 1 (delivers `yes please help` once #10949 lands) |
| `qwen sessions answer <id> please --version now` | version on stdout, exit 0 | strict unknown-command error on stderr, exit 1 (delivers `please --version now` once #10949 lands) |
| `qwen sessions answer <id> --help` | shows help, exit 0 | unchanged — shows help, exit 0 |

### Evidence (Before & After)

Non-UI change; verification is the test suites and the built-CLI probe above. After the fix, all eight probed shapes behave as listed (three swallow shapes loud-exit 1, both `--help` carve-outs still print help with exit 0, `sessions list -v` still prints the version with exit 0, and a user-supplied `--` behaves identically to before).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

`npm ci` + `npm run build` at the repo root; unit/entry tests via `LC_ALL=en_US.UTF-8 npx vitest run` in `packages/cli`; CLI probes via `node packages/cli/dist/index.js ... </dev/null`.

## Risk & Scope

- Main risk or tradeoff: the argv prefix must match exactly (`sessions` as the first token, `answer` as the second, a non-flag session id third). A flag-shifted shape (`qwen --debug sessions answer ...`) is deliberately not fenced — recognizing it needs a value-slot scan, which is exactly the class of hand-maintained argv scans issue #11065 owns consolidating; until then those invocations keep the existing escapes (`--`, `=`-form tokens, or a version token in a base value-flag slot).
- Not validated / out of scope: end-to-end delivery of an answer with the real `sessions answer` command (it does not exist on `main` yet — it lands with #10949, whose `rawAnswerTail` and `forgetInheritedOptions` are designed to consume the fenced payload verbatim); flag-shifted invocations; interactions with #11065's upcoming scan consolidation.
- Breaking changes / migration notes: none expected. The only behavior change is on `sessions answer <id> <payload>` argv where the payload quotes help/version tokens: silent exit 0 becomes a loud exit 1 today, and correct delivery once #10949 merges. A payload that is exactly `--help`/`-h` intentionally keeps showing help.

## Linked Issues

Fixes #11193

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 修复了 bootstrap 层的 help/version 拦截静默吞掉 `qwen sessions answer <session> <answer...>` 自由文本负载的问题。此前，当回答文本中引用了 `--help`、`-h`、`--version`/`-v`，或以单独的 `help` 单词结尾时，CLI 会打印用法说明或版本号并以 exit 0 退出——驱动后台会话的脚本（`qwen sessions answer <id> ... || fail`）会读到"成功"，而回答根本没有送达。

修复方式是在 session id 与回答负载之间插入一个 `--` 分隔符，插入位置是 yargs 解析前重写 raw argv 的两处：bootstrap 路由扫描（`cli.ts` 的 `resolveBootstrapRoute`）和 `config.ts` 的 `parseArguments()`（紧挨现有的 entry-point-token 重写）。分隔符之后的每个 token 按构造就是 positional data——对遇到 `--` 即停止的 `hasVersionToken`/`hasFlag` bootstrap 扫描如此，对无法把 `--` 之后的 token 变成 flag 或 command 匹配的 yargs 解析也如此。新增的共享 helper（`insertSessionAnswerSeparator`）只实现一次插入逻辑，两层以完全相同的方式调用。

issue 要求保留的 carve-out 均已保留并由测试钉死：恰为 `--help`（或 `-h`）的负载仍然显示命令帮助而不是把字面文本 `--help` 当回答送达；`qwen sessions answer --help`（不带 id）仍然路由到帮助；用户自己提供的 `--` 不会被重复插入；对其他所有命令的 fail-closed version 拦截（`qwen sessions list -v`、`qwen mcp remove x -v help` 等）原封不动——唯一行为变化的形状是带真实 `answer <id>` 负载的 `sessions` 前缀 argv。

关于时序的说明：`sessions answer` 子命令本身随 #10949 落地，而那个 PR 不改动 `cli.ts` 和 `config.ts`。本 PR 修复的是 issue 所指向的、预先存在的 bootstrap/root-argv 半边问题，因此可以独立合并且合并顺序无关。在当前 `main` 上（还没有 #10949），三种吞没形状现在会以 strict 的 unknown-command 错误响亮地 exit 1，而不是打印 help/version 后 exit 0；一旦 #10949 落地，同样的 argv 会把回答原样送达——它的 `rawAnswerTail` 从原始 args 截取文本并把第一个 `--` 剥掉，所以注入的分隔符只是脚手架，永远不会进入回答文本。

## 为什么需要它

Issue #11193：bootstrap 层在任何子命令解析之前运行 argv 扫描，而 `sessions answer` 是第一个位置参数为任意用户文本的命令。任何恰好包含 help/version token 的回答都会被某个拦截消费掉——打印并 exit 0。失败路径是响亮的（不存在的 flag 上 `--debug` 会在 stderr 上 exit 1），而吞没路径是静默的，这对脚本化使用是最坏的组合。issue 的护栏是：对其他所有命令必须保留拦截（降级会执行子命令——`qwen mcp remove victim -v help` 会删掉 server），因此修复选择在 argv 层把负载剥出来，而不是削弱任何扫描——正是 issue 提出的"在 `sessions answer <session>` 后插入单个 `--`"方案。

## 审阅者测试计划

### 如何验证

回归测试走 issue 点名 的真实入口路由——`resolveBootstrapRoute` 和 `parseArguments`——而不只是内部 helper：

- `packages/cli/src/utils/session-answer-argv.test.ts`——插入矩阵：三个复现形状被栅栏隔离；其他命令、缺失/flag 形式的 session id、恰为 `--help` 的负载、已存在的 `--`、无负载的 id 均保持原样。
- `packages/cli/src/cli.test.ts`（`resolveBootstrapRoute`）——三个复现 argv 路由到 `'default'` 而不是 `'version'`/被吞；而 `sessions list -v`、`mcp remove victim -v help`、`sessions answer --help` 和恰为 `--help` 的负载保持其拦截/帮助行为。
- `packages/cli/src/config/config.test.ts`（`parseArguments`，mock `process.argv` 的真实解析）——引用 `--help` 的回答和以裸 `help` 结尾的回答现在走 strict 的 unknown-command 失败（exit 1）而不是 help 拦截（exit 0）；恰为 `--help` 的负载仍然显示帮助并 exit 0。

针对构建出的 CLI（`npm run build` 后 `node packages/cli/dist/index.js ... </dev/null`），issue 复现表的每一行：

| 命令 | 修复前 | 修复后 |
| --- | --- | --- |
| `qwen sessions answer <id> please --help me` | stdout 用法块，exit 0 | stderr strict unknown-command 错误，exit 1（#10949 落地后送达 `please --help me`） |
| `qwen sessions answer <id> yes please help` | stdout 用法块，exit 0 | stderr strict unknown-command 错误，exit 1（#10949 落地后送达 `yes please help`） |
| `qwen sessions answer <id> please --version now` | stdout 版本号，exit 0 | stderr strict unknown-command 错误，exit 1（#10949 落地后送达 `please --version now`） |
| `qwen sessions answer <id> --help` | 显示帮助，exit 0 | 不变——显示帮助，exit 0 |

### 证据（前后对比）

非 UI 改动；验证即上述测试套件与构建 CLI 的探测。修复后，八个探测形状全部符合预期（三个吞没形状响亮 exit 1，两个 `--help` carve-out 仍打印帮助且 exit 0，`sessions list -v` 仍打印版本且 exit 0，用户自供的 `--` 行为与之前一致）。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows  | N/A  |
|  🐧 Linux   | N/A  |

### 环境（可选）

仓库根 `npm ci` + `npm run build`；`packages/cli` 下以 `LC_ALL=en_US.UTF-8 npx vitest run` 跑单元/入口测试；`node packages/cli/dist/index.js ... </dev/null` 探测 CLI。

## 风险与范围

- 主要风险或取舍：argv 前缀必须精确匹配（第一个 token 是 `sessions`、第二个是 `answer`、第三个是非 flag 的 session id）。flag 前置形状（`qwen --debug sessions answer ...`）刻意不做栅栏——识别它需要值槽扫描，而那正是 issue #11065 负责整合的手工维护 argv 扫描类别；在那之前，这类调用保有既有的逃生通道（`--`、`=` 形式 token、或位于基础值 flag 槽位中的 version token）。
- 未验证/范围之外：与真实 `sessions answer` 命令的端到端送达（它还不在 `main` 上——随 #10949 落地，其 `rawAnswerTail` 与 `forgetInheritedOptions` 正是为原样消费栅栏化负载而设计）；flag 前置调用；与 #11065 即将进行的扫描整合的交互。
- 破坏性变更/迁移说明：预期无。唯一的行为变化发生在负载引用了 help/version token 的 `sessions answer <id> <payload>` argv 上：今天的静默 exit 0 变为响亮的 exit 1，#10949 合并后变为正确送达。恰为 `--help`/`-h` 的负载有意保留显示帮助。

## 关联 Issue

Fixes #11193

</details>