### PR TITLE
chore(core): wrap two over-width cancellation assertions

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -13373,7 +13373,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(completedCall.status).toBe('cancelled');
     expect(completedCall.response.executionStatus).toBe('cancelled');
     const responseText = JSON.stringify(completedCall.response.responseParts);
-    expect(responseText).toContain('User intentionally cancelled this tool call.');
+    expect(responseText).toContain(
+      'User intentionally cancelled this tool call.',
+    );
     expect(responseText).not.toContain('had already completed');
   });
 
@@ -13392,7 +13394,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(completedCall.response.executionStatus).toBe('cancelled');
     const responseText = JSON.stringify(completedCall.response.responseParts);
     expect(responseText).toContain('The tool had already completed');
-    expect(responseText).not.toContain('User intentionally cancelled this tool call. Stop');
+    expect(responseText).not.toContain(
+      'User intentionally cancelled this tool call. Stop',
+    );
   });
 
   // A post-execution cancellation drops the model-visible output, but the


### PR DESCRIPTION
## What this PR does

Wraps two assertions in the tool-cancellation tests whose string arguments outgrew the 80-column print width, putting each argument on its own line. Whitespace and two trailing commas only — no token changes, no behaviour change. This is Prettier's own output for the file, nothing hand-written.

## Why it's needed

`main` is red. The push run for `62588d2892` ([run 34070970087](https://github.com/QwenLM/qwen-code/actions/runs/34070970087/job/101590188894)) died in `Lint & Static` at the Prettier step:

```
Checking formatting...
[warn] packages/core/src/core/coreToolScheduler.test.ts
[warn] Code style issues found in 1 file. Run Prettier with --write to fix.
```

Every step behind that gate in the job was skipped, and every job that `needs` it was skipped too, so two long lines turned the whole run red. `Test (ubuntu-latest)` passed in the same run, so this is the only thing standing between `main` and green.

How it landed is a race rather than carelessness. The cancellation-message rewrite lengthened two short assertion strings into long ones and reached `main` without a format pass — but the green check that authorized the merge was produced seventeen hours earlier, under a Prettier lane that ran `prettier --write .` and exited 0 no matter what it rewrote. Four minutes before the merge, that lane flipped to `prettier --check .`, and nothing re-ran CI in between. ESLint cannot cover the gap: the shared config loads `eslint-config-prettier`, which disables formatting rules instead of enforcing them, so the lane that just became strict was the only enforcement point outside the pre-commit hook.

## Reviewer Test Plan

### How to verify

- Run the exact command the failing step runs: `node scripts/lint.js --prettier`. Before this PR it names the one file above and exits 1; after, it prints `All matched files use Prettier code style!` and exits 0.
- `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts` → 406 passed, 0 skipped.
- To confirm the two rewritten assertions still execute rather than being quietly filtered out: `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t 'tells the model a'` → 2 passed, 404 skipped.
- The change is provably formatting-only. Stripping all whitespace, and all commas that directly precede a closing paren, from both revisions of the file yields byte-identical strings.
- Local Prettier is 3.6.1, the exact version pinned in the lockfile, so the formatting here is what CI will compute.

### Evidence (Before & After)

N/A — non-user-visible formatting change. The gate output above is the before/after.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node 22.22.2, `npm run build --workspace=packages/core` then vitest, no sandbox involved.

## Risk & Scope

- Main risk or tradeoff: none material. The diff is whitespace and two trailing commas in a test file, and it is the formatter's own output rather than a human judgment about style.
- Not validated / out of scope: three of the nine steps that were skipped behind the gate could not be reproduced in this checkout, and I am not claiming they are green from local runs. `Check serve fast-path bundle closure` and `Check VS Code companion notices are up-to-date` fail locally because `@tanstack/react-table` is absent from `node_modules` — the same reason a local full build stops at the web-shell package, and unrelated to this diff. `Run .github/scripts helper tests` fails 42 subtests locally on macOS because the flakiness gate's integrity checks call GNU `stat -c` with no BSD `stat -f` fallback, while CI runs them on Ubuntu. All three are pre-existing local artifacts, not regressions: the helper tests fail identically at `7567824d4c`, the last `main` commit whose `Lint & Static` run was green, and no triage or flake file changed between there and this branch. The other six steps behind the gate pass locally — sensitive keyword linter, i18n check, settings schema generation, settings schema freshness, notices generation, and core subpath exports — as do ESLint on the touched file and `tsc --noEmit` on the touched package, neither of which sits behind the gate.
- Breaking changes / migration notes: none.
- Worth a follow-up, deliberately not bundled here: the merge path accepted a required check whose result was computed before a base-branch workflow change made that check stricter. Any gate that tightens will re-run this scenario against whatever PRs are in flight, and the first red appears on `main` rather than on the PR.

## Linked Issues

Refs #11109, the issue behind the Prettier gate that made this failure visible. Does not close it.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把工具取消相关测试里两个字符串实参超出 80 列打印宽度的断言换行，让每个实参各占一行。只涉及空白字符和两个尾逗号——没有 token 变化，没有行为变化。这就是 Prettier 对该文件自己的输出，没有任何手写内容。

## 为什么需要

`main` 现在是红的。`62588d2892` 的 push run（[run 34070970087](https://github.com/QwenLM/qwen-code/actions/runs/34070970087/job/101590188894)）在 `Lint & Static` 的 Prettier 步骤挂掉：

```
Checking formatting...
[warn] packages/core/src/core/coreToolScheduler.test.ts
[warn] Code style issues found in 1 file. Run Prettier with --write to fix.
```

该 job 里 gate 之后的所有步骤被跳过，所有 `needs` 它的 job 也被跳过，于是两行超长代码把整个 run 染红。同一次 run 里 `Test (ubuntu-latest)` 是成功的，所以这是 `main` 转绿之前唯一的障碍。

它是怎么进 main 的：这是一次时序竞态，而不是谁不小心。取消提示语的改写把两个短断言字符串变长了，进 `main` 前没有跑格式化——但授权那次合并的绿灯是十七小时前产出的，当时 Prettier lane 跑的还是 `prettier --write .`，无论重写了什么都退出 0。合并前四分钟，这条 lane 翻成了 `prettier --check .`，而中间没有任何东西重跑 CI。ESLint 补不上这个缺口：共享配置加载了 `eslint-config-prettier`，它是**关闭**格式规则而不是强制执行，所以刚刚变严格的这条 lane 是 pre-commit hook 之外唯一的强制点。

## Reviewer 测试计划

### 如何验证

- 跑失败步骤的原样命令：`node scripts/lint.js --prettier`。本 PR 之前它会点名上面那个文件并退出 1；之后输出 `All matched files use Prettier code style!` 并退出 0。
- `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts` → 406 passed，0 skipped。
- 确认两处被改写的断言确实还在执行、没有被悄悄过滤掉：`cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t 'tells the model a'` → 2 passed，404 skipped。
- 这次改动可证明是纯格式的。把文件两个版本里的所有空白字符、以及所有紧邻右括号前的逗号都剥掉之后，得到的字符串逐字节相同。
- 本地 Prettier 是 3.6.1，与 lockfile 里钉住的版本完全一致，所以这里的格式就是 CI 会算出来的格式。

### 证据（Before & After）

N/A——非用户可见的格式改动。上面的 gate 输出就是 before/after。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

Node 22.22.2，`npm run build --workspace=packages/core` 之后跑 vitest，不涉及 sandbox。

## 风险与范围

- 主要风险或取舍：无实质风险。diff 是一个测试文件里的空白字符和两个尾逗号，而且是格式化器自己的输出，不是人对风格的判断。
- 未验证 / 范围之外：gate 之后被跳过的九个步骤里有三个在我这份工作副本中无法复现，我不声称它们在本地是绿的。`Check serve fast-path bundle closure` 和 `Check VS Code companion notices are up-to-date` 在本地失败，原因是 `node_modules` 里缺 `@tanstack/react-table`——这也是本地全量构建停在 web-shell 包的原因，与本 diff 无关。`Run .github/scripts helper tests` 在 macOS 本地失败 42 个子测试，因为 flakiness gate 的完整性校验调用 GNU `stat -c` 且没有 BSD `stat -f` 回退，而 CI 是在 Ubuntu 上跑它们的。这三个都是既有的本地环境产物，不是回归：helper tests 在 `7567824d4c`（`Lint & Static` 上一次全绿的 `main` commit）上失败情况完全相同，且从那以后到这个分支之间没有任何 triage 或 flake 文件被改动。gate 之后其余六个步骤本地全部通过——敏感词 linter、i18n 检查、settings schema 生成、settings schema 新鲜度、notices 生成、core subpath exports；被改动文件的 ESLint 与被改动包的 `tsc --noEmit` 也通过，这两者都不在 gate 之后。
- 破坏性变更 / 迁移说明：无。
- 值得后续跟进、这里刻意不捆绑：合并路径接受了一个「其结果是在 base 分支 workflow 变更让该检查变严格之前算出来的」必需检查。任何收紧的 gate 都会对当时在飞的 PR 重演这个场景，而第一个红叉出现在 `main` 上，不是 PR 上。

## 关联 Issue

Refs #11109，即让这次失败显现出来的 Prettier gate 背后的 issue。不关闭它。

</details>
