### PR TITLE
feat(mesh): add programmatic agent launch boundary

### DIFF
--- a/packages/core/src/agents/agent-transcript.ts
+++ b/packages/core/src/agents/agent-transcript.ts
@@ -110,6 +110,8 @@ export function getAgentMetaPath(
 
 export interface AgentMeta {
   agentId: string;
+  /** Durable mesh identity when this runtime belongs to the shared-thread mesh. */
+  meshAgentId?: string;
   agentType: string;
   description: string;
   /** SessionId of the user session that launched this agent. */

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -94,6 +94,14 @@ describe('BackgroundAgentResumeService', () => {
           : null,
       ),
       createAgentHeadless: vi.fn(),
+      convertToRuntimeConfig: vi.fn().mockResolvedValue({
+        promptConfig: {},
+        modelConfig: {},
+        runConfig: {},
+        toolConfig: {
+          tools: [ToolNames.READ_FILE, ToolNames.EDIT, ToolNames.SHELL],
+        },
+      }),
     };
     const hookSystem =
       options.hookSystem !== undefined
@@ -208,6 +216,7 @@ describe('BackgroundAgentResumeService', () => {
       getToolRegistry: () => stubToolRegistry,
       createToolRegistry: vi.fn().mockResolvedValue(overrideToolRegistry),
       getPermissionManager: () => permissionManager,
+      getToolInvocationGuard: () => undefined,
     } as unknown as Config;
 
     return {
@@ -800,6 +809,86 @@ describe('BackgroundAgentResumeService', () => {
       (Object.create(bgConfig) as Config).getShouldAvoidPermissionPrompts(),
     ).toBe(true);
 
+    await vi.waitFor(() => {
+      expect(registry.get(agentId)?.status).toBe('completed');
+    });
+  });
+
+  it('restores the mesh capability ceiling on cold resume', async () => {
+    const sessionId = 'session-mesh-resume';
+    const agentId = 'mesh-ag_alice';
+    const metaPath = getAgentMetaPath(tempDir, sessionId, agentId);
+    const outputFile = getAgentJsonlPath(tempDir, sessionId, agentId);
+    writeAgentMeta(metaPath, {
+      agentId,
+      meshAgentId: 'ag_alice',
+      agentType: 'researcher',
+      description: 'Review',
+      parentSessionId: sessionId,
+      parentAgentId: null,
+      createdAt: '2026-04-20T00:00:00.000Z',
+      status: 'running',
+      subagentName: 'researcher',
+      resolvedApprovalMode: 'auto-edit',
+    });
+    fs.writeFileSync(
+      outputFile,
+      JSON.stringify({
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId,
+        timestamp: '2026-04-20T00:00:00.000Z',
+        type: 'user',
+        message: { role: 'user', parts: [{ text: 'Review' }] },
+      }) + '\n',
+      'utf8',
+    );
+    registry.register({
+      agentId,
+      description: 'Review',
+      subagentType: 'researcher',
+      isBackgrounded: true,
+      status: 'paused',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      prompt: 'Review',
+      outputFile,
+      metaPath,
+    });
+    const subagent = {
+      execute: vi.fn(async () => {}),
+      setExternalMessageProvider: vi.fn(),
+      getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+      getExecutionSummary: () => ({
+        totalTokens: 0,
+        outputTokens: 0,
+        totalDurationMs: 0,
+      }),
+      getTerminateMode: () => AgentTerminateMode.GOAL,
+      getFinalText: () => 'done',
+    };
+    const { service, subagentManager } = createService();
+    subagentManager.createAgentHeadless.mockResolvedValue({
+      subagent,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await service.resumeBackgroundAgent(agentId, 'continue');
+
+    const createCall = subagentManager.createAgentHeadless.mock.calls.at(-1)!;
+    expect(createCall[2]?.toolConfigOverride).toMatchObject({
+      tools: expect.arrayContaining([ToolNames.READ_FILE, ToolNames.SHELL]),
+      disallowedTools: expect.arrayContaining([ToolNames.EDIT]),
+    });
+    const guard = (createCall[1] as Config).getToolInvocationGuard();
+    await expect(
+      guard?.({
+        callId: 'call-edit',
+        toolName: ToolNames.EDIT,
+        args: {},
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual(expect.objectContaining({ allowed: false }));
     await vi.waitFor(() => {
       expect(registry.get(agentId)?.status).toBe('completed');
     });

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -7,7 +7,11 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { Content, Part } from '@google/genai';
-import type { ApprovalModeValue, Config } from '../config/config.js';
+import {
+  deriveConfig,
+  type ApprovalModeValue,
+  type Config,
+} from '../config/config.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -82,6 +86,10 @@ import type {
   AgentBootstrapRecordPayload,
   NotificationRecordPayload,
 } from '../services/chatRecordingService.js';
+import {
+  buildMeshToolConfig,
+  createMeshToolInvocationGuard,
+} from './mesh/capability.js';
 
 const debugLogger = createDebugLogger('BACKGROUND_AGENT_RESUME');
 
@@ -915,7 +923,15 @@ export class BackgroundAgentResumeService {
         resolvedApprovalMode as ApprovalMode,
         { persistedCliFlags: meta.persistedCliFlags },
       );
-      const activeAgentConfig = approvalOverride.config;
+      const approvalConfig = approvalOverride.config;
+      const activeAgentConfig = meta.meshAgentId
+        ? deriveConfig(approvalConfig, {
+            getToolInvocationGuard: () =>
+              createMeshToolInvocationGuard(
+                approvalConfig.getToolInvocationGuard(),
+              ),
+          })
+        : approvalConfig;
       const activeRestoreParentPM = approvalOverride.cleanup;
       agentConfig = activeAgentConfig;
       restoreParentPM = activeRestoreParentPM;
@@ -1008,6 +1024,14 @@ export class BackgroundAgentResumeService {
           launchModel && meta.persistedCliFlags?.authType
             ? { ...target.subagentConfig!, model: 'inherit' }
             : target.subagentConfig!;
+        const meshRuntimeConfig = meta.meshAgentId
+          ? await this.config
+              .getSubagentManager()
+              .convertToRuntimeConfig(target.subagentConfig!, activeAgentConfig)
+          : undefined;
+        const meshToolConfig = meta.meshAgentId
+          ? buildMeshToolConfig(meshRuntimeConfig?.toolConfig)
+          : undefined;
         const result = await this.config
           .getSubagentManager()
           .createAgentHeadless(resumeSubagentConfig, activeAgentConfig, {
@@ -1032,6 +1056,7 @@ export class BackgroundAgentResumeService {
                   },
                 }
               : {}),
+            ...(meshToolConfig ? { toolConfigOverride: meshToolConfig } : {}),
           });
         subagent = result.subagent;
         // Per-spawn cleanup from `SubagentManager.createAgentHeadless` —

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -29,4 +29,7 @@ export {
   sanitizeFilenameComponent,
 } from './agent-transcript.js';
 export type { AgentTrace, AgentTraceNode } from './agent-transcript.js';
+export { launchMeshAgent } from './mesh/launcher.js';
+export type { MeshAgentLaunchResult } from './mesh/launcher.js';
+export type { MeshAgent } from './mesh/types.js';
 export * from './tasks/types.js';

--- a/packages/core/src/agents/mesh/capability.test.ts
+++ b/packages/core/src/agents/mesh/capability.test.ts
@@ -11,6 +11,7 @@ import {
   buildMeshToolConfig,
   checkMeshShellCommand,
   classifyMeshTool,
+  createMeshToolInvocationGuard,
   MESH_THREAD_TOOL_NAMES,
   MESH_TOOL_CLASSIFICATION,
 } from './capability.js';
@@ -43,12 +44,10 @@ describe('mesh capability boundary', () => {
 
   it('applies the built-in ceiling and always adds thread tools', () => {
     const full = buildMeshToolConfig();
-    const wildcard = buildMeshToolConfig(['*']);
-    const narrowed = buildMeshToolConfig([
-      ToolNames.READ_FILE,
-      ToolNames.EDIT,
-      'mcp__server__read',
-    ]);
+    const wildcard = buildMeshToolConfig({ tools: ['*'] });
+    const narrowed = buildMeshToolConfig({
+      tools: [ToolNames.READ_FILE, ToolNames.EDIT, 'mcp__server__read'],
+    });
 
     expect(wildcard).toEqual(full);
     expect(full.tools).toContain(ToolNames.SHELL);
@@ -66,6 +65,22 @@ describe('mesh capability boundary', () => {
     ]);
     expect(narrowed.executionAllowedTools).toEqual(narrowed.tools);
     expect(narrowed.disallowedTools).toEqual(full.disallowedTools);
+  });
+
+  it('preserves definition execution and disallow restrictions', () => {
+    const narrowed = buildMeshToolConfig({
+      tools: ['*'],
+      executionAllowedTools: [ToolNames.READ_FILE, ToolNames.SHELL],
+      disallowedTools: [ToolNames.READ_FILE, 'thread_post'],
+    });
+
+    expect(narrowed.tools).toEqual([
+      ToolNames.SHELL,
+      ...MESH_THREAD_TOOL_NAMES,
+    ]);
+    expect(narrowed.executionAllowedTools).toEqual(narrowed.tools);
+    expect(narrowed.disallowedTools).not.toContain('thread_post');
+    expect(narrowed.disallowedTools).toContain(ToolNames.READ_FILE);
   });
 
   it.each(['cat package.json', 'git status', 'grep -r TODO packages/core'])(
@@ -88,5 +103,34 @@ describe('mesh capability boundary', () => {
       allowed: false,
       reason: expect.stringContaining(safety),
     });
+  });
+
+  it('enforces the boundary at invocation time', async () => {
+    const guard = createMeshToolInvocationGuard();
+    const base = { callId: 'call-1', signal: new AbortController().signal };
+    await expect(
+      guard({
+        ...base,
+        toolName: ToolNames.EDIT,
+        args: {},
+        cwd: process.cwd(),
+      }),
+    ).resolves.toEqual(expect.objectContaining({ allowed: false }));
+    await expect(
+      guard({
+        ...base,
+        toolName: ToolNames.SHELL,
+        args: { command: 'git push' },
+        cwd: process.cwd(),
+      }),
+    ).resolves.toEqual(expect.objectContaining({ allowed: false }));
+    await expect(
+      guard({
+        ...base,
+        toolName: ToolNames.SHELL,
+        args: { command: 'git status' },
+        cwd: process.cwd(),
+      }),
+    ).resolves.toEqual({ allowed: true });
   });
 });

--- a/packages/core/src/agents/mesh/capability.ts
+++ b/packages/core/src/agents/mesh/capability.ts
@@ -5,6 +5,10 @@
  */
 
 import type { ToolConfig } from '../runtime/agent-types.js';
+import {
+  evaluateToolInvocationGuard,
+  type ToolInvocationGuard,
+} from '../../core/tool-invocation-guard.js';
 import { ToolNames } from '../../tools/tool-names.js';
 import { classifyShellCommandSafetyInDirectory } from '../../utils/shellAstParser.js';
 
@@ -90,24 +94,42 @@ export function classifyMeshTool(name: string): MeshToolClassification {
   ];
 }
 
-export function buildMeshToolConfig(
-  definitionTools?: readonly string[],
-): ToolConfig {
-  const allowAll =
-    definitionTools === undefined || definitionTools.includes('*');
-  const allowed = allowAll
+export function buildMeshToolConfig(definition?: ToolConfig): ToolConfig {
+  const allowAll = definition === undefined || definition.tools.includes('*');
+  let allowed = allowAll
     ? Object.entries(MESH_TOOL_CLASSIFICATION)
         .filter(([, classification]) => classification === 'allow')
         .map(([name]) => name)
-    : definitionTools.filter((name) => classifyMeshTool(name) === 'allow');
+    : definition.tools
+        .map((tool) => (typeof tool === 'string' ? tool : tool.name))
+        .filter(
+          (name): name is string =>
+            typeof name === 'string' && classifyMeshTool(name) === 'allow',
+        );
+  if (definition?.executionAllowedTools !== undefined) {
+    const executable = new Set(definition.executionAllowedTools);
+    allowed = allowed.filter((name) => executable.has(name));
+  }
+  if (definition?.disallowedTools?.length) {
+    const disallowed = new Set(definition.disallowedTools);
+    allowed = allowed.filter((name) => !disallowed.has(name));
+  }
   const tools = Array.from(new Set([...allowed, ...MESH_THREAD_TOOL_NAMES]));
+  const threadTools = new Set<string>(MESH_THREAD_TOOL_NAMES);
 
   return {
     tools,
     executionAllowedTools: [...tools],
-    disallowedTools: Object.entries(MESH_TOOL_CLASSIFICATION)
-      .filter(([, classification]) => classification === 'deny')
-      .map(([name]) => name),
+    disallowedTools: Array.from(
+      new Set([
+        ...Object.entries(MESH_TOOL_CLASSIFICATION)
+          .filter(([, classification]) => classification === 'deny')
+          .map(([name]) => name),
+        ...(definition?.disallowedTools ?? []).filter(
+          (name) => !threadTools.has(name),
+        ),
+      ]),
+    ),
   };
 }
 
@@ -122,4 +144,44 @@ export async function checkMeshShellCommand(
         allowed: false,
         reason: `Mesh agents may only run read-only shell commands; classified as ${safety}.`,
       };
+}
+
+export function createMeshToolInvocationGuard(
+  upstream?: ToolInvocationGuard,
+): ToolInvocationGuard {
+  return async (context) => {
+    if (upstream) {
+      const upstreamDecision = await evaluateToolInvocationGuard(
+        upstream,
+        context,
+      );
+      if (!upstreamDecision.allowed) return upstreamDecision;
+    }
+
+    const classification = classifyMeshTool(context.toolName);
+    if (classification === 'deny') {
+      return {
+        allowed: false,
+        reason: `Tool "${context.toolName}" is outside the mesh read-only capability boundary.`,
+      };
+    }
+    if (context.toolName !== ToolNames.SHELL) return { allowed: true };
+    if (context.args['is_background'] === true) {
+      return {
+        allowed: false,
+        reason: 'Mesh agents may not start background shell processes.',
+      };
+    }
+    const command = context.args['command'];
+    if (typeof command !== 'string') {
+      return { allowed: false, reason: 'Mesh shell command is missing.' };
+    }
+    const directory = context.args['directory'];
+    return checkMeshShellCommand(
+      command,
+      typeof directory === 'string'
+        ? directory
+        : (context.cwd ?? process.cwd()),
+    );
+  };
 }

--- a/packages/core/src/agents/mesh/launcher.test.ts
+++ b/packages/core/src/agents/mesh/launcher.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Config } from '../../config/config.js';
+import {
+  BackgroundTaskRegistry,
+  resolveMaxConcurrentBackgroundAgents,
+} from '../background-tasks.js';
+import { ToolNames } from '../../tools/tool-names.js';
+import type { MeshAgent } from './types.js';
+
+const launchProgrammaticBackgroundAgent = vi.hoisted(() => vi.fn());
+
+vi.mock('../../tools/agent/agent.js', () => ({
+  launchProgrammaticBackgroundAgent,
+}));
+
+import { launchMeshAgent } from './launcher.js';
+
+const AGENT: MeshAgent = {
+  id: 'ag_alice',
+  name: 'alice',
+  agentType: 'reviewer',
+  createdAt: 1,
+};
+
+function config(options: {
+  definition?: { name: string; model?: string };
+  registry?: BackgroundTaskRegistry;
+}): Config {
+  const definition = options.definition;
+  const manager = {
+    loadSubagent: vi.fn().mockResolvedValue(definition),
+    convertToRuntimeConfig: vi.fn().mockResolvedValue({
+      promptConfig: {},
+      modelConfig: { model: definition?.model ?? 'model-a' },
+      runConfig: {},
+      toolConfig: {
+        tools: [ToolNames.READ_FILE, ToolNames.EDIT, ToolNames.SHELL],
+      },
+    }),
+  };
+  return {
+    getSubagentManager: () => manager,
+    getBackgroundTaskRegistry: () =>
+      options.registry ?? new BackgroundTaskRegistry(),
+    getToolInvocationGuard: () => undefined,
+    getSessionId: () => 'mesh-host-session',
+  } as unknown as Config;
+}
+
+describe('mesh launcher', () => {
+  beforeEach(() => {
+    launchProgrammaticBackgroundAgent.mockReset();
+  });
+
+  it('converts the definition and starts the fixed mesh runtime identity', async () => {
+    launchProgrammaticBackgroundAgent.mockResolvedValue({ status: 'started' });
+
+    await expect(
+      launchMeshAgent(
+        config({ definition: { name: 'reviewer' } }),
+        AGENT,
+        'go',
+      ),
+    ).resolves.toEqual({
+      status: 'started',
+      runtimeId: 'local:mesh-ag_alice',
+      backgroundAgentId: 'mesh-ag_alice',
+      sessionId: 'mesh-host-session',
+    });
+    expect(launchProgrammaticBackgroundAgent).toHaveBeenCalledWith(
+      expect.anything(),
+      { description: 'Mesh agent alice', prompt: 'go' },
+      expect.objectContaining({
+        agentId: 'mesh-ag_alice',
+        meshAgentId: 'ag_alice',
+        toolConfig: expect.objectContaining({
+          tools: expect.arrayContaining([ToolNames.READ_FILE, ToolNames.SHELL]),
+          executionAllowedTools: expect.arrayContaining([
+            ToolNames.READ_FILE,
+            ToolNames.SHELL,
+          ]),
+          disallowedTools: expect.arrayContaining([ToolNames.EDIT]),
+        }),
+      }),
+    );
+  });
+
+  it('returns agent_unavailable without creating a runtime', async () => {
+    await expect(launchMeshAgent(config({}), AGENT, 'go')).resolves.toEqual({
+      status: 'agent_unavailable',
+      error: 'Agent definition "reviewer" is unavailable.',
+    });
+    expect(launchProgrammaticBackgroundAgent).not.toHaveBeenCalled();
+  });
+
+  it('does not launch a disabled identity', async () => {
+    await expect(
+      launchMeshAgent(
+        config({ definition: { name: 'reviewer' } }),
+        { ...AGENT, enabled: false },
+        'go',
+      ),
+    ).resolves.toMatchObject({ status: 'agent_unavailable' });
+    expect(launchProgrammaticBackgroundAgent).not.toHaveBeenCalled();
+  });
+
+  it('returns capacity_wait without booking a launch at the global cap', async () => {
+    const registry = new BackgroundTaskRegistry({
+      maxConcurrentBackgroundAgents: resolveMaxConcurrentBackgroundAgents({
+        QWEN_CODE_MAX_BACKGROUND_AGENTS: '1',
+      }),
+    });
+    expect(registry.tryReserveBackgroundSlot()).toBeDefined();
+
+    await expect(
+      launchMeshAgent(
+        config({ definition: { name: 'reviewer' }, registry }),
+        AGENT,
+        'go',
+      ),
+    ).resolves.toEqual({ status: 'capacity_wait' });
+    expect(launchProgrammaticBackgroundAgent).not.toHaveBeenCalled();
+    expect(registry.getQueuedCount()).toBe(0);
+  });
+});

--- a/packages/core/src/agents/mesh/launcher.ts
+++ b/packages/core/src/agents/mesh/launcher.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { deriveConfig, type Config } from '../../config/config.js';
+import { DEFAULT_BUILTIN_SUBAGENT_TYPE } from '../../subagents/builtin-agents.js';
+import type {
+  SubagentConfig,
+  SubagentRuntimeConfig,
+} from '../../subagents/types.js';
+import { launchProgrammaticBackgroundAgent } from '../../tools/agent/agent.js';
+import {
+  buildMeshToolConfig,
+  createMeshToolInvocationGuard,
+} from './capability.js';
+import type { MeshAgent } from './types.js';
+
+export type MeshAgentLaunchResult =
+  | {
+      status: 'started';
+      runtimeId: string;
+      backgroundAgentId: string;
+      sessionId: string;
+    }
+  | { status: 'capacity_wait' }
+  | { status: 'agent_unavailable'; error: string }
+  | { status: 'launch_failed'; error: string };
+
+export async function launchMeshAgent(
+  config: Config,
+  agent: MeshAgent,
+  prompt: string,
+): Promise<MeshAgentLaunchResult> {
+  if (agent.enabled === false) {
+    return {
+      status: 'agent_unavailable',
+      error: `Agent "${agent.name}" is disabled.`,
+    };
+  }
+  const manager = config.getSubagentManager();
+  const agentType = agent.agentType ?? DEFAULT_BUILTIN_SUBAGENT_TYPE;
+  let definition: SubagentConfig;
+  let runtimeConfig: SubagentRuntimeConfig;
+  try {
+    const loadedDefinition = await manager.loadSubagent(agentType);
+    if (!loadedDefinition) {
+      return {
+        status: 'agent_unavailable',
+        error: `Agent definition "${agentType}" is unavailable.`,
+      };
+    }
+    definition = loadedDefinition;
+    if (agent.model) definition = { ...definition, model: agent.model };
+    runtimeConfig = await manager.convertToRuntimeConfig(definition, config);
+  } catch (error) {
+    return {
+      status: 'agent_unavailable',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const backgroundAgentId = `mesh-${agent.id}`;
+  if (
+    !config
+      .getBackgroundTaskRegistry()
+      .canStartBackgroundAgent(runtimeConfig.modelConfig.model)
+  ) {
+    return { status: 'capacity_wait' };
+  }
+  const guardedConfig = deriveConfig(config, {
+    getToolInvocationGuard: () =>
+      createMeshToolInvocationGuard(config.getToolInvocationGuard()),
+  });
+  try {
+    const result = await launchProgrammaticBackgroundAgent(
+      guardedConfig,
+      {
+        description: agent.description ?? `Mesh agent ${agent.name}`,
+        prompt,
+      },
+      {
+        agentId: backgroundAgentId,
+        meshAgentId: agent.id,
+        subagentConfig: definition,
+        toolConfig: buildMeshToolConfig(runtimeConfig.toolConfig),
+      },
+    );
+    if (result.status !== 'started') return result;
+    return {
+      status: 'started',
+      runtimeId: `local:${backgroundAgentId}`,
+      backgroundAgentId,
+      sessionId: config.getSessionId(),
+    };
+  } catch (error) {
+    return {
+      status: 'launch_failed',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1801,6 +1801,7 @@ export type DerivedConfigOverrides = Partial<
     | 'getDisableAllHooks'
     | 'getHookSystem'
     | 'getMessageBus'
+    | 'getToolInvocationGuard'
     | 'getAutoMemoryPrompt'
     | 'getUserMemory'
   >

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -271,6 +271,51 @@ export interface AgentParams {
   working_dir?: string;
 }
 
+export type ProgrammaticBackgroundAgentLaunchResult =
+  | { status: 'started'; backgroundAgentId: string }
+  | { status: 'capacity_wait' }
+  | { status: 'launch_failed'; error: string };
+
+interface ProgrammaticBackgroundAgentLaunchOptions {
+  agentId: string;
+  meshAgentId: string;
+  subagentConfig: SubagentConfig;
+  toolConfig: ToolConfig;
+}
+
+export async function launchProgrammaticBackgroundAgent(
+  config: Config,
+  params: Pick<AgentParams, 'description' | 'prompt'>,
+  options: ProgrammaticBackgroundAgentLaunchOptions,
+): Promise<ProgrammaticBackgroundAgentLaunchResult> {
+  const invocation = new AgentToolInvocation(
+    config,
+    config.getSubagentManager(),
+    {
+      ...params,
+      subagent_type: options.subagentConfig.name,
+      run_in_background: true,
+    },
+    undefined,
+    options,
+  );
+  const result = await invocation.execute();
+  if (invocation.programmaticStatus === 'started') {
+    return { status: 'started', backgroundAgentId: options.agentId };
+  }
+  if (invocation.programmaticStatus === 'capacity_wait') {
+    return { status: 'capacity_wait' };
+  }
+  return {
+    status: 'launch_failed',
+    error:
+      result.error?.message ??
+      (typeof result.llmContent === 'string'
+        ? result.llmContent
+        : 'Failed to launch background agent.'),
+  };
+}
+
 const debugLogger = createDebugLogger('AGENT');
 const resolvedForkProfiles = new WeakMap<AgentParams, ForkProfile>();
 const FORK_PROFILE_SAFE_MODE_ERROR =
@@ -1387,12 +1432,15 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
   private currentDisplay: AgentResultDisplay | null = null;
   private currentToolCalls: AgentResultDisplay['toolCalls'] = [];
   private callId?: string;
+  programmaticStatus: 'started' | 'capacity_wait' | 'launch_failed' =
+    'launch_failed';
 
   constructor(
     private readonly config: Config,
     private readonly subagentManager: SubagentManager,
     params: AgentParams,
     private readonly forkProfile?: ForkProfile,
+    private readonly programmatic?: ProgrammaticBackgroundAgentLaunchOptions,
   ) {
     super(params);
   }
@@ -2607,6 +2655,8 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
 
       if (isFork) {
         subagentConfig = FORK_AGENT;
+      } else if (this.programmatic) {
+        subagentConfig = this.programmatic.subagentConfig;
       } else {
         const loadedConfig = await this.subagentManager.loadSubagent(
           effectiveSubagentType,
@@ -2750,6 +2800,13 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           backgroundOwnerId,
         );
         if (!backgroundSlotReservation) {
+          if (this.programmatic) {
+            this.programmaticStatus = 'capacity_wait';
+            return this.buildSpawnBlockedResult(
+              'No background-agent capacity is currently available.',
+              'Background-agent capacity is full',
+            );
+          }
           const queuedCount = registry.getQueuedCount();
           const queueText =
             queuedCount === 0
@@ -2991,7 +3048,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       const agentIdSuffix = this.callId ?? randomUUID().slice(0, 8);
       const launchDepth = childLaunchDepth();
       const hookOpts = {
-        agentId: `${subagentConfig.name}-${agentIdSuffix}`,
+        agentId:
+          this.programmatic?.agentId ??
+          `${subagentConfig.name}-${agentIdSuffix}`,
         // Resolved config name, not the raw requested type. Hooks, spans, task
         // rows, and the meta sidecar all read this field.
         agentType: subagentConfig.name,
@@ -3057,11 +3116,15 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
             ...(shouldRunInBackground && subagentRuntimeAuthOverrides
               ? { runtimeAuthOverrides: subagentRuntimeAuthOverrides }
               : {}),
+            ...(this.programmatic
+              ? { toolConfigOverride: this.programmatic.toolConfig }
+              : {}),
           },
         );
         subagent = result.subagent;
         subagentDispose = result.dispose;
         taskPrompt = this.params.prompt;
+        toolConfig = this.programmatic?.toolConfig;
       }
       const runtimeEventEmitter =
         subagent.getCore().getEventEmitter?.() ?? this.eventEmitter;
@@ -3272,6 +3335,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         );
         writeAgentMeta(metaPath, {
           agentId: hookOpts.agentId,
+          ...(this.programmatic
+            ? { meshAgentId: this.programmatic.meshAgentId }
+            : {}),
           agentType: hookOpts.agentType,
           description: this.params.description,
           parentSessionId: sessionId,
@@ -3287,9 +3353,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           isolation: this.params.isolation,
           lastUpdatedAt: new Date().toISOString(),
           resolvedApprovalMode,
-          ...(isFork &&
-          (this.params.fork_tools !== undefined ||
-            this.forkProfile !== undefined) &&
+          ...((this.programmatic !== undefined ||
+            (isFork &&
+              (this.params.fork_tools !== undefined ||
+                this.forkProfile !== undefined))) &&
           bgToolConfig?.executionAllowedTools !== undefined
             ? {
                 executionAllowedTools: [...bgToolConfig.executionAllowedTools],
@@ -3864,6 +3931,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         );
         currentTurnPromise.catch(reportUnexpectedBackgroundError);
 
+        this.programmaticStatus = 'started';
         this.updateDisplay({ status: 'background' as const }, updateOutput);
         return {
           llmContent:


### PR DESCRIPTION
## What this PR does

This stacked prerequisite adds the runtime seam required by mesh step 4. It launches a configured background agent with a fixed mesh identity, preserves the definition's tool restrictions under the mesh read-only ceiling, returns typed capacity and launch outcomes, and restores the same capability boundary after a cold resume.

## Why it's needed

The mesh launcher must reuse the existing background-agent lifecycle without putting mesh-specific dispatch logic into that shared path. Keeping this change in a separate child PR also keeps the shared runtime hot path out of the step-4 host-session PR, as required by the implementation workflow.

## Reviewer Test Plan

### How to verify

Run the four named core test files. Confirm that a saturated background registry returns `capacity_wait` without queueing, a missing definition creates no runtime, a valid definition is converted before launch, definition-level execution/disallow restrictions cannot be widened, and a cold-resumed mesh runtime still rejects write tools.

### Evidence (Before & After)

N/A — internal runtime contract only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 218 named tests; targeted ACP bridge package build |
| 🪟 Windows | ⚠️ pending #11206 whole-branch CI |
|  🐧 Linux  | ⚠️ pending #11206 whole-branch CI |

### Environment (optional)

Node.js workspace with the existing repository dependencies.

## Risk & Scope

- Main risk or tradeoff: This touches the shared background-agent launch and cold-resume paths; normal Agent tool behavior remains on the existing branch and the new path is opt-in.
- Not validated / out of scope: Hidden host ownership, dispatcher wiring, thread tools, and live-model execution stay in later stacked steps.
- Breaking changes / migration notes: None.

## Linked Issues

Stacked prerequisite for mesh step 4 in #11206.

<details>
<summary>中文说明</summary>

## 这个 PR 做什么

这是 mesh 第 4 步的 runtime 前置子 PR。它使用固定 mesh 身份启动已配置的后台 agent，在 mesh 只读上限内保留 agent definition 自身的工具收窄规则，返回带类型的容量与启动结果，并在冷恢复后重新建立同一能力边界。

## 为什么需要

mesh launcher 需要复用现有后台 agent 生命周期，但不应把 mesh 的派发逻辑塞进共享 runtime 路径。按实现工作流把这部分单独放在子 PR，也能确保第 4 步的 host-session PR 不直接修改共享 runtime 热路径。

## Reviewer Test Plan

### 如何验证

运行四个指定的 core 测试文件。确认后台 registry 饱和时返回 `capacity_wait` 且不入队；definition 缺失时不创建 runtime；有效 definition 在启动前经过转换；definition 自身的 execution/disallow 限制不会被放宽；mesh runtime 冷恢复后仍拒绝写工具。

### 前后证据

不适用——仅内部 runtime 契约。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 218 个指定测试；定向 ACP bridge package build |
| 🪟 Windows | ⚠️ 等待 #11206 整分支 CI |
|  🐧 Linux  | ⚠️ 等待 #11206 整分支 CI |

### 环境（可选）

Node.js workspace，使用仓库现有依赖。

## 风险与范围

- 主要风险或取舍：改动了共享后台 agent 启动与冷恢复路径；普通 Agent 工具仍走原分支，新路径只在显式调用时启用。
- 未验证 / 不在范围：隐藏 host 所有权、dispatcher 接线、thread 工具和真实模型运行留在后续 stacked 步骤。
- 破坏性变更 / 迁移说明：无。

## 关联事项

#11206 中 mesh 第 4 步的 stacked 前置 PR。

</details>
