### PR TITLE
feat(external-context): Add opt-in auto recall for administrator-owned Mem0 dialects

### DIFF
--- a/docs/design/external-context-mem0-auto-recall.md
+++ b/docs/design/external-context-mem0-auto-recall.md
@@ -105,12 +105,16 @@ Each eligible invocation starts a new Node process:
 8. Emit `{}` for missing provenance, mismatched paths, empty results, invalid
    configuration, timeouts, transport failures, or invalid provider responses.
 
-The Hook never reads or falls back to the legacy `prompt` field. Qwen currently
-omits `submitted_prompt` for tool-result continuations, retries, steering, cron,
-notifications, teammates, ACP, headless, serve, SDK, and remote-input paths, so
-those paths cannot trigger retrieval.
+The Hook never reads or falls back to the legacy `prompt` field. Eligibility
+depends on `submitted_prompt`, not the input transport: supported TUI
+submissions and headless CLI user turns supply it, including `qwen -p` and
+stream-json user messages from SDK clients. Events without this field, such as
+tool-result continuations, skip retrieval. Do not infer a TUI-only origin or
+exclude a transport merely from its name.
 
-Configuration and dialect files are bounded to 64 KiB. The long-running MCP
+Configuration and dialect paths must resolve to regular files and are bounded
+to 64 KiB. Nonblocking open and descriptor validation reject FIFOs before a
+filesystem worker can block waiting for a writer. The long-running MCP
 process reads them once at startup. The command Hook reads them once per
 eligible invocation, so administrator file changes apply to the next eligible
 submission; changing its environment or Hook registration requires restarting
@@ -129,10 +133,15 @@ Qwen.
 
 There is no retry, redirect, or cache. The Hook writes exactly one JSON object
 to stdout and emits no integration-generated stderr. Once the pinned Node
-entry point starts, all failures return `{}` with exit code zero. A launcher or
-command-resolution failure before Node starts and an outer Qwen timeout retain
-the command-Hook blocking semantics, so administrators must validate the fixed
-binary and bundle paths before rollout.
+entry point starts, handled failures return `{}` with exit code zero. The
+executable flushes stdout and explicitly exits so abandoned connections do not
+keep the event loop alive after the result is ready. Secret-assignment
+matching starts at identifier boundaries and checks the keyword separately from
+the assignment suffix, avoiding overlapping scans on repeated-keyword inputs.
+A launcher failure before Node starts or an outer Qwen timeout follows the
+command-Hook runner's own error policy; ordinary runner timeouts are nonfatal
+but delay the turn. Administrators must validate the fixed binary and bundle
+paths before rollout.
 
 Sanitization is a best-effort reduction, not DLP. The external provider may log
 the sanitized query. Retrieved content is sent to the model provider and may be
@@ -151,6 +160,13 @@ the configuration path and credential through the managed process environment,
 and copies the applicable Hook definition into an administrator-controlled
 `QWEN_HOME/settings.json`.
 
+This registration opts in every eligible input handled by that launcher,
+including headless and stream-json user turns. Administrators who want recall
+only in their interactive launcher must give automation a separate controlled
+`QWEN_HOME` without the Hook and omit its configuration and credential from the
+automation environment. A protocol-level TUI-only filter would require a
+separate Core/CLI provenance change and is outside this package-only design.
+
 The auto-recall process must not enable the package's default Extension
 manifest or configure another on-demand Mem0 MCP server. Otherwise one turn
 could produce both a deterministic Hook request and a model-selected MCP
@@ -165,8 +181,12 @@ launcher and restarts Qwen. It does not delete provider records or access logs.
 Unit tests cover strict v2/v3 parsing, canonical roots, containment, missing
 provenance, legacy-prompt isolation, input limits, credential patterns, Unicode
 bounds, one-request behavior, fail-open output, timeouts, and final context
-bounds. A local fake-provider test exercises configuration, `DialectV1`, the
-real request engine, Hook stdin/stdout, and exact outbound request shape.
+bounds. Package test commands build the shipped bundles before running tests.
+Local subprocess tests execute the Hook bundle with a fake provider and cover
+configuration, `DialectV1`, exact outbound requests, flushed Hook stdout, and
+successful process exit during a stalled TLS handshake and rejection of instance
+or dialect FIFOs. Repeated secret-keyword
+near misses are tested in bundle-importing subprocesses with a real deadline.
 
 Package verification builds both entry points and inspects `npm pack --dry-run`
 to confirm that the tarball contains the runtime, schemas, manifest,

--- a/docs/design/external-context-mem0-auto-recall.md
+++ b/docs/design/external-context-mem0-auto-recall.md
@@ -1,0 +1,175 @@
+# Mem0 External Context Auto Recall
+
+**Status:** Implemented
+
+**Date:** 2026-09-04
+
+## Decision
+
+Add an administrator-installed `UserPromptSubmit` command Hook to the public
+Mem0 External Context package. The Hook reuses the administrator-owned
+`DialectV1`, bounded request engine, and untrusted result envelope without
+changing Qwen Core or the default Extension manifest.
+
+The retrieval profiles are mutually exclusive:
+
+- **On-demand:** `InstanceConfigV2`, the default Extension manifest, and the
+  `context_search({ query })` MCP tool.
+- **Auto recall:** `InstanceConfigV3`, an administrator-installed Hook, and no
+  Mem0 External Context MCP server.
+
+The default manifest does not register the Hook. Installing or upgrading the
+Extension therefore cannot cause automatic prompt forwarding or add a process
+spawn to existing user turns. Auto recall requires both a v3 configuration and
+an explicit Hook registration in an administrator-controlled `QWEN_HOME`.
+
+## Scope
+
+### Goals
+
+- Perform at most one provider search for an eligible user submission.
+- Preserve the v2 MCP configuration and `context_search` contract.
+- Keep the endpoint, credential, scope, dialect, and repository binding outside
+  model control.
+- Use only `submitted_prompt` provenance captured before model-bound expansion.
+- Reduce accidental credential forwarding before a query leaves the host.
+- Inject only bounded, structured, untrusted user-layer context.
+- Fail open with bounded latency and no integration-generated request logs.
+
+### Non-goals
+
+- Memory creation, update, deletion, ingestion, or automatic memory extraction.
+- Built-in provider presets or provider-specific dialects.
+- Qwen Core changes or conditional Extension-manifest features.
+- DLP, user authentication, tenant authorization, or compliance audit.
+- Input paths that do not provide `submitted_prompt`.
+- Retry, redirect, cache, protocol probing, or a persistent Hook process.
+- Preventing indirect prompt injection from retrieved content.
+
+## Configuration
+
+`InstanceConfigV2` remains the exact on-demand schema. Auto recall uses a
+separate canonical schema and `schemaVersion: 3`:
+
+```json
+{
+  "schemaVersion": 3,
+  "autoRecall": {
+    "repositoryRoot": "/absolute/path/to/repository"
+  },
+  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
+  "endpoint": {
+    "origin": "https://memory.example.com",
+    "basePath": "",
+    "allowInsecureHttp": false
+  },
+  "credentialEnv": "MEMORY_API_KEY",
+  "scope": {
+    "userId": "repository-memory"
+  },
+  "timeoutMs": 1500
+}
+```
+
+The Hook and MCP entry points share
+`QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG`, but accept different configuration
+versions. The MCP loader accepts only v2 and the Hook loader accepts only v3.
+This rejects accidental cross-mode use while preserving existing deployments.
+The auto-recall timeout must be from 100 through 5000 milliseconds.
+
+`repositoryRoot` must be an existing absolute directory and cannot be a
+filesystem root. The loader resolves it through `realpath`. Each event `cwd` is
+also resolved through `realpath`; retrieval runs only for the configured root
+or a descendant. The repository check prevents accidental corpus reuse after a
+directory change. Provider-side credentials and authorization remain the
+actual security boundary.
+
+`DialectV1` is unchanged. It remains a closed administrator-owned grammar and
+cannot define arbitrary headers, templates, transformations, or write methods.
+
+## Runtime flow
+
+Each eligible invocation starts a new Node process:
+
+1. Read at most 1 MiB of Hook JSON from stdin.
+2. Require `hook_event_name: "UserPromptSubmit"`, a non-empty
+   `submitted_prompt`, and a string `cwd`.
+3. Load and validate `InstanceConfigV3`, `DialectV1`, the canonical repository
+   root, and the named credential.
+4. Resolve `cwd` and skip retrieval when it is outside the configured root.
+5. Remove fenced code, the exact configured credential, and common secret
+   shapes; collapse whitespace and keep at most 512 Unicode code points.
+6. Call the existing request engine once with the configured timeout.
+7. Return at most five results through `UserPromptSubmit.additionalContext` as
+   the existing `untrusted_external_context` envelope.
+8. Emit `{}` for missing provenance, mismatched paths, empty results, invalid
+   configuration, timeouts, transport failures, or invalid provider responses.
+
+The Hook never reads or falls back to the legacy `prompt` field. Qwen currently
+omits `submitted_prompt` for tool-result continuations, retries, steering, cron,
+notifications, teammates, ACP, headless, serve, SDK, and remote-input paths, so
+those paths cannot trigger retrieval.
+
+Configuration and dialect files are bounded to 64 KiB. The long-running MCP
+process reads them once at startup. The command Hook reads them once per
+eligible invocation, so administrator file changes apply to the next eligible
+submission; changing its environment or Hook registration requires restarting
+Qwen.
+
+## Bounds and failure semantics
+
+- Sanitizer input: 4096 Unicode code points.
+- Provider query: 512 Unicode code points.
+- Provider timeout: 100-5000 ms.
+- Internal Hook wall-clock budget: 6500 ms.
+- Qwen command-Hook timeout: 8000 ms.
+- Provider response: 1 MiB before JSON parsing.
+- Output: five items, 1000 Unicode code points per content field, and 4000
+  JavaScript code units for the serialized envelope.
+
+There is no retry, redirect, or cache. The Hook writes exactly one JSON object
+to stdout and emits no integration-generated stderr. Once the pinned Node
+entry point starts, all failures return `{}` with exit code zero. A launcher or
+command-resolution failure before Node starts and an outer Qwen timeout retain
+the command-Hook blocking semantics, so administrators must validate the fixed
+binary and bundle paths before rollout.
+
+Sanitization is a best-effort reduction, not DLP. The external provider may log
+the sanitized query. Retrieved content is sent to the model provider and may be
+persisted in the session transcript. The untrusted envelope and Qwen's reserved
+Hook-context wrapper preserve provenance but do not prevent the model from
+following malicious retrieved instructions.
+
+## Deployment
+
+The package ships `dist/auto-recall.js`, the v3 schema, and unbranded POSIX and
+Windows Hook examples. It ships no provider preset or provider dialect.
+
+The administrator installs a pinned package version at a stable absolute path,
+creates the v3 instance and dialect files outside ordinary workspaces, injects
+the configuration path and credential through the managed process environment,
+and copies the applicable Hook definition into an administrator-controlled
+`QWEN_HOME/settings.json`.
+
+The auto-recall process must not enable the package's default Extension
+manifest or configure another on-demand Mem0 MCP server. Otherwise one turn
+could produce both a deterministic Hook request and a model-selected MCP
+request. A separate pinned installation path is preferred for the Hook-only
+profile.
+
+Rollback removes the Hook registration and credential from the managed
+launcher and restarts Qwen. It does not delete provider records or access logs.
+
+## Verification
+
+Unit tests cover strict v2/v3 parsing, canonical roots, containment, missing
+provenance, legacy-prompt isolation, input limits, credential patterns, Unicode
+bounds, one-request behavior, fail-open output, timeouts, and final context
+bounds. A local fake-provider test exercises configuration, `DialectV1`, the
+real request engine, Hook stdin/stdout, and exact outbound request shape.
+
+Package verification builds both entry points and inspects `npm pack --dry-run`
+to confirm that the tarball contains the runtime, schemas, manifest,
+documentation, and unbranded Hook examples, with no provider-specific data.
+The default manifest test continues to require exactly `context_search` and no
+Hook registration.

--- a/docs/design/external-context-mem0-auto-recall.md
+++ b/docs/design/external-context-mem0-auto-recall.md
@@ -161,9 +161,11 @@ and copies the applicable Hook definition into an administrator-controlled
 `QWEN_HOME/settings.json`.
 
 This registration opts in every eligible input handled by that launcher,
-including headless and stream-json user turns. Administrators who want recall
-only in their interactive launcher must give automation a separate controlled
-`QWEN_HOME` without the Hook and omit its configuration and credential from the
+including headless and stream-json user turns. Automation can disable all Hooks
+with `--bare`, `--safe-mode`, or `disableAllHooks: true` in managed settings
+before startup. The two flags also change which customizations are loaded.
+When automation needs other Hooks, use a separate controlled `QWEN_HOME`
+without this Hook and omit its configuration and credential from the
 automation environment. A protocol-level TUI-only filter would require a
 separate Core/CLI provenance change and is outside this package-only design.
 

--- a/docs/design/external-context-mem0-extension.md
+++ b/docs/design/external-context-mem0-extension.md
@@ -1,6 +1,6 @@
 # Administrator-configured Mem0 External Context Extension
 
-**Status:** PR2 implementation
+**Status:** Implemented base integration; optional Auto Recall follow-up implemented
 
 **Date:** 2026-08-28
 
@@ -23,11 +23,19 @@ absolute dialect path. The dialect file describes request and response
 differences within the existing closed `DialectV1` grammar. Its `id` is an
 administrator-managed audit label and has no registry or file-name semantics.
 
-External Context MCP Profile v1 remains the only public Qwen interoperability
-boundary. Qwen Core does not gain a provider registry, public provider SDK,
+External Context MCP Profile v1 remains the on-demand interoperability
+boundary. The optional automatic mode uses Qwen's existing
+`UserPromptSubmit` Hook contract; it does not add a provider-specific Qwen
+interface. Qwen Core does not gain a provider registry, public provider SDK,
 dynamic module loading, or new third-party cases in its private
 `ProviderConfig` union. The existing direct integration remains available for
 compatibility and is not modified by this design.
+
+The default Extension manifest remains MCP-only. Administrators may separately
+install the package's opt-in `UserPromptSubmit` command Hook to retrieve context
+before a prompt. That deployment mode is specified in
+[Opt-in Auto Recall for Administrator-configured Mem0](./external-context-mem0-auto-recall.md)
+and is intentionally not enabled by installing the Extension.
 
 ## Goals
 
@@ -37,6 +45,8 @@ compatibility and is not modified by this design.
   endpoint, credential, scope, timeout, and dialect remain administrator-owned.
 - Preserve the bounded request engine, response normalization, and failure
   behavior already implemented by the Extension.
+- Preserve zero automatic retrieval for the default Extension installation
+  while allowing an administrator-owned Hook profile to opt in explicitly.
 - Give protocols outside the closed grammar a clear path to a separate local
   or remote MCP Extension.
 
@@ -45,10 +55,11 @@ compatibility and is not modified by this design.
 - Publish provider presets, provider-specific contract fixtures, or live
   service credentials.
 - Add ordinary Qwen settings or Extension settings for the configuration path.
-- Define arbitrary request templates, JSONPath, scripting, custom headers, or
-  executable hooks.
+- Define arbitrary request templates, JSONPath, scripting, or custom headers.
 - Probe or fall back between upstream protocol versions.
-- Add memory creation, update, deletion, Auto Recall, redirects, or retries.
+- Enable Auto Recall by default or combine the on-demand MCP and automatic Hook
+  surfaces in one installation profile.
+- Add memory creation, update, deletion, redirects, or retries.
 - Migrate or remove the existing direct External Context integration.
 
 ## Architecture
@@ -61,12 +72,15 @@ flowchart LR
     D["Administrator-owned DialectV1"] --> E
     E --> R["Bounded request engine"]
     R --> S["Compatible HTTP service"]
+    H["Optional administrator-owned UserPromptSubmit Hook"] --> R
+    A["Administrator-owned InstanceConfigV3"] --> H
 ```
 
-The local Extension owns configuration loading and HTTP translation. Qwen sees
-only the MCP profile. A service that cannot fit the bounded dialect grammar
-owns a separate MCP implementation instead of expanding the grammar or Qwen
-Core.
+The local package owns configuration loading and HTTP translation. On-demand
+retrieval reaches it through the MCP profile; the optional automatic mode
+reaches it through the existing command-Hook contract. A service that cannot
+fit the bounded dialect grammar owns a separate MCP implementation instead of
+expanding the grammar or Qwen Core.
 
 ## Version model
 
@@ -74,8 +88,9 @@ Four independent version axes remain explicit:
 
 1. **MCP Profile version** defines the Qwen-to-Extension tool contract. This
    Extension implements External Context MCP Profile v1.
-2. **Instance schema version** defines administrator binding. This design uses
-   `schemaVersion: 2`.
+2. **Instance schema version** defines administrator binding. The MCP runtime
+   uses `schemaVersion: 2`; the separate Auto Recall Hook profile uses
+   `schemaVersion: 3` so each entry point rejects the other's configuration.
 3. **Dialect version** defines interpretation of the closed request and
    response grammar. This design keeps `dialectVersion: 1` unchanged.
 4. **Upstream API version** belongs to the service and appears only in the
@@ -175,9 +190,9 @@ The grammar stays deliberately closed:
 - `threshold` and `rerank` are typed fields, not request fragments.
 
 The dialect cannot define arbitrary headers, body interpolation, JSONPath,
-code, environment-variable expansion, redirects, or response transformations.
-Its `id` does not have to match its file name or any value in the instance
-file. Administrators own its naming and versioning policy.
+code, environment-variable expansion, redirects, response transformations, or
+trigger behavior. Its `id` does not have to match its file name or any value in
+the instance file. Administrators own its naming and versioning policy.
 
 ## Startup and failure behavior
 
@@ -217,16 +232,20 @@ query, credential, or upstream response.
 
 ## Retrieval-only boundary
 
-The manifest exposes exactly `context_search`. A dialect cannot enable memory
-creation, update, deletion, or Auto Recall. Write protocols require a separate
-future profile or Extension because their idempotency, duplication, timeout,
-and authorization semantics do not fit the retrieval grammar.
+The default manifest exposes exactly `context_search` and contains no Hooks. A
+dialect cannot enable memory creation, update, deletion, or Auto Recall. The
+optional administrator-installed Hook changes only when the same bounded
+retrieval runs; it does not add write operations or expand the dialect grammar.
+Write protocols require a separate future profile or Extension because their
+idempotency, duplication, timeout, and authorization semantics do not fit the
+retrieval grammar.
 
 ## Packaging and service ownership
 
-The npm package publishes only the bundled runtime, canonical schemas,
-Extension manifest, and README. It contains no administrator dialect, provider
-preset, provider identifier, or provider-specific contract fixture.
+The npm package publishes only the bundled MCP and Auto Recall entry points,
+canonical schemas, Extension manifest, unbranded Hook configuration examples,
+and README. It contains no administrator dialect, provider preset, provider
+identifier, or provider-specific contract fixture.
 
 The public package name is `@qwen-code/external-context-mem0`. Its package and
 Extension manifest versions follow the Qwen Code release version and are
@@ -265,16 +284,20 @@ built-in provider rollout for either case.
    and profile boundary.
 4. **Distribution follow-up:** Publish the self-contained Extension through the
    normal Qwen Code npm release without adding provider data or Core wiring.
-5. Design any portable write capability separately.
+5. **Auto Recall follow-up:** Add a separately installed, administrator-owned
+   Hook profile while leaving the default manifest MCP-only.
+6. Design any portable write capability separately.
 
 There is no Qwen-maintained provider-preset PR3. Administrators own compatible
 dialect data; incompatible protocols use their own MCP Extension.
 
 ## Verification
 
-Verification covers both canonical schemas; 64 KiB file limits; unavailable,
+Verification covers all canonical schemas; 64 KiB file limits; unavailable,
 malformed, unsupported, relative, and semantically invalid configurations;
 credential ordering; synthetic GET and POST request contracts; response
-normalization; the MCP tool surface; real stdio MCP startup against a local
-synthetic HTTP service; restart-only reload behavior; package contents; build,
-typecheck, lint, and tests. No verification contacts a live provider service.
+normalization; the MCP tool surface; Hook provenance, repository containment,
+sanitization, fail-open behavior, and wall-clock bounds; real stdio MCP and Hook
+startup against local synthetic HTTP services; reload behavior; package
+contents; build, typecheck, lint, and tests. No verification contacts a live
+provider service.

--- a/integrations/external-context-mem0/README.md
+++ b/integrations/external-context-mem0/README.md
@@ -258,13 +258,26 @@ could send two searches for one turn. Use the v2 Extension profile for
 on-demand `context_search`, or the v3 Hook-only profile for Auto Recall, never
 both in one Qwen process.
 
-The Hook requires a non-empty `submitted_prompt` captured by a supported
-interactive TUI submission. It never falls back to the expanded `prompt`, so
-tool-result continuations, retries, steering, cron, notifications, teammates,
-ACP, headless, `serve`, SDK, and remote-input paths do not trigger retrieval in
-the current version. Missing provenance, invalid configuration, a cwd outside
-the repository, an empty result, timeout, or provider failure returns `{}` and
-does not block the user turn after the pinned Node entry point starts.
+The Hook requires a non-empty `submitted_prompt` captured before prompt
+expansion. This includes supported interactive TUI submissions and headless
+CLI user turns (`qwen -p` and stream-json input, including SDK clients using
+that path). The field establishes prompt provenance, not a TUI-only origin.
+The Hook never falls back to the expanded `prompt`; events without
+`submitted_prompt` do not trigger retrieval.
+
+Register this profile only in launchers where automatic retrieval is intended
+for all eligible inputs. To exclude automation, give it a separate
+administrator-controlled `QWEN_HOME` without this Hook and omit the Auto Recall
+configuration and credential from that launcher's environment. The Hook itself
+does not distinguish TUI, SDK, or other transports supplying the field.
+
+Instance and dialect paths must resolve to regular files. FIFOs and other
+special files are rejected before reading configuration.
+
+Missing provenance, invalid configuration, a cwd outside the repository, an
+empty result, timeout, or provider failure returns `{}`. The executable flushes
+stdout and exits zero even if an aborted request retains open handles, allowing
+the user turn to continue after the pinned Node entry point starts.
 
 Before sending the query, the Hook removes fenced code, the configured
 credential, and common secret shapes, then keeps at most 512 Unicode code

--- a/integrations/external-context-mem0/README.md
+++ b/integrations/external-context-mem0/README.md
@@ -1,9 +1,14 @@
 # Mem0 External Context Extension
 
-This package provides a retrieval-only External Context MCP Profile v1 server
-for administrator-configured Mem0-compatible HTTP services. It validates a
-closed dialect grammar and uses a bounded HTTP request engine; it does not ship
+This package provides retrieval-only on-demand and Auto Recall profiles for
+administrator-configured Mem0-compatible HTTP services. It validates a closed
+dialect grammar and uses a bounded HTTP request engine; it does not ship
 provider presets or provider-specific configuration.
+
+The default Extension exposes exactly one tool, `context_search({ query })`.
+Administrators can instead install the packaged `UserPromptSubmit` Hook for
+automatic retrieval. The model cannot select the endpoint, credential, scope,
+timeout, result limit, or dialect in either profile.
 
 ## Installation
 
@@ -21,39 +26,29 @@ Use an explicit package version when the deployment must remain pinned:
 qwen extensions install @qwen-code/external-context-mem0@x.y.z
 ```
 
-The Extension version follows the Qwen Code release version. Installing the
-package does not configure a memory service or install provider data; an
-administrator must supply the two files and credential environment described
-below.
+The Extension version follows the Qwen Code release version. Installation does
+not configure a memory service or install provider data. An administrator must
+supply an instance file, a dialect file, and the credential environment
+variable described below.
 
-## Configuration
+## Administrator deployment
 
-Set `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` in the Extension process environment to
-the absolute path of an administrator-owned instance JSON file. The instance
-file must conform to
-[`schemas/instance-config.schema.json`](./schemas/instance-config.schema.json)
-and reference a separate dialect JSON file by absolute `dialectPath`:
+### 1. Confirm that the upstream API fits the bounded dialect
 
-```json
-{
-  "schemaVersion": 2,
-  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
-  "endpoint": {
-    "origin": "https://memory.example.com",
-    "basePath": "",
-    "allowInsecureHttp": false
-  },
-  "credentialEnv": "MEMORY_API_KEY",
-  "scope": {
-    "userId": "repository-memory"
-  },
-  "timeoutMs": 5000
-}
-```
+The upstream search API must use a static `GET` or `POST` path, one supported
+authentication header, simple query and scope placement, and a JSON response
+that matches the supported result fields. The dialect cannot define arbitrary
+headers, request templates, JSONPath, executable transformations, redirects,
+retries, or write operations.
 
-The dialect file must conform to
-[`schemas/dialect.schema.json`](./schemas/dialect.schema.json). This synthetic
-example describes one supported shape without identifying a provider:
+If the upstream API cannot fit this grammar, implement a separate MCP Extension
+instead of weakening the boundary.
+
+### 2. Create the dialect file
+
+Store the file outside ordinary workspaces. The following unbranded template
+describes a `POST` search endpoint that receives the query and fixed user scope
+in JSON:
 
 ```json
 {
@@ -81,21 +76,248 @@ example describes one supported shape without identifying a provider:
 }
 ```
 
-The administrator controls both files and the process environment. Production
-deployments should keep them outside ordinary workspaces and supply the
-instance path through a system environment, controlled launcher, or pinned MCP
-configuration. `dialectPath` is never resolved relative to the instance file,
-expanded from environment variables, or loaded from a URL.
+Save it, for example, as
+`/etc/qwen/external-context/memory.dialect.json`. It must conform to
+[`schemas/dialect.schema.json`](./schemas/dialect.schema.json).
 
-The credential value must exist only in the environment variable named by
-`credentialEnv`; neither JSON file may contain it. Both files are limited to
-64 KiB and are read once when the Extension starts. Restart the Extension after
-changing either file.
+Use the dialect fields as follows:
 
-The schema intentionally supports only the bounded request and response
-grammar recorded in the design. Protocols that require arbitrary templates,
-headers, JSONPath, redirects, executable transformations, or write operations
-must use a separate MCP Extension.
+| Upstream contract                    | Dialect value                                |
+| ------------------------------------ | -------------------------------------------- |
+| `Authorization: Token <credential>`  | `auth: "authorization-token"`                |
+| `Authorization: Bearer <credential>` | `auth: "authorization-bearer"`               |
+| `X-API-Key: <credential>`            | `auth: "x-api-key"`                          |
+| Query string search                  | `method: "GET"` and `queryLocation: "query"` |
+| JSON request search                  | `method: "POST"` and `queryLocation: "json"` |
+| Scope at the JSON root               | `json`                                       |
+| Scope under `filters`                | `json.filters`                               |
+| Scope in the query string            | `query`                                      |
+| Scope not sent upstream              | `omit`                                       |
+| Upstream result limit                | `limitField: "limit"` or `"top_k"`           |
+| No upstream result-limit field       | `limitField: "omit"`                         |
+
+`GET` dialects cannot use JSON locations. The `response` object selects only
+the supported collection and field names; it does not contain paths or
+transformations. The dialect `id` is an administrator-owned audit label and
+does not participate in lookup or file-name matching.
+
+Optional `search.threshold` values from 0 through 1 and boolean
+`search.rerank` values are sent as query parameters for `GET` or JSON fields
+for `POST`. The complete response-field allowlists are defined by the dialect
+schema.
+
+### 3. Create the instance file
+
+The instance file binds the dialect to one endpoint, credential variable,
+fixed scope, and timeout:
+
+```json
+{
+  "schemaVersion": 2,
+  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
+  "endpoint": {
+    "origin": "https://memory.example.com",
+    "basePath": "",
+    "allowInsecureHttp": false
+  },
+  "credentialEnv": "MEMORY_API_KEY",
+  "scope": {
+    "userId": "repository-memory"
+  },
+  "timeoutMs": 5000
+}
+```
+
+Save it, for example, as
+`/etc/qwen/external-context/memory.instance.json`. It must conform to
+[`schemas/instance-config.schema.json`](./schemas/instance-config.schema.json).
+
+`dialectPath` must be an absolute local path. It is not resolved relative to
+the instance file, expanded from environment variables, or loaded from a URL.
+The old `schemaVersion: 1` and `preset` shape is intentionally unsupported.
+
+Every non-`omit` dialect scope location requires the corresponding `userId`,
+`agentId`, or `appId` in the instance file. Every `omit` location requires that
+scope value to be absent. Scope values are fixed routing inputs, not an
+authorization boundary. Use separate administrator bindings when deployments
+must access different fixed corpora.
+
+`endpoint.origin` contains only the scheme and authority. Put a shared static
+path prefix in `basePath` and the operation path in the dialect. HTTPS is
+required by default. Set `allowInsecureHttp` to `true` only for a trusted
+private-network HTTP endpoint; never send a credential over public HTTP in a
+production deployment.
+
+### 4. Protect the files and inject the environment
+
+Both JSON files are administrator-controlled configuration, even though they
+contain no credential. Restrict their ownership and permissions according to
+the host policy. For example:
+
+```bash
+install -d -m 700 /etc/qwen/external-context
+chmod 600 /etc/qwen/external-context/memory.*.json
+```
+
+These are Unix examples. On Windows, use an administrator-controlled absolute
+directory and equivalent ACLs; escape backslashes when writing the absolute
+path in JSON.
+
+Set `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` to the absolute instance-file path in
+the Qwen process environment. Separately inject the environment variable named
+by `credentialEnv` through the deployment's secret manager or service manager:
+
+```bash
+export QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG=/etc/qwen/external-context/memory.instance.json
+# The secret manager must populate and export MEMORY_API_KEY before this point.
+test -n "${MEMORY_API_KEY:-}" || exit 1
+qwen
+```
+
+The Extension inherits these values from the Qwen process. Do not put the
+credential in either JSON file, Qwen settings, a repository `.env` file, a
+launcher script, or a command-line argument. The configuration path is not an
+ordinary Qwen setting.
+
+Both files are limited to 64 KiB. The on-demand MCP process reads them once at
+startup. Restart Qwen Code after changing either file or environment value in
+that profile.
+
+### 5. Verify the deployment
+
+1. Start Qwen Code from the configured process environment.
+2. Open `/mcp` and verify that `external-context-mem0` is connected.
+3. Verify that the server exposes only `context_search`.
+4. Search for a known, non-sensitive record in the fixed scope and confirm the
+   expected result.
+5. If available, correlate the request with the upstream service access log
+   without recording the credential or response body.
+
+The Extension is retrieval-only. Provision a disposable test record through an
+administrator-approved upstream path if a known record is not already
+available; the Extension itself cannot create or delete memories.
+
+## Auto Recall profile
+
+Auto Recall retrieves external context before each eligible ordinary user
+submission. It is not enabled by the default Extension manifest. Installing or
+upgrading the Extension therefore does not automatically forward prompts or
+add a Hook process to existing turns.
+
+Use a separate `schemaVersion: 3` instance file for Auto Recall:
+
+```json
+{
+  "schemaVersion": 3,
+  "autoRecall": {
+    "repositoryRoot": "/workspace/my-repository"
+  },
+  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
+  "endpoint": {
+    "origin": "https://memory.example.com",
+    "basePath": "",
+    "allowInsecureHttp": false
+  },
+  "credentialEnv": "MEMORY_API_KEY",
+  "scope": {
+    "userId": "repository-memory"
+  },
+  "timeoutMs": 1500
+}
+```
+
+The file must conform to
+[`schemas/auto-recall-instance-config.schema.json`](./schemas/auto-recall-instance-config.schema.json).
+`repositoryRoot` must be an existing absolute directory and cannot be a
+filesystem root. Auto Recall runs only when the Hook event working directory
+is that canonical directory or one of its descendants. The provider timeout
+must be from 100 through 5000 milliseconds.
+
+Install a pinned package version at a stable administrator-controlled path,
+for example:
+
+```bash
+npm install --prefix /opt/qwen/external-context-mem0-auto-recall \
+  @qwen-code/external-context-mem0@x.y.z
+```
+
+The corresponding bundle is
+`/opt/qwen/external-context-mem0-auto-recall/node_modules/@qwen-code/external-context-mem0/dist/auto-recall.js`.
+Copy the applicable unbranded Hook definition from
+[`examples/managed-auto-recall-user-settings-posix.json`](./examples/managed-auto-recall-user-settings-posix.json)
+or
+[`examples/managed-auto-recall-user-settings-windows.json`](./examples/managed-auto-recall-user-settings-windows.json)
+into the `settings.json` of an administrator-controlled `QWEN_HOME`. Replace
+both command placeholders with fixed absolute Node and `dist/auto-recall.js`
+paths. The Mem0 instance and dialect remain independent JSON files; Qwen
+settings contain only the Hook registration.
+
+The Auto Recall profile must not enable this package's default Extension
+manifest or configure another on-demand Mem0 MCP server. Running both profiles
+could send two searches for one turn. Use the v2 Extension profile for
+on-demand `context_search`, or the v3 Hook-only profile for Auto Recall, never
+both in one Qwen process.
+
+The Hook requires a non-empty `submitted_prompt` captured by a supported
+interactive TUI submission. It never falls back to the expanded `prompt`, so
+tool-result continuations, retries, steering, cron, notifications, teammates,
+ACP, headless, `serve`, SDK, and remote-input paths do not trigger retrieval in
+the current version. Missing provenance, invalid configuration, a cwd outside
+the repository, an empty result, timeout, or provider failure returns `{}` and
+does not block the user turn after the pinned Node entry point starts.
+
+Before sending the query, the Hook removes fenced code, the configured
+credential, and common secret shapes, then keeps at most 512 Unicode code
+points. This is best-effort reduction, not DLP. Each eligible invocation is a
+new process and reads the v3 instance and dialect once, so administrator file
+changes apply to the next eligible prompt. Environment and Hook registration
+changes require restarting Qwen Code.
+
+## Runtime guarantees
+
+- The on-demand model supplies only a normalized query of at most 2,000
+  Unicode code points; Auto Recall derives at most 512 Unicode code points from
+  `submitted_prompt`.
+- Requests have the configured timeout, do not retry, and do not follow
+  redirects.
+- Responses are limited to 1 MiB before JSON parsing.
+- Results preserve upstream order and are capped at five entries, 1,000 Unicode
+  characters per content field, and 4,000 UTF-16 code units in the serialized
+  tool output.
+- Provider output is returned as `untrusted_external_context`; it is reference
+  data, not trusted instructions.
+- Startup and request errors are redacted and do not expose paths, endpoints,
+  queries, credentials, or upstream response bodies.
+
+## Troubleshooting
+
+| Symptom                                              | What to check                                                                                                                                                                     |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `configuration path must be absolute`                | `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` must contain an absolute local path.                                                                                                          |
+| `instance configuration is unavailable`              | The instance path or named credential environment variable is missing, blank, unresolved, or unreadable.                                                                          |
+| `instance configuration is invalid`                  | Validate the on-demand JSON, `schemaVersion: 2`, required fields, file size, and rejection of extra fields.                                                                       |
+| Auto Recall returns `{}`                             | Validate the v3 schema, Hook paths, `submitted_prompt`, repository containment, credential, network, timeout, and provider response. Failures are intentionally silent.           |
+| `dialect path must be absolute`                      | `dialectPath` must contain an absolute local path.                                                                                                                                |
+| `dialect configuration is unavailable`               | Confirm that the dialect file exists and is readable by the Qwen process user.                                                                                                    |
+| `dialect configuration is invalid`                   | Validate JSON, `dialectVersion: 1`, enum values, required fields, file size, and rejection of extra fields.                                                                       |
+| `endpoint`, `path`, `scope`, or `dialect` is invalid | Check HTTPS or explicit private HTTP opt-in, static path rules, GET/JSON compatibility, and exact scope/`omit` consistency.                                                       |
+| MCP server connects but search returns an error      | Check network routing, DNS, firewall or allowlist rules, upstream authentication, timeout, status code, and response shape. The Extension intentionally redacts upstream details. |
+
+## Administrator acceptance checklist
+
+- The endpoint is reachable from the Qwen host and its network allowlist is
+  intentionally scoped.
+- Production traffic uses HTTPS; private HTTP is an explicit exception.
+- Both configuration paths are absolute, outside ordinary workspaces, and
+  readable only by the intended administrator and process user.
+- No credential appears in configuration files, settings, repositories,
+  scripts, logs, or shell history.
+- Every non-`omit` dialect scope has exactly one matching fixed instance value.
+- The deployment enables exactly one retrieval profile: v2 MCP or v3 Hook.
+- `/mcp` shows only `context_search` in the on-demand profile and no Mem0 MCP
+  server in the Auto Recall profile.
+- A known-record search succeeds. On-demand file changes take effect after
+  restart; Auto Recall file changes take effect on the next eligible prompt.
 
 ## Development
 

--- a/integrations/external-context-mem0/README.md
+++ b/integrations/external-context-mem0/README.md
@@ -266,10 +266,14 @@ The Hook never falls back to the expanded `prompt`; events without
 `submitted_prompt` do not trigger retrieval.
 
 Register this profile only in launchers where automatic retrieval is intended
-for all eligible inputs. To exclude automation, give it a separate
-administrator-controlled `QWEN_HOME` without this Hook and omit the Auto Recall
-configuration and credential from that launcher's environment. The Hook itself
-does not distinguish TUI, SDK, or other transports supplying the field.
+for all eligible inputs. To disable every Hook for an automation run, use
+`qwen --bare -p '…'`, `qwen --safe-mode -p '…'`, or set `disableAllHooks: true`
+in its managed settings before starting Qwen. These options disable all Hooks;
+`--bare` and `--safe-mode` also change which customizations are loaded. If
+automation needs other Hooks, give it a separate administrator-controlled
+`QWEN_HOME` without this Hook and omit the Auto Recall configuration and
+credential from that launcher's environment. The Hook itself does not
+distinguish TUI, SDK, or other transports supplying the field.
 
 Instance and dialect paths must resolve to regular files. FIFOs and other
 special files are rejected before reading configuration.

--- a/integrations/external-context-mem0/examples/managed-auto-recall-user-settings-posix.json
+++ b/integrations/external-context-mem0/examples/managed-auto-recall-user-settings-posix.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exec '/absolute/path/to/node' '/administrator/path/to/external-context-mem0/dist/auto-recall.js'",
+            "timeout": 8000,
+            "name": "external-context-mem0-auto-recall",
+            "statusMessage": "Retrieving external context"
+          }
+        ]
+      }
+    ]
+  },
+  "$version": 4
+}

--- a/integrations/external-context-mem0/examples/managed-auto-recall-user-settings-windows.json
+++ b/integrations/external-context-mem0/examples/managed-auto-recall-user-settings-windows.json
@@ -1,0 +1,20 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "& 'C:\\Program Files\\nodejs\\node.exe' 'C:\\administrator\\external-context-mem0\\dist\\auto-recall.js'",
+            "shell": "powershell",
+            "timeout": 8000,
+            "name": "external-context-mem0-auto-recall",
+            "statusMessage": "Retrieving external context"
+          }
+        ]
+      }
+    ]
+  },
+  "$version": 4
+}

--- a/integrations/external-context-mem0/package.json
+++ b/integrations/external-context-mem0/package.json
@@ -15,8 +15,8 @@
     "build": "npm run clean && esbuild src/main.ts src/auto-recall.ts --bundle --platform=node --target=node22 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outdir=dist",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "lint": "eslint src",
-    "test": "vitest run --config vitest.config.ts",
-    "test:ci": "vitest run --config vitest.config.ts",
+    "test": "npm run build && vitest run --config vitest.config.ts",
+    "test:ci": "npm run build && vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/integrations/external-context-mem0/package.json
+++ b/integrations/external-context-mem0/package.json
@@ -12,7 +12,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "npm run clean && esbuild src/main.ts --bundle --platform=node --target=node22 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outfile=dist/main.js",
+    "build": "npm run clean && esbuild src/main.ts src/auto-recall.ts --bundle --platform=node --target=node22 --format=esm --banner:js=\"import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);\" --outdir=dist",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "lint": "eslint src",
     "test": "vitest run --config vitest.config.ts",
@@ -21,7 +21,9 @@
   },
   "files": [
     "dist/main.js",
+    "dist/auto-recall.js",
     "schemas",
+    "examples",
     "qwen-extension.json",
     "README.md"
   ],

--- a/integrations/external-context-mem0/schemas/auto-recall-instance-config.schema.json
+++ b/integrations/external-context-mem0/schemas/auto-recall-instance-config.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mem0 External Context auto-recall instance configuration v3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "autoRecall",
+    "dialectPath",
+    "endpoint",
+    "credentialEnv",
+    "scope",
+    "timeoutMs"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 3
+    },
+    "autoRecall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repositoryRoot"],
+      "properties": {
+        "repositoryRoot": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096
+        }
+      }
+    },
+    "dialectPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["origin"],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "basePath": {
+          "type": "string",
+          "maxLength": 512,
+          "default": ""
+        },
+        "allowInsecureHttp": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "credentialEnv": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Z_][A-Z0-9_]*$"
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "userId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "agentId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "appId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      }
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 100,
+      "maximum": 5000
+    }
+  }
+}

--- a/integrations/external-context-mem0/src/auto-recall-config.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall-config.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, parse } from 'node:path';
+import { Ajv, type AnySchema } from 'ajv';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  isWithinRepository,
+  loadAutoRecallRuntimeConfiguration,
+  loadRuntimeConfiguration,
+} from './config.js';
+import { parseAutoRecallInstanceConfig } from './schemas.js';
+import type { DialectV1, InstanceConfigV2 } from './types.js';
+
+const MAX_CONFIG_BYTES = 64 * 1024;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('Mem0 Auto Recall configuration', () => {
+  it('accepts the canonical v3 schema and resolves the repository root', async () => {
+    const fixture = await readFixture();
+    const directory = await makeTemporaryDirectory();
+    const instance = autoRecallInstance(fixture.instance, directory);
+    const schema = await readJson(
+      '../schemas/auto-recall-instance-config.schema.json',
+    );
+    const validate = new Ajv({ allErrors: true, strict: true }).compile(
+      schema as AnySchema,
+    );
+
+    expect(validate(instance)).toBe(true);
+    expect(parseAutoRecallInstanceConfig(instance).schemaVersion).toBe(3);
+    const { configPath } = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+    );
+
+    await expect(
+      loadAutoRecallRuntimeConfiguration({
+        env: runtimeEnvironment(configPath),
+      }),
+    ).resolves.toMatchObject({
+      instance: {
+        schemaVersion: 3,
+        autoRecall: { repositoryRoot: await realpath(directory) },
+      },
+      dialect: { id: fixture.dialect.id },
+      credential: 'runtime-token',
+    });
+  });
+
+  it('rejects on-demand, unknown, and extended configuration shapes', async () => {
+    const fixture = await readFixture();
+    const directory = await makeTemporaryDirectory();
+    const instance = autoRecallInstance(fixture.instance, directory);
+
+    expect(() => parseAutoRecallInstanceConfig(fixture.instance)).toThrow(
+      'auto-recall configuration is invalid',
+    );
+    expect(() =>
+      parseAutoRecallInstanceConfig({ ...instance, schemaVersion: 4 }),
+    ).toThrow('auto-recall configuration is invalid');
+    expect(() =>
+      parseAutoRecallInstanceConfig({
+        ...instance,
+        autoRecall: {
+          ...instance.autoRecall,
+          dynamicScope: true,
+        },
+      }),
+    ).toThrow('auto-recall configuration is invalid');
+
+    const autoRecall = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+    );
+    await expect(
+      loadRuntimeConfiguration({
+        env: runtimeEnvironment(autoRecall.configPath),
+      }),
+    ).rejects.toThrow('instance configuration is invalid');
+
+    const onDemand = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+    );
+    await expect(
+      loadAutoRecallRuntimeConfiguration({
+        env: runtimeEnvironment(onDemand.configPath),
+      }),
+    ).rejects.toThrow('auto-recall configuration is invalid');
+  });
+
+  it('requires an Auto Recall timeout from 100 through 5000 milliseconds', async () => {
+    const fixture = await readFixture();
+    const repositoryRoot = await makeTemporaryDirectory();
+    const instance = autoRecallInstance(fixture.instance, repositoryRoot);
+
+    for (const timeoutMs of [100, 5000]) {
+      expect(
+        parseAutoRecallInstanceConfig({ ...instance, timeoutMs }).timeoutMs,
+      ).toBe(timeoutMs);
+    }
+    for (const timeoutMs of [99, 5001]) {
+      expect(() =>
+        parseAutoRecallInstanceConfig({ ...instance, timeoutMs }),
+      ).toThrow('auto-recall configuration is invalid');
+    }
+  });
+
+  it('rejects relative, missing, and filesystem-root repositories', async () => {
+    const fixture = await readFixture();
+    const directory = await makeTemporaryDirectory();
+    for (const repositoryRoot of [
+      'relative/repository',
+      join(directory, 'missing'),
+      parse(process.cwd()).root,
+    ]) {
+      const instance = autoRecallInstance(fixture.instance, repositoryRoot);
+      const { configPath } = await writeRuntimeConfiguration(
+        instance,
+        fixture.dialect,
+      );
+
+      await expect(
+        loadAutoRecallRuntimeConfiguration({
+          env: runtimeEnvironment(configPath),
+        }),
+      ).rejects.toThrow('repository root is invalid');
+    }
+  });
+
+  it('allows canonical descendants and rejects paths outside the repository', async () => {
+    const repositoryRoot = await makeTemporaryDirectory();
+    const canonicalRoot = await realpath(repositoryRoot);
+    const child = join(repositoryRoot, 'child');
+    const outside = await makeTemporaryDirectory();
+    await mkdir(child);
+
+    await expect(isWithinRepository(canonicalRoot, child)).resolves.toBe(true);
+    await expect(isWithinRepository(canonicalRoot, outside)).resolves.toBe(
+      false,
+    );
+    await expect(
+      isWithinRepository(canonicalRoot, 'relative/repository'),
+    ).resolves.toBe(false);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a descendant path that resolves outside through a symbolic link',
+    async () => {
+      const repositoryRoot = await makeTemporaryDirectory();
+      const canonicalRoot = await realpath(repositoryRoot);
+      const outside = await makeTemporaryDirectory();
+      const escaped = join(repositoryRoot, 'escaped');
+      await symlink(outside, escaped, 'dir');
+
+      await expect(isWithinRepository(canonicalRoot, escaped)).resolves.toBe(
+        false,
+      );
+    },
+  );
+
+  it('keeps the v3 instance file bounded', async () => {
+    const fixture = await readFixture();
+    const repositoryRoot = await makeTemporaryDirectory();
+    const instance = autoRecallInstance(fixture.instance, repositoryRoot);
+    const exact = await writeRuntimeConfiguration(instance, fixture.dialect, {
+      instanceSource: (configured) =>
+        JSON.stringify(configured).padEnd(MAX_CONFIG_BYTES, ' '),
+    });
+    await expect(
+      loadAutoRecallRuntimeConfiguration({
+        env: runtimeEnvironment(exact.configPath),
+      }),
+    ).resolves.toMatchObject({ instance: { schemaVersion: 3 } });
+
+    const oversized = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+      {
+        instanceSource: (configured) =>
+          JSON.stringify(configured).padEnd(MAX_CONFIG_BYTES + 1, ' '),
+      },
+    );
+    await expect(
+      loadAutoRecallRuntimeConfiguration({
+        env: runtimeEnvironment(oversized.configPath),
+      }),
+    ).rejects.toThrow('instance configuration is invalid');
+  });
+});
+
+interface SyntheticFixture {
+  instance: InstanceConfigV2;
+  dialect: DialectV1;
+}
+
+interface RuntimeWriteOptions {
+  instanceSource?: (instance: unknown) => string;
+}
+
+function autoRecallInstance(
+  instance: InstanceConfigV2,
+  repositoryRoot: string,
+) {
+  return {
+    ...structuredClone(instance),
+    schemaVersion: 3 as const,
+    autoRecall: { repositoryRoot },
+    timeoutMs: 1500,
+  };
+}
+
+async function readFixture(): Promise<SyntheticFixture> {
+  return (await readJson(
+    '../test/fixtures/synthetic-filtered-post-v1.json',
+  )) as SyntheticFixture;
+}
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(
+    await readFile(new URL(relativePath, import.meta.url), 'utf8'),
+  ) as unknown;
+}
+
+async function writeRuntimeConfiguration(
+  instance: unknown,
+  dialect: unknown,
+  options: RuntimeWriteOptions = {},
+): Promise<{ configPath: string }> {
+  const directory = await makeTemporaryDirectory();
+  const configPath = join(directory, 'instance.json');
+  const dialectPath = join(directory, 'dialect.json');
+  const configuredInstance = {
+    ...(instance as Record<string, unknown>),
+    dialectPath,
+  };
+  await writeFile(dialectPath, JSON.stringify(dialect));
+  await writeFile(
+    configPath,
+    options.instanceSource?.(configuredInstance) ??
+      JSON.stringify(configuredInstance),
+  );
+  return { configPath };
+}
+
+async function makeTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'qwen-mem0-auto-config-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function runtimeEnvironment(configPath: string): NodeJS.ProcessEnv {
+  return {
+    QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
+    SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
+  };
+}

--- a/integrations/external-context-mem0/src/auto-recall.integration.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall.integration.test.ts
@@ -4,10 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { spawn } from 'node:child_process';
-import { createServer, type Server } from 'node:http';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { type AddressInfo } from 'node:net';
+import { spawn, spawnSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  createServer as createTcpServer,
+  type AddressInfo,
+  type Server,
+  type Socket,
+} from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,8 +20,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const temporaryDirectories: string[] = [];
 const servers: Server[] = [];
+const sockets: Socket[] = [];
+const hookBundle = new URL('../dist/auto-recall.js', import.meta.url);
 
 afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.destroy();
   await Promise.all(
     servers
       .splice(0)
@@ -89,51 +97,7 @@ describe('Mem0 Auto Recall local provider', () => {
       server.listen(0, '127.0.0.1', resolve),
     );
     const port = (server.address() as AddressInfo).port;
-    const directory = await makeTemporaryDirectory();
-    const dialectPath = join(directory, 'dialect.json');
-    const configPath = join(directory, 'instance.json');
-    await writeFile(
-      dialectPath,
-      JSON.stringify({
-        dialectVersion: 1,
-        id: 'synthetic-auto-recall-v1',
-        auth: 'authorization-token',
-        search: {
-          method: 'POST',
-          path: '/v2/memories/search/',
-          queryLocation: 'json',
-          userIdLocation: 'json.filters',
-          agentIdLocation: 'omit',
-          appIdLocation: 'omit',
-          limitField: 'limit',
-        },
-        response: {
-          collection: 'results',
-          idField: 'id',
-          contentField: 'memory',
-          titleField: 'omit',
-          uriField: 'omit',
-          scoreField: 'omit',
-          updatedAtField: 'omit',
-        },
-      }),
-    );
-    await writeFile(
-      configPath,
-      JSON.stringify({
-        schemaVersion: 3,
-        autoRecall: { repositoryRoot: directory },
-        dialectPath,
-        endpoint: {
-          origin: `http://127.0.0.1:${port}`,
-          basePath: '',
-          allowInsecureHttp: true,
-        },
-        credentialEnv: 'SYNTHETIC_MEMORY_TOKEN',
-        scope: { userId: 'repository-memory' },
-        timeoutMs: 1500,
-      }),
-    );
+    const { directory, env } = await makeRuntime(`http://127.0.0.1:${port}`);
 
     const result = await runAutoRecallProcess(
       JSON.stringify({
@@ -142,10 +106,7 @@ describe('Mem0 Auto Recall local provider', () => {
         submitted_prompt: 'deployment policy API_KEY=remove-me',
         cwd: directory,
       }),
-      {
-        QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-        SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-      },
+      env,
     );
 
     expect(result.exitCode).toBe(0);
@@ -174,6 +135,107 @@ describe('Mem0 Auto Recall local provider', () => {
       },
     });
   });
+
+  it('exits successfully after a provider timeout during a stalled TLS handshake', async () => {
+    let connected = false;
+    const server = createTcpServer((socket) => {
+      connected = true;
+      sockets.push(socket);
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const port = (server.address() as AddressInfo).port;
+    const { directory, env } = await makeRuntime(`https://127.0.0.1:${port}`);
+
+    const startedAt = performance.now();
+    const result = await runAutoRecallProcess(
+      JSON.stringify({
+        hook_event_name: 'UserPromptSubmit',
+        submitted_prompt: 'deployment policy',
+        cwd: directory,
+      }),
+      env,
+    );
+
+    expect(connected).toBe(true);
+    expect(result).toEqual({
+      exitCode: 0,
+      signal: null,
+      stdout: '{}',
+      stderr: '',
+    });
+    expect(performance.now() - startedAt).toBeLessThan(5000);
+  }, 10000);
+
+  it.each(['token', 'api_key', 'password', 'secret'])(
+    'bounds repeated %s near misses in the bundle with a process deadline',
+    (keyword) => {
+      const result = spawnSync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '--eval',
+          `
+        import { createAutoRecallQuery } from ${JSON.stringify(hookBundle.href)};
+        const query = createAutoRecallQuery(${JSON.stringify(keyword)}.repeat(Math.floor(4096 / ${keyword.length})), '');
+        process.stdout.write(JSON.stringify(query ?? null));
+      `,
+        ],
+        { encoding: 'utf8', timeout: 2000, killSignal: 'SIGKILL' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe('null');
+      expect(result.stderr).toBe('');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32').each(['instance', 'dialect'])(
+    'rejects a stalled %s FIFO and exits successfully',
+    async (kind) => {
+      const { directory, env } = await makeRuntime(
+        'https://memory.example.com',
+      );
+      const fifo = join(directory, 'blocked.json');
+      expect(spawnSync('mkfifo', [fifo]).status).toBe(0);
+      if (kind === 'instance') {
+        env.QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG = fifo;
+      } else {
+        const configPath = env.QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG;
+        const config = JSON.parse(await readFile(configPath, 'utf8')) as Record<
+          string,
+          unknown
+        >;
+        await writeFile(
+          configPath,
+          JSON.stringify({ ...config, dialectPath: fifo }),
+        );
+      }
+
+      const startedAt = performance.now();
+      const result = await runAutoRecallProcess(
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          submitted_prompt: 'deployment policy',
+          cwd: directory,
+        }),
+        env,
+      );
+
+      expect(result).toEqual({
+        exitCode: 0,
+        signal: null,
+        stdout: '{}',
+        stderr: '',
+      });
+      expect(performance.now() - startedAt).toBeLessThan(5000);
+    },
+    10000,
+  );
 });
 
 async function runAutoRecallProcess(
@@ -187,20 +249,12 @@ async function runAutoRecallProcess(
 }> {
   const env = { ...process.env };
   delete env['QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG'];
-  const child = spawn(
-    process.execPath,
-    [
-      '--import',
-      'tsx/esm',
-      fileURLToPath(new URL('./auto-recall.ts', import.meta.url)),
-    ],
-    {
-      env: { ...env, ...envOverrides, NODE_NO_WARNINGS: '1' },
-      killSignal: 'SIGKILL',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 8000,
-    },
-  );
+  const child = spawn(process.execPath, [fileURLToPath(hookBundle)], {
+    env: { ...env, ...envOverrides, NODE_NO_WARNINGS: '1' },
+    killSignal: 'SIGKILL',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 8000,
+  });
   let stdout = '';
   let stderr = '';
   child.stdout.on('data', (chunk: Buffer) => {
@@ -223,4 +277,60 @@ async function makeTemporaryDirectory(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'qwen-mem0-auto-e2e-'));
   temporaryDirectories.push(directory);
   return directory;
+}
+
+async function makeRuntime(origin: string) {
+  const directory = await makeTemporaryDirectory();
+  const dialectPath = join(directory, 'dialect.json');
+  const configPath = join(directory, 'instance.json');
+  await writeFile(
+    dialectPath,
+    JSON.stringify({
+      dialectVersion: 1,
+      id: 'synthetic-auto-recall-v1',
+      auth: 'authorization-token',
+      search: {
+        method: 'POST',
+        path: '/v2/memories/search/',
+        queryLocation: 'json',
+        userIdLocation: 'json.filters',
+        agentIdLocation: 'omit',
+        appIdLocation: 'omit',
+        limitField: 'limit',
+      },
+      response: {
+        collection: 'results',
+        idField: 'id',
+        contentField: 'memory',
+        titleField: 'omit',
+        uriField: 'omit',
+        scoreField: 'omit',
+        updatedAtField: 'omit',
+      },
+    }),
+  );
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      schemaVersion: 3,
+      autoRecall: { repositoryRoot: directory },
+      dialectPath,
+      endpoint: {
+        origin,
+        basePath: '',
+        allowInsecureHttp: origin.startsWith('http:'),
+      },
+      credentialEnv: 'SYNTHETIC_MEMORY_TOKEN',
+      scope: { userId: 'repository-memory' },
+      timeoutMs: 1500,
+    }),
+  );
+
+  return {
+    directory,
+    env: {
+      QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
+      SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
+    },
+  };
 }

--- a/integrations/external-context-mem0/src/auto-recall.integration.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall.integration.test.ts
@@ -67,7 +67,7 @@ describe('Mem0 Auto Recall local provider', () => {
       stdout: '{}',
       stderr: '',
     });
-  });
+  }, 20000);
 
   it('executes the v3 configuration, dialect, request engine, and Hook envelope', async () => {
     const requests: Array<{
@@ -134,7 +134,7 @@ describe('Mem0 Auto Recall local provider', () => {
         ),
       },
     });
-  });
+  }, 10000);
 
   it('exits successfully after a provider timeout during a stalled TLS handshake', async () => {
     let connected = false;
@@ -179,19 +179,26 @@ describe('Mem0 Auto Recall local provider', () => {
           '--eval',
           `
         import { createAutoRecallQuery } from ${JSON.stringify(hookBundle.href)};
+        const startedAt = performance.now();
         const query = createAutoRecallQuery(${JSON.stringify(keyword)}.repeat(Math.floor(4096 / ${keyword.length})), '');
-        process.stdout.write(JSON.stringify(query ?? null));
+        process.stdout.write(JSON.stringify({ query: query ?? null, elapsedMs: performance.now() - startedAt }));
       `,
         ],
-        { encoding: 'utf8', timeout: 2000, killSignal: 'SIGKILL' },
+        { encoding: 'utf8', timeout: 8000, killSignal: 'SIGKILL' },
       );
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
       expect(result.signal).toBeNull();
-      expect(result.stdout).toBe('null');
+      const output = JSON.parse(result.stdout) as {
+        query: string | null;
+        elapsedMs: number;
+      };
+      expect(output.query).toBeNull();
+      expect(output.elapsedMs).toBeLessThan(2000);
       expect(result.stderr).toBe('');
     },
+    10000,
   );
 
   it.skipIf(process.platform === 'win32').each(['instance', 'dialect'])(

--- a/integrations/external-context-mem0/src/auto-recall.integration.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { type AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('Mem0 Auto Recall local provider', () => {
+  it('runs the real entry point and fails open without stderr', async () => {
+    await expect(runAutoRecallProcess('{')).resolves.toEqual({
+      exitCode: 0,
+      signal: null,
+      stdout: '{}',
+      stderr: '',
+    });
+
+    await expect(
+      runAutoRecallProcess(
+        JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          submitted_prompt: 'question',
+          cwd: process.cwd(),
+        }),
+        {
+          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG:
+            '/missing/administrator/instance.json',
+        },
+      ),
+    ).resolves.toEqual({
+      exitCode: 0,
+      signal: null,
+      stdout: '{}',
+      stderr: '',
+    });
+  });
+
+  it('executes the v3 configuration, dialect, request engine, and Hook envelope', async () => {
+    const requests: Array<{
+      authorization: string | undefined;
+      body: unknown;
+      path: string | undefined;
+    }> = [];
+    const server = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      requests.push({
+        authorization: request.headers.authorization,
+        body: JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown,
+        path: request.url,
+      });
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          results: [
+            { id: 'memory-1', memory: 'Use the bounded request engine.' },
+          ],
+        }),
+      );
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const port = (server.address() as AddressInfo).port;
+    const directory = await makeTemporaryDirectory();
+    const dialectPath = join(directory, 'dialect.json');
+    const configPath = join(directory, 'instance.json');
+    await writeFile(
+      dialectPath,
+      JSON.stringify({
+        dialectVersion: 1,
+        id: 'synthetic-auto-recall-v1',
+        auth: 'authorization-token',
+        search: {
+          method: 'POST',
+          path: '/v2/memories/search/',
+          queryLocation: 'json',
+          userIdLocation: 'json.filters',
+          agentIdLocation: 'omit',
+          appIdLocation: 'omit',
+          limitField: 'limit',
+        },
+        response: {
+          collection: 'results',
+          idField: 'id',
+          contentField: 'memory',
+          titleField: 'omit',
+          uriField: 'omit',
+          scoreField: 'omit',
+          updatedAtField: 'omit',
+        },
+      }),
+    );
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        schemaVersion: 3,
+        autoRecall: { repositoryRoot: directory },
+        dialectPath,
+        endpoint: {
+          origin: `http://127.0.0.1:${port}`,
+          basePath: '',
+          allowInsecureHttp: true,
+        },
+        credentialEnv: 'SYNTHETIC_MEMORY_TOKEN',
+        scope: { userId: 'repository-memory' },
+        timeoutMs: 1500,
+      }),
+    );
+
+    const result = await runAutoRecallProcess(
+      JSON.stringify({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'expanded prompt must not leave the process',
+        submitted_prompt: 'deployment policy API_KEY=remove-me',
+        cwd: directory,
+      }),
+      {
+        QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
+        SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stderr).toBe('');
+    expect(requests).toEqual([
+      {
+        authorization: 'Token runtime-token',
+        path: '/v2/memories/search/',
+        body: {
+          query: 'deployment policy',
+          filters: { user_id: 'repository-memory' },
+          limit: 5,
+        },
+      },
+    ]);
+    expect(JSON.stringify(requests)).not.toContain(
+      'expanded prompt must not leave the process',
+    );
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: expect.stringContaining(
+          'Use the bounded request engine.',
+        ),
+      },
+    });
+  });
+});
+
+async function runAutoRecallProcess(
+  input: string,
+  envOverrides: NodeJS.ProcessEnv = {},
+): Promise<{
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const env = { ...process.env };
+  delete env['QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG'];
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      'tsx/esm',
+      fileURLToPath(new URL('./auto-recall.ts', import.meta.url)),
+    ],
+    {
+      env: { ...env, ...envOverrides, NODE_NO_WARNINGS: '1' },
+      killSignal: 'SIGKILL',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 8000,
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  child.stdin.end(input);
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (exitCode, signal) => {
+      resolve({ exitCode, signal, stdout, stderr });
+    });
+  });
+}
+
+async function makeTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'qwen-mem0-auto-e2e-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/integrations/external-context-mem0/src/auto-recall.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall.test.ts
@@ -1,0 +1,323 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PassThrough, Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadAutoRecallRuntimeConfiguration = vi.hoisted(() => vi.fn());
+const isWithinRepository = vi.hoisted(() => vi.fn());
+const search = vi.hoisted(() => vi.fn());
+const createRequestEngine = vi.hoisted(() => vi.fn(() => search));
+
+vi.mock('./config.js', () => ({
+  loadAutoRecallRuntimeConfiguration,
+  isWithinRepository,
+}));
+vi.mock('./request-engine.js', () => ({ createRequestEngine }));
+
+beforeEach(() => {
+  loadAutoRecallRuntimeConfiguration.mockReset().mockResolvedValue(runtime());
+  isWithinRepository.mockReset().mockResolvedValue(true);
+  search.mockReset();
+  createRequestEngine.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createAutoRecallQuery', () => {
+  it('removes code and common credential shapes', async () => {
+    const { createAutoRecallQuery } = await import('./auto-recall.js');
+    const query = createAutoRecallQuery(
+      [
+        'How should deployment work?',
+        '```sh',
+        'curl -H "Authorization: Bearer code-secret"',
+        '```',
+        'API_KEY=assignment-secret',
+        'Bearer bearer-secret',
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIn0.signature123',
+        'provider-secret-value',
+      ].join('\n'),
+      'provider-secret-value',
+    );
+
+    expect(query).toBe('How should deployment work?');
+  });
+
+  it('keeps benign prose and limits output to 512 Unicode code points', async () => {
+    const { createAutoRecallQuery } = await import('./auto-recall.js');
+
+    expect(
+      createAutoRecallQuery(
+        'readme: token refresh flow, where is it documented?',
+        '',
+      ),
+    ).toBe('readme: token refresh flow, where is it documented?');
+    expect(createAutoRecallQuery('🙂'.repeat(513), '')).toBe('🙂'.repeat(512));
+    expect(
+      createAutoRecallQuery('```text\nonly code\n```', ''),
+    ).toBeUndefined();
+  });
+
+  it('bounds sanitizer work before applying credential patterns', async () => {
+    const { createAutoRecallQuery } = await import('./auto-recall.js');
+    const startedAt = Date.now();
+    const query = createAutoRecallQuery('a-'.repeat(25_000), 'secret');
+
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+    expect(query ?? '').not.toContain('a-a');
+  });
+});
+
+describe('runAutoRecall', () => {
+  it('retrieves once from submitted prompt provenance', async () => {
+    search.mockResolvedValue([
+      { id: '<one>', content: '<policy>repository</policy>' },
+    ]);
+    const { runAutoRecall } = await import('./auto-recall.js');
+
+    const output = await runAutoRecall({
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'expanded prompt that must be ignored',
+      submitted_prompt: '  deployment\npolicy  ',
+      cwd: '/repository/child',
+    });
+
+    expect(loadAutoRecallRuntimeConfiguration).toHaveBeenCalledOnce();
+    expect(isWithinRepository).toHaveBeenCalledWith(
+      '/repository',
+      '/repository/child',
+    );
+    expect(createRequestEngine).toHaveBeenCalledOnce();
+    expect(search).toHaveBeenCalledOnce();
+    expect(search).toHaveBeenCalledWith({
+      query: 'deployment policy',
+      signal: expect.any(AbortSignal),
+    });
+    expect(output).toMatchObject({
+      hookSpecificOutput: { hookEventName: 'UserPromptSubmit' },
+    });
+    const context =
+      'hookSpecificOutput' in output
+        ? output.hookSpecificOutput.additionalContext
+        : '';
+    expect(context).not.toContain('<');
+    expect(JSON.parse(context)).toMatchObject({
+      untrusted_external_context: {
+        items: [{ id: '<one>', content: '<policy>repository</policy>' }],
+      },
+    });
+  });
+
+  it('does not inspect the expanded prompt field', async () => {
+    search.mockResolvedValue([]);
+    const { runAutoRecall } = await import('./auto-recall.js');
+    const input = {
+      hook_event_name: 'UserPromptSubmit',
+      submitted_prompt: 'question',
+      cwd: '/repository',
+    };
+    Object.defineProperty(input, 'prompt', {
+      get() {
+        throw new Error('expanded prompt was read');
+      },
+    });
+
+    await expect(runAutoRecall(input)).resolves.toEqual({});
+    expect(search).toHaveBeenCalledWith({
+      query: 'question',
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it.each([
+    {},
+    { hook_event_name: 'ToolResult', submitted_prompt: 'question', cwd: '/' },
+    { hook_event_name: 'UserPromptSubmit', prompt: 'expanded', cwd: '/' },
+    {
+      hook_event_name: 'UserPromptSubmit',
+      submitted_prompt: '   ',
+      cwd: '/',
+    },
+  ])('skips unsupported input before loading configuration', async (input) => {
+    const { runAutoRecall } = await import('./auto-recall.js');
+
+    await expect(runAutoRecall(input)).resolves.toEqual({});
+    expect(loadAutoRecallRuntimeConfiguration).not.toHaveBeenCalled();
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('skips a working directory outside the configured repository', async () => {
+    isWithinRepository.mockResolvedValue(false);
+    const { runAutoRecall } = await import('./auto-recall.js');
+
+    await expect(runAutoRecall(validInput())).resolves.toEqual({});
+    expect(createRequestEngine).not.toHaveBeenCalled();
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('returns no context for an empty provider result', async () => {
+    search.mockResolvedValue([]);
+    const { runAutoRecall } = await import('./auto-recall.js');
+
+    await expect(runAutoRecall(validInput())).resolves.toEqual({});
+    expect(search).toHaveBeenCalledOnce();
+  });
+
+  it('aborts an in-flight request at the configured provider timeout', async () => {
+    loadAutoRecallRuntimeConfiguration.mockResolvedValue({
+      ...runtime(),
+      instance: { ...runtime().instance, timeoutMs: 100 },
+    });
+    let providerSignal: AbortSignal | undefined;
+    search.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          providerSignal = signal;
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    const { runAutoRecallCli } = await import('./auto-recall.js');
+
+    await expect(
+      captureCli(runAutoRecallCli, JSON.stringify(validInput())),
+    ).resolves.toBe('{}');
+    expect(providerSignal?.aborted).toBe(true);
+    expect(search).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runAutoRecallCli', () => {
+  it('fails open for malformed input and configuration failures', async () => {
+    const { runAutoRecallCli } = await import('./auto-recall.js');
+    const malformed = await captureCli(runAutoRecallCli, '{');
+    expect(malformed).toBe('{}');
+    expect(loadAutoRecallRuntimeConfiguration).not.toHaveBeenCalled();
+
+    loadAutoRecallRuntimeConfiguration.mockRejectedValue(
+      new Error('/secret/path token=secret'),
+    );
+    const failed = await captureCli(
+      runAutoRecallCli,
+      JSON.stringify(validInput()),
+    );
+    expect(failed).toBe('{}');
+  });
+
+  it('accepts exactly 1 MiB and rejects one additional byte before configuration', async () => {
+    const { runAutoRecallCli } = await import('./auto-recall.js');
+    search.mockResolvedValue([]);
+    const baseInput = JSON.stringify({ ...validInput(), padding: '' });
+    const exactInput = JSON.stringify({
+      ...validInput(),
+      padding: 'x'.repeat(1024 * 1024 - Buffer.byteLength(baseInput)),
+    });
+
+    expect(Buffer.byteLength(exactInput)).toBe(1024 * 1024);
+    await expect(captureCli(runAutoRecallCli, exactInput)).resolves.toBe('{}');
+    expect(loadAutoRecallRuntimeConfiguration).toHaveBeenCalledOnce();
+    loadAutoRecallRuntimeConfiguration.mockClear();
+
+    const oversized = `${exactInput} `;
+    expect(Buffer.byteLength(oversized)).toBe(1024 * 1024 + 1);
+    await expect(captureCli(runAutoRecallCli, oversized)).resolves.toBe('{}');
+
+    expect(loadAutoRecallRuntimeConfiguration).not.toHaveBeenCalled();
+  });
+
+  it('returns within the internal wall-clock budget', async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    search.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          providerSignal = signal;
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    const { runAutoRecallCli } = await import('./auto-recall.js');
+    const output = { value: '' };
+    const work = runAutoRecallCli(
+      Readable.from([JSON.stringify(validInput())]),
+      { write: (value) => (output.value += value) },
+      {},
+    );
+    await vi.waitFor(() => expect(search).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(6500);
+    await work;
+
+    expect(output.value).toBe('{}');
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
+  it('closes stalled input at the internal wall-clock budget', async () => {
+    vi.useFakeTimers();
+    const input = new PassThrough();
+    const output = { value: '' };
+    const { runAutoRecallCli } = await import('./auto-recall.js');
+    const work = runAutoRecallCli(input, {
+      write: (value) => (output.value += value),
+    });
+
+    await vi.advanceTimersByTimeAsync(6500);
+    await work;
+
+    expect(input.destroyed).toBe(true);
+    expect(output.value).toBe('{}');
+    expect(loadAutoRecallRuntimeConfiguration).not.toHaveBeenCalled();
+  });
+});
+
+function runtime() {
+  return {
+    instance: {
+      schemaVersion: 3,
+      autoRecall: { repositoryRoot: '/repository' },
+      dialectPath: '/dialect.json',
+      endpoint: {
+        origin: 'https://memory.example.com',
+        basePath: '',
+        allowInsecureHttp: false,
+      },
+      credentialEnv: 'MEMORY_TOKEN',
+      scope: { userId: 'repository-memory' },
+      timeoutMs: 1500,
+    },
+    dialect: {},
+    credential: 'provider-secret-value',
+  };
+}
+
+function validInput() {
+  return {
+    hook_event_name: 'UserPromptSubmit',
+    submitted_prompt: 'question',
+    cwd: '/repository',
+  };
+}
+
+async function captureCli(
+  run: (
+    input: Readable,
+    output: { write(value: string): unknown },
+    env: NodeJS.ProcessEnv,
+  ) => Promise<void>,
+  input: string,
+): Promise<string> {
+  let output = '';
+  await run(
+    Readable.from([input]),
+    { write: (value) => (output += value) },
+    {},
+  );
+  return output;
+}

--- a/integrations/external-context-mem0/src/auto-recall.test.ts
+++ b/integrations/external-context-mem0/src/auto-recall.test.ts
@@ -64,6 +64,21 @@ describe('createAutoRecallQuery', () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    'my_api_key_suffix=remove-me',
+    '"service.token": "remove me"',
+    "'db.password' = 'remove me'",
+    'client-secret: remove-me',
+    'config: token=remove-me',
+  ])('removes secret assignments in %s', async (assignment) => {
+    const { createAutoRecallQuery } = await import('./auto-recall.js');
+
+    const query = createAutoRecallQuery(`deployment ${assignment}`, '');
+
+    expect(query).not.toContain('remove');
+    expect(query).toContain('deployment');
+  });
+
   it('bounds sanitizer work before applying credential patterns', async () => {
     const { createAutoRecallQuery } = await import('./auto-recall.js');
     const startedAt = Date.now();

--- a/integrations/external-context-mem0/src/auto-recall.ts
+++ b/integrations/external-context-mem0/src/auto-recall.ts
@@ -18,8 +18,9 @@ const MAX_HOOK_INPUT_BYTES = 1024 * 1024;
 const MAX_AUTO_QUERY_CHARACTERS = 512;
 const MAX_SANITIZER_INPUT_CHARACTERS = 4096;
 const HOOK_WALL_CLOCK_TIMEOUT_MS = 6500;
+// Check each identifier once, without overlapping scans around the keyword.
 const SECRET_ASSIGNMENT_PATTERN =
-  /["']?[A-Za-z0-9_.-]*(?:api[_-]?key|token|password|secret)[A-Za-z0-9_.-]*["']?[^\S\r\n]*[:=][^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)?/gi;
+  /(?<![A-Za-z0-9_.-])["']?(?=[A-Za-z0-9_.-]*(?:api[_-]?key|token|password|secret))[A-Za-z0-9_.-]+["']?[^\S\r\n]*[:=][^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)?/gi;
 
 interface HookInput {
   submittedPrompt: string;
@@ -192,4 +193,6 @@ async function isDirectEntryPoint(): Promise<boolean> {
 
 if (await isDirectEntryPoint()) {
   await runAutoRecallCli().catch(() => undefined);
+  // Aborted fetches or filesystem reads can retain handles after output is ready.
+  process.stdout.end(() => process.exit(0));
 }

--- a/integrations/external-context-mem0/src/auto-recall.ts
+++ b/integrations/external-context-mem0/src/auto-recall.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { realpath } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  isWithinRepository,
+  loadAutoRecallRuntimeConfiguration,
+} from './config.js';
+import { renderResult } from './profile.js';
+import { createRequestEngine } from './request-engine.js';
+
+const MAX_HOOK_INPUT_BYTES = 1024 * 1024;
+const MAX_AUTO_QUERY_CHARACTERS = 512;
+const MAX_SANITIZER_INPUT_CHARACTERS = 4096;
+const HOOK_WALL_CLOCK_TIMEOUT_MS = 6500;
+const SECRET_ASSIGNMENT_PATTERN =
+  /["']?[A-Za-z0-9_.-]*(?:api[_-]?key|token|password|secret)[A-Za-z0-9_.-]*["']?[^\S\r\n]*[:=][^\S\r\n]*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)?/gi;
+
+interface HookInput {
+  submittedPrompt: string;
+  cwd: string;
+}
+
+type HookOutput =
+  | Record<string, never>
+  | {
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit';
+        additionalContext: string;
+      };
+    };
+
+type HookInputStream = AsyncIterable<string | Uint8Array> & {
+  destroy?(): void;
+};
+
+interface HookOutputStream {
+  write(value: string): unknown;
+}
+
+export async function runAutoRecall(
+  value: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+  signal: AbortSignal = new AbortController().signal,
+): Promise<HookOutput> {
+  const input = parseHookInput(value);
+  if (!input) return {};
+
+  const runtime = await loadAutoRecallRuntimeConfiguration({ env });
+  if (
+    !(await isWithinRepository(
+      runtime.instance.autoRecall.repositoryRoot,
+      input.cwd,
+    ))
+  ) {
+    return {};
+  }
+
+  const query = createAutoRecallQuery(
+    input.submittedPrompt,
+    runtime.credential,
+  );
+  if (!query) return {};
+
+  const items = await createRequestEngine(runtime)({
+    query,
+    signal: AbortSignal.any([
+      signal,
+      AbortSignal.timeout(runtime.instance.timeoutMs),
+    ]),
+  });
+  if (items.length === 0) return {};
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: renderResult(items).text,
+    },
+  };
+}
+
+export function createAutoRecallQuery(
+  submittedPrompt: string,
+  credential: string,
+): string | undefined {
+  let query = submittedPrompt;
+  if (query.length > MAX_SANITIZER_INPUT_CHARACTERS) {
+    query = Array.from(query).slice(0, MAX_SANITIZER_INPUT_CHARACTERS).join('');
+  }
+  query = query
+    .replace(/(```|~~~)[\s\S]*?\1/g, ' ')
+    .replace(/(?:```|~~~)[\s\S]*$/g, ' ');
+  if (credential) query = query.replaceAll(credential, ' ');
+  query = query
+    .replace(SECRET_ASSIGNMENT_PATTERN, ' ')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, ' ')
+    .replace(
+      /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+      ' ',
+    )
+    .replace(/\b[A-Za-z0-9_-]{32,}\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!query) return undefined;
+  return Array.from(query).slice(0, MAX_AUTO_QUERY_CHARACTERS).join('');
+}
+
+export async function runAutoRecallCli(
+  inputStream: HookInputStream = process.stdin,
+  outputStream: HookOutputStream = process.stdout,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<HookOutput>((resolveTimeout) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      inputStream.destroy?.();
+      resolveTimeout({});
+    }, HOOK_WALL_CLOCK_TIMEOUT_MS);
+  });
+
+  const work = (async (): Promise<HookOutput> => {
+    const input = await readHookInput(inputStream);
+    return input === undefined
+      ? {}
+      : runAutoRecall(input, env, controller.signal);
+  })().catch(() => ({}));
+
+  const output = await Promise.race([work, timedOut]);
+  controller.abort();
+  if (timeout !== undefined) clearTimeout(timeout);
+  outputStream.write(JSON.stringify(output));
+}
+
+async function readHookInput(
+  inputStream: HookInputStream,
+): Promise<unknown | undefined> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const source of inputStream) {
+    const chunk = Buffer.from(source);
+    total += chunk.byteLength;
+    if (total > MAX_HOOK_INPUT_BYTES) return undefined;
+    chunks.push(chunk);
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseHookInput(value: unknown): HookInput | undefined {
+  if (!isRecord(value)) return undefined;
+  const submittedPrompt = value['submitted_prompt'];
+  const cwd = value['cwd'];
+  if (
+    value['hook_event_name'] !== 'UserPromptSubmit' ||
+    typeof submittedPrompt !== 'string' ||
+    submittedPrompt.trim().length === 0 ||
+    typeof cwd !== 'string'
+  ) {
+    return undefined;
+  }
+  return { submittedPrompt, cwd };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function isDirectEntryPoint(): Promise<boolean> {
+  const entryPoint = process.argv[1];
+  if (entryPoint === undefined) return false;
+  try {
+    return (
+      (await realpath(fileURLToPath(import.meta.url))) ===
+      (await realpath(resolve(entryPoint)))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (await isDirectEntryPoint()) {
+  await runAutoRecallCli().catch(() => undefined);
+}

--- a/integrations/external-context-mem0/src/config.ts
+++ b/integrations/external-context-mem0/src/config.ts
@@ -5,6 +5,7 @@
  */
 
 import { isAbsolute, parse, relative, sep } from 'node:path';
+import { constants } from 'node:fs';
 import { open, realpath, stat, type FileHandle } from 'node:fs/promises';
 import {
   ConfigurationError,
@@ -84,7 +85,9 @@ async function readConfigFile(
   let source: Buffer;
   let file: FileHandle | undefined;
   try {
-    file = await open(path, 'r');
+    // A blocked FIFO open can outlive even the Hook's explicit process exit.
+    file = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+    if (!(await file.stat()).isFile()) throw new Error('Not a regular file.');
     source = Buffer.allocUnsafe(MAX_CONFIG_BYTES + 1);
     let offset = 0;
     while (offset < source.byteLength) {

--- a/integrations/external-context-mem0/src/config.ts
+++ b/integrations/external-context-mem0/src/config.ts
@@ -4,16 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isAbsolute } from 'node:path';
-import { open, type FileHandle } from 'node:fs/promises';
+import { isAbsolute, parse, relative, sep } from 'node:path';
+import { open, realpath, stat, type FileHandle } from 'node:fs/promises';
 import {
   ConfigurationError,
+  parseAutoRecallInstanceConfig,
   parseDialect,
   parseInstanceConfig,
 } from './schemas.js';
 import type {
+  AutoRecallRuntimeConfiguration,
   DialectV1,
   InstanceConfigV2,
+  InstanceConfigV3,
   RuntimeConfiguration,
   ScopeLocation,
 } from './types.js';
@@ -25,6 +28,30 @@ export async function loadRuntimeConfiguration(
   options: { env?: NodeJS.ProcessEnv } = {},
 ): Promise<RuntimeConfiguration> {
   const env = options.env ?? process.env;
+  return loadConfiguration(env, parseInstanceConfig);
+}
+
+export async function loadAutoRecallRuntimeConfiguration(
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<AutoRecallRuntimeConfiguration> {
+  const env = options.env ?? process.env;
+  const runtime = await loadConfiguration(env, parseAutoRecallInstanceConfig);
+  const repositoryRoot = await resolveRepositoryRoot(
+    runtime.instance.autoRecall.repositoryRoot,
+  );
+  return {
+    ...runtime,
+    instance: {
+      ...runtime.instance,
+      autoRecall: { repositoryRoot },
+    },
+  };
+}
+
+async function loadConfiguration<T extends InstanceConfigV2 | InstanceConfigV3>(
+  env: NodeJS.ProcessEnv,
+  parseInstance: (value: unknown) => T,
+): Promise<{ instance: T; dialect: DialectV1; credential: string }> {
   const configPath = readRequiredEnvironment(env, CONFIG_ENV);
   if (!isAbsolute(configPath)) {
     throw new ConfigurationError(
@@ -32,9 +59,7 @@ export async function loadRuntimeConfiguration(
     );
   }
 
-  const instance = parseInstanceConfig(
-    await readConfigFile(configPath, 'instance'),
-  );
+  const instance = parseInstance(await readConfigFile(configPath, 'instance'));
   if (!isAbsolute(instance.dialectPath)) {
     throw new ConfigurationError(
       'Mem0 extension dialect path must be absolute.',
@@ -95,7 +120,7 @@ async function readConfigFile(
 }
 
 function validateInstance(
-  instance: InstanceConfigV2,
+  instance: InstanceConfigV2 | InstanceConfigV3,
   dialect: DialectV1,
 ): void {
   validateEndpoint(instance);
@@ -105,7 +130,7 @@ function validateInstance(
   validateScope(instance, dialect);
 }
 
-function validateEndpoint(instance: InstanceConfigV2): void {
+function validateEndpoint(instance: InstanceConfigV2 | InstanceConfigV3): void {
   let origin: URL;
   try {
     origin = new URL(instance.endpoint.origin);
@@ -169,10 +194,54 @@ function validateDialectSemantics(dialect: DialectV1): void {
   }
 }
 
-function validateScope(instance: InstanceConfigV2, dialect: DialectV1): void {
+function validateScope(
+  instance: InstanceConfigV2 | InstanceConfigV3,
+  dialect: DialectV1,
+): void {
   requireScopeValue(instance.scope.userId, dialect.search.userIdLocation);
   requireScopeValue(instance.scope.agentId, dialect.search.agentIdLocation);
   requireScopeValue(instance.scope.appId, dialect.search.appIdLocation);
+}
+
+async function resolveRepositoryRoot(value: string): Promise<string> {
+  if (!isAbsolute(value)) {
+    throw new ConfigurationError('Mem0 extension repository root is invalid.');
+  }
+  try {
+    const resolved = await realpath(value);
+    if (
+      !(await stat(resolved)).isDirectory() ||
+      parse(resolved).root === resolved
+    ) {
+      throw new ConfigurationError(
+        'Mem0 extension repository root is invalid.',
+      );
+    }
+    return resolved;
+  } catch (error) {
+    if (error instanceof ConfigurationError) throw error;
+    throw new ConfigurationError('Mem0 extension repository root is invalid.');
+  }
+}
+
+export async function isWithinRepository(
+  repositoryRoot: string,
+  candidate: string,
+): Promise<boolean> {
+  if (!isAbsolute(candidate)) return false;
+  try {
+    const resolved = await realpath(candidate);
+    if (!(await stat(resolved)).isDirectory()) return false;
+    const pathFromRoot = relative(repositoryRoot, resolved);
+    return (
+      pathFromRoot === '' ||
+      (!pathFromRoot.startsWith(`..${sep}`) &&
+        pathFromRoot !== '..' &&
+        !isAbsolute(pathFromRoot))
+    );
+  } catch {
+    return false;
+  }
 }
 
 function requireScopeValue(
@@ -195,7 +264,7 @@ function readRequiredEnvironment(env: NodeJS.ProcessEnv, name: string): string {
 }
 
 export function buildSearchUrl(
-  instance: InstanceConfigV2,
+  instance: InstanceConfigV2 | InstanceConfigV3,
   dialect: DialectV1,
 ): URL {
   const url = new URL(instance.endpoint.origin);

--- a/integrations/external-context-mem0/src/manifest.test.ts
+++ b/integrations/external-context-mem0/src/manifest.test.ts
@@ -23,10 +23,12 @@ describe('Mem0 Extension package', () => {
       includeTools: ['context_search'],
     });
     expect(manifest.settings).toBeUndefined();
+    expect(manifest.hooks).toBeUndefined();
     expect(server?.['env']).toBeUndefined();
     expect(server?.['trust']).toBeUndefined();
     expect(packageJson.scripts?.['build']).toContain('--bundle');
     expect(packageJson.files).toContain('dist/main.js');
+    expect(packageJson.files).toContain('dist/auto-recall.js');
     expect(packageJson.dependencies).toBeUndefined();
     expect(packageJson.private).not.toBe(true);
     expect(packageJson.name).toBe('@qwen-code/external-context-mem0');
@@ -38,20 +40,71 @@ describe('Mem0 Extension package', () => {
     });
   });
 
-  it('ships only the runtime, schemas, manifest, and documentation', async () => {
+  it('ships only the runtime, schemas, examples, manifest, and documentation', async () => {
     const packageJson = await readJson('../package.json');
 
     expect(packageJson.files).toEqual([
       'dist/main.js',
+      'dist/auto-recall.js',
       'schemas',
+      'examples',
       'qwen-extension.json',
       'README.md',
     ]);
   });
+
+  it.each([
+    {
+      platform: 'posix',
+      command:
+        "exec '/absolute/path/to/node' '/administrator/path/to/external-context-mem0/dist/auto-recall.js'",
+      shell: undefined,
+    },
+    {
+      platform: 'windows',
+      command:
+        "& 'C:\\Program Files\\nodejs\\node.exe' 'C:\\administrator\\external-context-mem0\\dist\\auto-recall.js'",
+      shell: 'powershell',
+    },
+  ])(
+    'keeps the managed Auto Recall $platform profile Hook-only',
+    async ({ platform, command, shell }) => {
+      const settings = await readJson(
+        `../examples/managed-auto-recall-user-settings-${platform}.json`,
+      );
+      const groups = settings.hooks?.['UserPromptSubmit'] ?? [];
+      const group = groups[0];
+      const hooks = group?.hooks ?? [];
+
+      expect(settings.$version).toBe(4);
+      expect(settings.mcpServers).toBeUndefined();
+      expect(Object.keys(settings.hooks ?? {})).toEqual(['UserPromptSubmit']);
+      expect(groups).toHaveLength(1);
+      expect(group?.matcher).toBe('*');
+      expect(hooks).toEqual([
+        {
+          type: 'command',
+          command,
+          ...(shell === undefined ? {} : { shell }),
+          timeout: 8000,
+          name: 'external-context-mem0-auto-recall',
+          statusMessage: 'Retrieving external context',
+        },
+      ]);
+    },
+  );
 });
 
 interface Manifest {
+  $version?: number;
   version?: string;
+  hooks?: Record<
+    string,
+    Array<{
+      matcher?: string;
+      hooks?: Array<Record<string, unknown>>;
+    }>
+  >;
   mcpServers?: Record<string, Record<string, unknown>>;
   settings?: unknown;
 }

--- a/integrations/external-context-mem0/src/request-engine.ts
+++ b/integrations/external-context-mem0/src/request-engine.ts
@@ -8,7 +8,7 @@ import { buildSearchUrl } from './config.js';
 import type {
   DialectV1,
   ExternalContextItem,
-  RuntimeConfiguration,
+  SearchRuntimeConfiguration,
   ScopeLocation,
   SearchProvider,
 } from './types.js';
@@ -22,7 +22,7 @@ export type FetchLike = (
 ) => Promise<Response>;
 
 export function createRequestEngine(
-  runtime: RuntimeConfiguration,
+  runtime: SearchRuntimeConfiguration,
   fetcher: FetchLike = fetch,
 ): SearchProvider {
   return async ({ query, signal }) => {
@@ -56,7 +56,7 @@ export function createRequestEngine(
 
 function applyAuthentication(
   headers: Headers,
-  runtime: RuntimeConfiguration,
+  runtime: SearchRuntimeConfiguration,
 ): void {
   switch (runtime.dialect.auth) {
     case 'authorization-token':
@@ -75,7 +75,7 @@ function applyAuthentication(
 
 function buildRequest(
   url: URL,
-  runtime: RuntimeConfiguration,
+  runtime: SearchRuntimeConfiguration,
   query: string,
 ): string | undefined {
   const body: Record<string, unknown> = {};

--- a/integrations/external-context-mem0/src/schemas.ts
+++ b/integrations/external-context-mem0/src/schemas.ts
@@ -6,40 +6,36 @@
 
 import { Ajv, type ValidateFunction } from 'ajv';
 // eslint-disable-next-line import/no-internal-modules -- bundle the canonical package schema
+import autoRecallInstanceConfigSchema from '../schemas/auto-recall-instance-config.schema.json' with { type: 'json' };
+// eslint-disable-next-line import/no-internal-modules -- bundle the canonical package schema
 import dialectSchema from '../schemas/dialect.schema.json' with { type: 'json' };
 // eslint-disable-next-line import/no-internal-modules -- bundle the canonical package schema
 import instanceConfigSchema from '../schemas/instance-config.schema.json' with { type: 'json' };
-import type { DialectV1, InstanceConfigV2 } from './types.js';
+import type { DialectV1, InstanceConfigV2, InstanceConfigV3 } from './types.js';
 
 const ajv = new Ajv({ allErrors: true, strict: true });
 const validateInstance = ajv.compile(instanceConfigSchema);
+const validateAutoRecallInstance = ajv.compile(autoRecallInstanceConfigSchema);
 const validateDialect = ajv.compile(dialectSchema);
 
 export class ConfigurationError extends Error {}
 
 export function parseInstanceConfig(value: unknown): InstanceConfigV2 {
-  requireValid(
+  return parseInstance(
     validateInstance,
     value,
     'Mem0 extension instance configuration is invalid.',
   );
-  const parsed = value as Omit<InstanceConfigV2, 'endpoint'> & {
-    endpoint: Omit<
-      InstanceConfigV2['endpoint'],
-      'basePath' | 'allowInsecureHttp'
-    > &
-      Partial<
-        Pick<InstanceConfigV2['endpoint'], 'basePath' | 'allowInsecureHttp'>
-      >;
-  };
-  return {
-    ...parsed,
-    endpoint: {
-      ...parsed.endpoint,
-      basePath: parsed.endpoint.basePath ?? '',
-      allowInsecureHttp: parsed.endpoint.allowInsecureHttp ?? false,
-    },
-  };
+}
+
+export function parseAutoRecallInstanceConfig(
+  value: unknown,
+): InstanceConfigV3 {
+  return parseInstance(
+    validateAutoRecallInstance,
+    value,
+    'Mem0 extension auto-recall configuration is invalid.',
+  );
 }
 
 export function parseDialect(value: unknown): DialectV1 {
@@ -59,4 +55,21 @@ function requireValid(
   if (!validate(value)) {
     throw new ConfigurationError(message);
   }
+}
+
+function parseInstance<T extends InstanceConfigV2 | InstanceConfigV3>(
+  validate: ValidateFunction,
+  value: unknown,
+  message: string,
+): T {
+  requireValid(validate, value, message);
+  const parsed = value as T;
+  return {
+    ...parsed,
+    endpoint: {
+      ...parsed.endpoint,
+      basePath: parsed.endpoint.basePath ?? '',
+      allowInsecureHttp: parsed.endpoint.allowInsecureHttp ?? false,
+    },
+  };
 }

--- a/integrations/external-context-mem0/src/types.ts
+++ b/integrations/external-context-mem0/src/types.ts
@@ -11,8 +11,7 @@ export type AuthenticationKind =
 
 export type ScopeLocation = 'json' | 'json.filters' | 'query' | 'omit';
 
-export interface InstanceConfigV2 {
-  schemaVersion: 2;
+interface InstanceConfigBase {
   dialectPath: string;
   endpoint: {
     origin: string;
@@ -26,6 +25,17 @@ export interface InstanceConfigV2 {
     appId?: string;
   };
   timeoutMs: number;
+}
+
+export interface InstanceConfigV2 extends InstanceConfigBase {
+  schemaVersion: 2;
+}
+
+export interface InstanceConfigV3 extends InstanceConfigBase {
+  schemaVersion: 3;
+  autoRecall: {
+    repositoryRoot: string;
+  };
 }
 
 export interface DialectV1 {
@@ -59,6 +69,16 @@ export interface RuntimeConfiguration {
   dialect: DialectV1;
   credential: string;
 }
+
+export interface AutoRecallRuntimeConfiguration {
+  instance: InstanceConfigV3;
+  dialect: DialectV1;
+  credential: string;
+}
+
+export type SearchRuntimeConfiguration =
+  | RuntimeConfiguration
+  | AutoRecallRuntimeConfiguration;
 
 export interface ExternalContextItem {
   id: string;


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Adds an administrator-installed, opt-in `UserPromptSubmit` command-Hook profile to the published Mem0 External Context package. The profile accepts a strict `schemaVersion: 3` instance configuration with a canonical repository binding, reuses the administrator-owned `DialectV1` and existing bounded request engine, derives its query only from `submitted_prompt`, and injects at most five retrieved records as structured `untrusted_external_context`. The default Extension manifest remains MCP-only with exactly `context_search`, and existing `schemaVersion: 2` deployments using regular configuration files are unchanged. The package also ships the separate Hook bundle, strict v3 schema, unbranded POSIX and Windows registration examples, and administrator deployment guidance.

## Why it's needed

Administrators who need deterministic recall before eligible user turns currently must build another integration or rely on the model to choose `context_search`. This adds a narrow Hook-only path while keeping endpoints, credentials, fixed scope, repository binding, and enablement outside model control, without changing Qwen Core or shipping provider presets.

## Reviewer Test Plan

### How to verify

1. Configure a temporary repository root, a v3 instance file, an administrator-owned `DialectV1`, and a loopback HTTP provider. Invoke the packaged Hook with a valid `UserPromptSubmit` event and confirm it sends exactly one bounded request derived from `submitted_prompt`, not the expanded prompt, then returns the provider result as `untrusted_external_context`.
2. Repeat with missing provenance, an outside working directory, invalid configuration, an empty result, an oversized response, and a provider timeout. Confirm each case returns `{}` with exit code zero and no integration-generated stderr after the fixed Hook entry point starts. Include a TCP server that accepts a connection but never completes TLS: the Hook must flush its output and actually exit promptly after the provider timeout. Instance and dialect FIFO paths must be rejected promptly without an outer process kill. Repeated `token`, `api_key`, `password`, and `secret` near misses must take less than 2 seconds of sanitizer work after bundle import, with a separate 8-second subprocess deadline covering startup and exit.
3. Start the existing MCP entry point with a v2 configuration and confirm it still exposes exactly `context_search`; confirm a v3 configuration is rejected by MCP and the default Extension manifest contains no Hook.
4. Inspect the package dry-run and confirm it contains both runtime bundles, both instance schemas, the dialect schema, manifest, README, and unbranded Hook examples, with no provider-specific preset or dialect. Package test commands build these bundles before running the subprocess suite.
5. Run TUI or headless user turns with the administrator Hook profile and confirm one recall per eligible submission. Run automation with each all-Hook opt-out (`--bare`, `--safe-mode`, and `disableAllHooks: true`) and confirm it reaches the model without executing the Hook or sending a recall request. A separate administrator configuration without this Hook supports automation that needs other Hooks. Events lacking `submitted_prompt` must also send no recall request.

### Evidence (Before & After)

Before: the package supported only on-demand retrieval through the model-selected `context_search` MCP tool.

After: an administrator can explicitly install the separate `UserPromptSubmit` command Hook so eligible TUI and headless CLI user submissions (including stream-json input from SDK clients) receive bounded, structured, untrusted external context before model invocation.

Automated subprocess E2E evidence is posted as a separate PR comment. This change adds no TUI surface, so screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS; Node.js v22.22.3; npm 10.9.8; local loopback synthetic HTTP/TCP providers and model; locally built CLI and shipped Hook bundles.

## Risk & Scope

- Main risk or tradeoff: Once an administrator explicitly enables the Hook, sanitized user prompt text is sent to the configured external service and retrieved content is sent to the model. This includes headless and stream-json user turns supplying `submitted_prompt`; it is not a TUI-only filter. Automation can disable all Hooks with `--bare`, `--safe-mode`, or `disableAllHooks: true` in managed settings before startup; the two flags also change which customizations are loaded. When automation needs other Hooks, administrators can use a separate controlled `QWEN_HOME` without this Hook and omit its configuration and credential from that launcher. Sanitization is best effort rather than DLP, and each eligible turn starts one bounded Node process and may wait for the configured provider timeout.
- Not validated / out of scope: Live vendor services, Windows and Linux runtime execution, write operations, memory extraction, retries, redirects, arbitrary templates, and provider-specific dialects are not validated or included.
- Breaking changes / migration notes: No schema change. Instance and dialect paths must resolve to regular files; FIFO and other special-file configurations are now rejected in both profiles. The default manifest and regular-file v2 `context_search` deployments remain unchanged; v3 is accepted only by the separately installed Hook and is never enabled automatically.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为已发布的 Mem0 External Context 包新增一个由管理员安装、显式选择启用的 `UserPromptSubmit` 命令 Hook 模式。该模式接受严格的 `schemaVersion: 3` 实例配置并绑定规范化后的仓库目录，复用管理员维护的 `DialectV1` 和现有有界请求引擎，只从 `submitted_prompt` 派生查询，并以结构化 `untrusted_external_context` 的形式注入最多五条检索结果。默认 Extension manifest 仍然只有 MCP，并且只暴露 `context_search`；使用普通配置文件的现有 `schemaVersion: 2` 部署保持不变。包内同时发布独立 Hook bundle、严格的 v3 schema、无品牌的 POSIX/Windows 注册示例和管理员部署说明。

## 为什么需要

当前，需要在符合条件的用户轮次前确定性召回上下文的管理员，只能自行构建另一套集成，或者依赖模型主动选择 `context_search`。本 PR 增加一条范围收敛的 Hook-only 路径，同时继续将 endpoint、凭证、固定 scope、仓库绑定和启用权置于模型控制之外，不修改 Qwen Core，也不发布任何厂商 preset。

## 审阅者测试计划

### 如何验证

1. 配置临时仓库根目录、v3 实例文件、管理员维护的 `DialectV1` 和本机回环 HTTP provider。使用有效 `UserPromptSubmit` 事件调用打包后的 Hook，确认它只基于 `submitted_prompt` 而非扩展后的 prompt 发出恰好一次有界请求，并将 provider 结果作为 `untrusted_external_context` 返回。
2. 分别使用缺失 provenance、仓库外工作目录、非法配置、空结果、超限响应和 provider 超时再次调用。确认固定 Hook 入口启动后，每种情况都返回 `{}`、退出码为零，且没有集成自身产生的 stderr。包括用只接受连接、始终不完成 TLS 握手的 TCP 服务验证：Hook 必须刷完输出，并在 provider 超时后及时真正退出。instance 和 dialect 的 FIFO 路径必须被及时拒绝，无需外部终止进程。重复 `token`、`api_key`、`password` 和 `secret` 的近似匹配输入在 bundle 导入完成后的脱敏计算必须低于 2 秒；另有 8 秒子进程期限覆盖启动和退出。
3. 使用 v2 配置启动现有 MCP 入口，确认它仍然只暴露 `context_search`；确认 MCP 会拒绝 v3 配置，且默认 Extension manifest 中没有 Hook。
4. 检查 package dry-run，确认包内包含两个运行时 bundle、两个实例 schema、dialect schema、manifest、README 和无品牌 Hook 示例，并且不包含任何厂商专用 preset 或 dialect。 包级测试命令会先构建这些 bundle，再执行子进程测试。
5. 使用管理员 Hook 模式运行 TUI 或 headless 用户轮次，确认每次符合条件的提交恰好召回一次。分别使用禁用全部 Hook 的三种方式（`--bare`、`--safe-mode` 和 `disableAllHooks: true`）运行自动化，确认模型正常调用，但不执行 Hook、不发送召回请求。如果自动化仍需其他 Hook，可使用未注册本 Hook 的独立管理员配置。缺少 `submitted_prompt` 的事件也必须不发送召回请求。

### 证据（前后对比）

之前：该包只支持通过模型选择的 `context_search` MCP 工具按需检索。

之后：管理员可以显式安装独立的 `UserPromptSubmit` 命令 Hook，使符合条件的 TUI 和 headless CLI 用户提交（包括 SDK 客户端的 stream-json 输入）在模型调用前获得有界、结构化且不可信的外部上下文。

自动化子进程 E2E 证据会作为独立 PR 评论发布。本改动没有新增 TUI 界面，因此截图为 N/A。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS；Node.js v22.22.3；npm 10.9.8；本机回环 synthetic HTTP/TCP provider 和模型；本地构建的 CLI 与发布用 Hook bundle。

## 风险与范围

- 主要风险或取舍：管理员显式启用 Hook 后，经过脱敏的用户 prompt 文本会发送给所配置的外部服务，检索内容则会发送给模型。这包括提供 `submitted_prompt` 的 headless 和 stream-json 用户轮次，并非仅限 TUI 的过滤器。自动化可在启动前使用 `--bare`、`--safe-mode`，或在受控配置中设置 `disableAllHooks: true` 来禁用全部 Hook；这两个 flag 还会改变其他自定义配置的加载范围。如果自动化仍需使用其他 Hook，管理员可使用不注册该 Hook 的独立受控 `QWEN_HOME`，并从该启动环境中去掉 Auto Recall 配置和凭证。脱敏是尽力而为的降低风险措施，并非 DLP；每个符合条件的轮次还会启动一个有界 Node 进程，并可能等待配置的 provider 超时。
- 未验证或不在范围内：未验证或包含真实厂商服务、Windows/Linux 运行时执行、写操作、记忆提取、重试、重定向、任意模板和厂商专用 dialect。
- 破坏性变更或迁移说明：没有 schema 变更。instance 和 dialect 路径必须解析到普通文件；两个模式现在都会拒绝 FIFO 及其他特殊文件配置。默认 manifest 和使用普通文件的 v2 `context_search` 部署保持不变；v3 只由单独安装的 Hook 接受，并且绝不会自动启用。

## 关联 Issue

N/A

</details>

