### PR TITLE
feat(goal): show what a Goal has spent against the window it is allowed

### DIFF
--- a/docs/users/features/goals.md
+++ b/docs/users/features/goals.md
@@ -16,7 +16,7 @@ A Goal keeps Qwen Code working across turns until a stated condition is met. Set
 
 Creating, editing, or resuming a Goal requires a trusted workspace (`/trust`). Headless usage is covered in [Headless Mode](./headless.md#run-a-persistent-goal).
 
-Once a Goal has billed a turn, the footer pill and every status card show what it has spent against the window it is allowed, as `1.2k/30.0m`. The figure counts the model calls the Goal makes in its own turns; subagents and the verifier's own checks are not included. The window is set by [`model.goalTokenBudget`](../configuration/settings.md), and a Goal with no budget shows only what it has spent. A Goal that has not billed a turn yet shows no figures at all.
+Once a Goal has billed a turn, the footer pill and every status card show what it has spent against the window it is allowed, as `1.2k/30.0m`. The figure counts the model calls the Goal makes in its own turns; subagents and the verifier's own checks are not included. The window is set by [`model.goalTokenBudget`](../configuration/settings.md); resuming a Goal that has spent its window grants another one on top of what it has already spent, so the figure reads `30.0m/60.0m` rather than starting over. A Goal with no budget shows only what it has spent. A Goal that has not billed a turn yet shows no figures at all.
 
 ## Interrupting a Goal
 

--- a/docs/users/features/goals.md
+++ b/docs/users/features/goals.md
@@ -16,6 +16,8 @@ A Goal keeps Qwen Code working across turns until a stated condition is met. Set
 
 Creating, editing, or resuming a Goal requires a trusted workspace (`/trust`). Headless usage is covered in [Headless Mode](./headless.md#run-a-persistent-goal).
 
+Once a Goal has billed a turn, the footer pill and every status card show what it has spent against the window it is allowed, as `1.2k/30.0m`. The figure counts the model calls the Goal makes in its own turns; subagents and the verifier's own checks are not included. The window is set by [`model.goalTokenBudget`](../configuration/settings.md), and a Goal with no budget shows only what it has spent. A Goal that has not billed a turn yet shows no figures at all.
+
 ## Interrupting a Goal
 
 Cancelling a Goal turn pauses the Goal. Press Esc while the model is answering or while its tools are still running, and the turn stops, the Goal moves to `paused`, and the card and `/goal` both say why it stopped. Nothing continues until you run `/goal resume`.

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -10,6 +10,7 @@ import type {
   CronJob,
   GoalJournal,
   GoalRuntime,
+  GoalSnapshotV2,
   GoalStateRecordPayloadV2,
   GoalTurnPermit,
   ToolCallRequestInfo,
@@ -55,6 +56,7 @@ import type { Part } from '@google/genai';
 import { EventEmitter } from 'node:events';
 import {
   runNonInteractive,
+  formatGoalState,
   skipHeadlessLoopSentinel,
   TurnInterruptedError,
 } from './nonInteractiveCli.js';
@@ -8623,5 +8625,93 @@ describe('runNonInteractive', () => {
         await fs.rm(realTmpDir, { recursive: true, force: true });
       }
     });
+  });
+});
+
+describe('formatGoalState', () => {
+  const goalSnapshot = (
+    overrides: Partial<NonNullable<GoalSnapshotV2['goal']>> = {},
+  ): GoalSnapshotV2 => ({
+    v: 2,
+    activity: 'idle',
+    goal: {
+      goalId: 'goal-1',
+      revision: 1,
+      objective: 'ship the release notes',
+      status: 'active',
+      evidenceCursor: { recordId: null },
+      turnCount: 0,
+      activeTimeMs: 0,
+      tokensUsed: 0,
+      createdAt: 0,
+      updatedAt: 0,
+      ...overrides,
+    },
+  });
+
+  it('reports turns and spend against the budget', () => {
+    // Spelled out rather than abbreviated: this output is read in a terminal
+    // and piped into scripts, neither of which is helped by `1.2k`.
+    expect(
+      formatGoalState(
+        goalSnapshot({
+          turnCount: 3,
+          tokensUsed: 1_234,
+          tokenBudget: 30_000_000,
+        }),
+        'status',
+      ),
+    ).toBe(
+      'Goal active: ship the release notes\nUsage: 3 turns · 1,234 of 30,000,000 tokens',
+    );
+  });
+
+  it('reports spend alone when the Goal has no budget', () => {
+    expect(
+      formatGoalState(
+        goalSnapshot({ turnCount: 1, tokensUsed: 900 }),
+        'status',
+      ),
+    ).toBe('Goal active: ship the release notes\nUsage: 1 turn · 900 tokens');
+  });
+
+  it('omits the spend it has none of', () => {
+    expect(
+      formatGoalState(
+        goalSnapshot({ turnCount: 2, tokenBudget: 30_000_000 }),
+        'status',
+      ),
+    ).toBe('Goal active: ship the release notes\nUsage: 2 turns');
+  });
+
+  it('says nothing about usage for a Goal that has not run', () => {
+    expect(formatGoalState(goalSnapshot(), 'status')).toBe(
+      'Goal active: ship the release notes',
+    );
+  });
+
+  it('keeps the stop reason below the usage line', () => {
+    // The reason is why the Goal is where it is; the figures are context for
+    // it, so they read first.
+    expect(
+      formatGoalState(
+        goalSnapshot({
+          status: 'paused',
+          turnCount: 3,
+          tokensUsed: 1_234,
+          tokenBudget: 30_000_000,
+          lastReason: 'Paused with /goal pause.',
+        }),
+        'status',
+      ),
+    ).toBe(
+      'Goal paused: ship the release notes\nUsage: 3 turns · 1,234 of 30,000,000 tokens\nReason: Paused with /goal pause.',
+    );
+  });
+
+  it('has no usage to report for a cleared Goal', () => {
+    expect(
+      formatGoalState({ v: 2, activity: 'idle', goal: null }, 'clear'),
+    ).toBe('Goal cleared.');
   });
 });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -257,7 +257,14 @@ function projectLegacyActiveGoal(snapshot: GoalSnapshotV2): ActiveGoal | null {
   };
 }
 
-function formatGoalState(
+/**
+ * The TEXT rendering of a Goal control's outcome.
+ *
+ * Exported so its shape can be pinned directly: the states worth checking --
+ * a Goal mid-run, one with no budget, one that has billed nothing -- are far
+ * cheaper to construct as snapshots than to drive a headless run into.
+ */
+export function formatGoalState(
   snapshot: GoalSnapshotV2,
   operation: 'status' | 'set' | 'edit' | 'pause' | 'resume' | 'clear',
 ): string {
@@ -268,12 +275,28 @@ function formatGoalState(
   const status =
     goal.status === 'usage_limited' ? 'usage limited' : goal.status;
   const summary = `Goal ${status}: ${goal.objective}`;
+  // Spelled out rather than abbreviated: this output is read in a terminal
+  // scrollback and piped into scripts, neither of which is helped by `1.2k`.
+  const usage: string[] = [];
+  if (goal.turnCount > 0) {
+    usage.push(`${goal.turnCount} ${goal.turnCount === 1 ? 'turn' : 'turns'}`);
+  }
+  if (goal.tokensUsed > 0) {
+    const used = goal.tokensUsed.toLocaleString('en-US');
+    usage.push(
+      goal.tokenBudget === undefined
+        ? `${used} tokens`
+        : `${used} of ${goal.tokenBudget.toLocaleString('en-US')} tokens`,
+    );
+  }
+  const withUsage =
+    usage.length > 0 ? `${summary}\nUsage: ${usage.join(' · ')}` : summary;
   // Every non-active status now carries a reason, so gating on two of them
   // drops a paused Goal's reason from TEXT output while STREAM_JSON still
   // ships it -- and the user doc promises every pause states why.
   return goal.status !== 'active' && goal.lastReason
-    ? `${summary}\nReason: ${goal.lastReason}`
-    : summary;
+    ? `${withUsage}\nReason: ${goal.lastReason}`
+    : withUsage;
 }
 
 async function claimUserGoalTurn(

--- a/packages/cli/src/ui/components/GoalPill.test.tsx
+++ b/packages/cli/src/ui/components/GoalPill.test.tsx
@@ -137,6 +137,55 @@ describe('GoalPill', () => {
     unmount();
   });
 
+  it('shows spend against the budget once a turn has billed', () => {
+    vi.setSystemTime(NOW);
+    const { lastFrame, unmount } = renderPill({
+      snapshot: snapshot('active', 'running', {
+        tokensUsed: 1_234,
+        tokenBudget: 30_000_000,
+      }),
+    });
+
+    expect(lastFrame()).toContain('(5s · 1.2k/30.0m)');
+    unmount();
+  });
+
+  it('shows spend alone when the Goal has no budget', () => {
+    vi.setSystemTime(NOW);
+    const { lastFrame, unmount } = renderPill({
+      snapshot: snapshot('active', 'running', { tokensUsed: 1_234 }),
+    });
+
+    expect(lastFrame()).toContain('(5s · 1.2k)');
+    unmount();
+  });
+
+  it('shows no figures for a Goal that has not billed a turn', () => {
+    // A fresh Goal reading `0/30.0m` says nothing the status has not, and
+    // the pill sits in a footer with little room to say it.
+    vi.setSystemTime(NOW);
+    const { lastFrame, unmount } = renderPill({
+      snapshot: snapshot('active', 'running', { tokenBudget: 30_000_000 }),
+    });
+
+    expect(lastFrame()).toContain('(5s)');
+    expect(lastFrame()).not.toContain('30.0m');
+    unmount();
+  });
+
+  it('keeps showing what a stopped Goal spent', () => {
+    vi.setSystemTime(NOW);
+    const { lastFrame, unmount } = renderPill({
+      snapshot: snapshot('paused', 'idle', {
+        tokensUsed: 2_500_000,
+        tokenBudget: 30_000_000,
+      }),
+    });
+
+    expect(lastFrame()).toContain('(2s · 2.5m/30.0m)');
+    unmount();
+  });
+
   it('keeps paused elapsed time frozen while wall clock advances', () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);

--- a/packages/cli/src/ui/components/GoalPill.tsx
+++ b/packages/cli/src/ui/components/GoalPill.tsx
@@ -14,8 +14,25 @@ import type { GoalRuntime } from '@qwen-code/qwen-code-core/goals/goal-runtime.j
 import { useConfig } from '../contexts/ConfigContext.js';
 import { theme } from '../semantic-colors.js';
 import { ICON } from '../constants.js';
+import { formatTokenCount } from '../statusLinePresets.js';
 
 const ELAPSED_REFRESH_MS = 1000;
+
+/**
+ * The Goal's spend against the window it is allowed, or nothing.
+ *
+ * A Goal that has not billed a turn yet shows no figures rather than a
+ * reassuring `0/30.0m`: the pill sits in a footer with little room, and a
+ * zero says nothing the status has not already said. A Goal with no budget
+ * shows what it has spent, since that is the whole of what is known.
+ */
+function formatSpend(goal: NonNullable<GoalSnapshotV2['goal']>): string {
+  if (goal.tokensUsed <= 0) return '';
+  const used = formatTokenCount(goal.tokensUsed);
+  return goal.tokenBudget === undefined
+    ? used
+    : `${used}/${formatTokenCount(goal.tokenBudget)}`;
+}
 
 function formatElapsed(ms: number): string {
   if (ms < 1000) return '';
@@ -130,7 +147,9 @@ export const GoalPill: React.FC<GoalPillProps> = ({ snapshot }) => {
   if (!visible) return null;
 
   const elapsed = formatElapsed(elapsedActiveTime(goal, Date.now()));
-  const suffix = elapsed ? ` (${elapsed})` : '';
+  const spend = formatSpend(goal);
+  const detail = [elapsed, spend].filter(Boolean).join(' · ');
+  const suffix = detail ? ` (${detail})` : '';
   return (
     <Text color={visible.color}>
       {visible.icon} /goal {visible.label}

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
@@ -171,7 +171,7 @@ describe('<GoalStatusMessage />', () => {
     );
 
     expect(lastFrame()).toContain('1.2k tokens');
-    expect(lastFrame()).not.toContain('/');
+    expect(lastFrame()).not.toContain('1.2k/');
   });
 
   it('says nothing about spend before a turn has billed', () => {

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
@@ -14,6 +14,7 @@ function snapshot(
   status: NonNullable<GoalSnapshotV2['goal']>['status'],
   activity: GoalSnapshotV2['activity'] = 'idle',
   lastReason?: string,
+  overrides: Partial<NonNullable<GoalSnapshotV2['goal']>> = {},
 ): GoalSnapshotV2 {
   return {
     v: 2,
@@ -30,6 +31,7 @@ function snapshot(
       createdAt: 1_000,
       updatedAt: 13_000,
       ...(lastReason ? { lastReason } : {}),
+      ...overrides,
     },
   };
 }
@@ -144,5 +146,54 @@ describe('<GoalStatusMessage />', () => {
     if (value.goal?.lastReason) {
       expect(output).toContain(`Reason: ${value.goal.lastReason}`);
     }
+  });
+
+  it('reports spend against the budget on a lifecycle card', () => {
+    const { lastFrame } = render(
+      <GoalStatusMessage
+        snapshot={snapshot('active', 'running', undefined, {
+          tokensUsed: 1_234,
+          tokenBudget: 30_000_000,
+        })}
+      />,
+    );
+
+    expect(lastFrame()).toContain('4 turns · 12s · 1.2k/30.0m tokens');
+  });
+
+  it('reports spend alone when the Goal has no budget', () => {
+    const { lastFrame } = render(
+      <GoalStatusMessage
+        snapshot={snapshot('paused', 'idle', undefined, {
+          tokensUsed: 1_234,
+        })}
+      />,
+    );
+
+    expect(lastFrame()).toContain('1.2k tokens');
+    expect(lastFrame()).not.toContain('/');
+  });
+
+  it('says nothing about spend before a turn has billed', () => {
+    const { lastFrame } = render(
+      <GoalStatusMessage
+        snapshot={snapshot('active', 'running', undefined, {
+          tokenBudget: 30_000_000,
+        })}
+      />,
+    );
+
+    expect(lastFrame()).toContain('4 turns · 12s');
+    expect(lastFrame()).not.toContain('tokens');
+  });
+
+  it('leaves the legacy card without spend it cannot know', () => {
+    // The legacy props carry an iteration count and nothing else; there is no
+    // record behind them to read a spend off.
+    const { lastFrame } = render(
+      <GoalStatusMessage kind="set" condition="finish the refactor" />,
+    );
+
+    expect(lastFrame()).not.toContain('tokens');
   });
 });

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
@@ -10,6 +10,7 @@ import type { GoalSnapshotV2, GoalStateCause } from '@qwen-code/qwen-code-core';
 import { theme } from '../../semantic-colors.js';
 import { ICON } from '../../constants.js';
 import { formatDuration } from '../../utils/formatters.js';
+import { formatTokenCount } from '../../statusLinePresets.js';
 import { isTerminalGoalStatusKind, type GoalStatusKind } from '../../types.js';
 
 interface LegacyGoalStatusMessageProps {
@@ -112,6 +113,14 @@ const GoalStateCard: React.FC<GoalStateMessageProps> = ({
   }
   if (goal.activeTimeMs > 0) {
     stats.push(formatDuration(goal.activeTimeMs, { hideTrailingZeros: true }));
+  }
+  if (goal.tokensUsed > 0) {
+    const used = formatTokenCount(goal.tokensUsed);
+    stats.push(
+      goal.tokenBudget === undefined
+        ? `${used} tokens`
+        : `${used}/${formatTokenCount(goal.tokenBudget)} tokens`,
+    );
   }
   const subtitle = stats.length > 0 ? stats.join(' · ') : null;
   const reason =

--- a/packages/cli/src/ui/opentui/event-adapter.ts
+++ b/packages/cli/src/ui/opentui/event-adapter.ts
@@ -752,6 +752,8 @@ export type GoalSnapshotLike = {
     status?: string;
     turnCount?: number;
     activeTimeMs?: number;
+    tokensUsed?: number;
+    tokenBudget?: number;
     lastReason?: string;
   } | null;
   activity?: string;

--- a/packages/cli/src/ui/opentui/live-session-model.test.ts
+++ b/packages/cli/src/ui/opentui/live-session-model.test.ts
@@ -656,6 +656,47 @@ describe('describeGoalCard (ink GoalStateCard)', () => {
     ).toMatchObject({ subtitle: '2 turns · 1m 1s' });
   });
 
+  it('carries spend in the subtitle, matching the ink card', () => {
+    expect(
+      describeGoalCard(
+        snap({
+          objective: 'o',
+          status: 'active',
+          turnCount: 2,
+          activeTimeMs: 61000,
+          tokensUsed: 1234,
+          tokenBudget: 30_000_000,
+        }),
+      ),
+    ).toMatchObject({ subtitle: '2 turns · 1m 1s · 1.2k/30.0m tokens' });
+  });
+
+  it('carries spend alone when the Goal has no budget', () => {
+    expect(
+      describeGoalCard(
+        snap({
+          objective: 'o',
+          status: 'active',
+          turnCount: 1,
+          tokensUsed: 900,
+        }),
+      ),
+    ).toMatchObject({ subtitle: '1 turn · 900 tokens' });
+  });
+
+  it('says nothing about spend before a turn has billed', () => {
+    expect(
+      describeGoalCard(
+        snap({
+          objective: 'o',
+          status: 'active',
+          turnCount: 2,
+          tokenBudget: 30_000_000,
+        }),
+      ),
+    ).toMatchObject({ subtitle: '2 turns' });
+  });
+
   it('shows the reason only off-active or verifying', () => {
     expect(
       describeGoalCard(

--- a/packages/cli/src/ui/opentui/live-session-model.ts
+++ b/packages/cli/src/ui/opentui/live-session-model.ts
@@ -19,6 +19,7 @@ import type { AnsiToken } from '@qwen-code/qwen-code-core';
 import type { CompressionProps } from '../types.js';
 import { ICON } from '../constants.js';
 import { formatDuration } from '../utils/formatters.js';
+import { formatTokenCount } from '../statusLinePresets.js';
 
 export type ToolConfirmState = 'pending' | 'approved' | 'rejected';
 
@@ -613,6 +614,15 @@ export function describeGoalCard(
   const activeTimeMs = goal.activeTimeMs ?? 0;
   if (activeTimeMs > 0)
     stats.push(formatDuration(activeTimeMs, { hideTrailingZeros: true }));
+  const tokensUsed = goal.tokensUsed ?? 0;
+  if (tokensUsed > 0) {
+    const used = formatTokenCount(tokensUsed);
+    stats.push(
+      goal.tokenBudget === undefined
+        ? `${used} tokens`
+        : `${used}/${formatTokenCount(goal.tokenBudget)} tokens`,
+    );
+  }
   const reason =
     (goal.status ?? 'active') !== 'active' || activity === 'verifying'
       ? goal.lastReason?.trim()


### PR DESCRIPTION
## What this PR does

Every surface that shows a Goal now also shows what it has spent against the window it is allowed. The footer pill reads `◎ /goal active (28s · 147.0k/30.0m)`, the status card's subtitle gains a `80.7k/30.0m tokens` stat, and headless status gains a `Usage:` line -- in the TEXT output and, because that string is the single final message, in `result.summary` under `--output-format json` as well.

Three display rules, applied identically at every site. A Goal that has not billed a turn shows no figures: a fresh `0/30.0m` says nothing the status has not already said, and the pill sits in a footer with little room to say it. A Goal with no budget shows what it has spent, since that is the whole of what is known about it. A stopped Goal keeps showing its spend, because what a paused or blocked Goal cost is exactly what the user is deciding about when they choose whether to resume.

The pill and the cards abbreviate through the `formatTokenCount` the status line already uses. The headless line spells the figures out instead, because that output is read in terminal scrollback and piped into scripts, and neither is helped by `1.2k`.

Two things beyond a literal reading of the change. The OpenTUI card computes its own subtitle from its own snapshot type, so both were extended alongside the ink card rather than left to drift apart under the parity gate. And `formatGoalState` is exported so its output can be pinned directly: the states worth checking, a Goal mid-run, one with no budget, one that has billed nothing, are far cheaper to construct as snapshots than to drive a headless run into, and the file already exports `skipHeadlessLoopSentinel` for the same reason.

## Why it's needed

The spend window is enforced but invisible. `tokensUsed` and `tokenBudget` have been on the Goal record since budgets landed, the 30,000,000 default stops the Goal and hands it back to the user, and until now nothing showed how close it was. Grepping `tokensUsed` across the TUI and the Web Shell returned test fixtures and nothing else.

So the user watched the turn count climb with no way to tell a Goal two percent into its window from one about to stop. Codex puts the same pair in its TUI status line as `63.9K/50K`; this is the equivalent, at the surfaces this CLI already uses to say what a Goal is doing.

Web Shell is deliberately not in this PR. Its strip and dialog read the hand-copied SDK `GoalRecord`, which lacks both fields, so it needs a type change first and is a separate change.

## Reviewer Test Plan

### How to verify

```
cd packages/cli && npx vitest run src/ui/components/GoalPill.test.tsx src/ui/components/messages/GoalStatusMessage.test.tsx src/ui/opentui/live-session-model.test.ts src/nonInteractiveCli.test.ts
```

The new cases pin the exact rendered string at all four sites, and each site has a case for the with-budget, no-budget, and nothing-billed rules. `formatGoalState` additionally pins that the stop reason still reads below the usage line.

To see it live, set any Goal that runs a few turns and watch the footer.

### Evidence (Before & After)

**Before.** Neither surface shows the pair; `tokensUsed` appears nowhere in either package's production code:

```
$ git grep -l tokensUsed -- packages/cli/src/ui packages/web-shell/client
packages/cli/src/ui/commands/goalCommand.test.ts
packages/cli/src/ui/components/GoalPill.test.tsx
packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
packages/cli/src/ui/hooks/use-llm-stream.test.tsx
packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
packages/web-shell/client/e2e/visuals/screenshots.spec.ts
```

Every hit is a test fixture. The footer read `◎ /goal active (19s)` and the card read `1 turn · 21.7s`.

**After — footer pill, live TUI**, climbing as the Goal works:

```
➜ work · qwen3.8-max · 1.0m Context 2.9% used          ◎︎ /goal active (19s · 87.2k/30.0m)
➜ work · qwen3.8-max · 1.0m Context 3% used           ◎︎ /goal active (28s · 147.0k/30.0m)
```

**After — status card, live TUI:**

```
✓︎ Goal complete · 1 turn · 21.7s · 80.7k/30.0m tokens
  Goal: Read a.txt, b.txt and c.txt with your file tools and quote the exact contents of each.
  Reason: The delivered output quotes the exact contents of all three files...
```

**After — headless TEXT**, resuming a session whose Goal had already run:

```
$ qwen -c -p '/goal'
Goal complete: Read a.txt, b.txt and c.txt with your file tools and quote the exact contents of each.
Usage: 1 turn · 63,214 of 30,000,000 tokens
Reason: All three files were read using the read_file tool (evidence f05eb286, cf501e22, 287fcc24)...
```

**After — a Goal that has not billed a turn**, which is what `/goal set` prints before the first turn runs:

```
$ qwen -p '/goal set Read a.txt and report its exact contents, then stop.'
Goal active: Read a.txt and report its exact contents, then stop.
```

No usage line, as intended.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, `npm run build`, interactive TUI under tmux at 120x34 and headless `--output-format text`, live model.

## Risk & Scope

- Main risk or tradeoff: the pill grows by up to eleven characters in a footer that is already tight on narrow terminals. The nothing-billed rule keeps it off a fresh Goal, and the abbreviated form keeps it short, but on a very narrow terminal it is one more thing competing for the line.
- Not validated / out of scope: Web Shell, which needs the SDK type first and is a separate change. The meter's own scope is unchanged; it still excludes subagents and the verifier's checks, and the user doc now says so.
- Breaking changes / migration notes: none. Display only, reading two fields that were already on the record. `formatGoalState` becomes exported.

## Linked Issues

Part of #4228.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

现在每一个显示 Goal 的界面都会同时显示它在被允许的额度里已经花掉多少。底栏 pill 读作 `◎ /goal active (28s · 147.0k/30.0m)`，状态卡片的副标题多出一段 `80.7k/30.0m tokens`，headless 的状态输出多出一行 `Usage:`——TEXT 里有，而且因为那个字符串就是唯一的最终消息，`--output-format json` 的 `result.summary` 里同样有。

三条显示规则，四个位置完全一致。还没计过费的 Goal 什么数字都不显示：刚创建时的 `0/30.0m` 并没有说出状态本身没说过的东西，而 pill 待在底栏里也没有多余的地方去说它。没有预算的 Goal 只显示已花掉多少，因为那就是已知的全部。已经停下的 Goal 继续显示它的花费，因为一个 paused 或 blocked 的 Goal 花了多少，恰恰就是用户在决定要不要恢复时要看的。

pill 和卡片用状态栏已有的 `formatTokenCount` 做缩写。headless 那行则把数字完整写出来，因为那份输出是在终端回滚里读、被管道喂给脚本的，这两种场景都不会因为 `1.2k` 而变好。

有两处超出字面改动的地方。OpenTUI 的卡片用它自己的快照类型算自己的副标题，所以两边一起改了，而不是留着它们在一致性门禁下分叉。另外 `formatGoalState` 被导出，以便直接钉住它的输出：真正值得检查的那几个状态——跑到一半的 Goal、没有预算的 Goal、还没计过费的 Goal——把它们构造成快照，远比把一次 headless 运行驱动到那个状态便宜；而且这个文件本来就为同样的理由导出了 `skipHeadlessLoopSentinel`。

## 为什么需要

这个额度窗口在执行，但是看不见。`tokensUsed` 和 `tokenBudget` 从预算功能落地起就在 Goal 记录上了，30,000,000 的默认值会停下 Goal 并把控制权交还用户，而在此之前没有任何地方显示离那个上限还有多远。在 TUI 和 Web Shell 里 grep `tokensUsed`，返回的全是测试夹具，别的什么都没有。

于是用户只能看着轮数往上爬，无从分辨一个才用掉窗口百分之二的 Goal 和一个马上就要停的 Goal。Codex 在它的 TUI 状态栏里放的就是同一对数字，形如 `63.9K/50K`；这里做的是等价的事，放在本 CLI 已经用来说明 Goal 在干什么的那些位置上。

Web Shell 刻意不在本 PR 里。它的 strip 和 dialog 读的是手抄的 SDK `GoalRecord`，那份类型缺这两个字段，所以要先改类型，是单独的一次改动。

## 评审验证方式

### 如何验证

```
cd packages/cli && npx vitest run src/ui/components/GoalPill.test.tsx src/ui/components/messages/GoalStatusMessage.test.tsx src/ui/opentui/live-session-model.test.ts src/nonInteractiveCli.test.ts
```

新增用例在四个位置上分别钉死了渲染出来的确切字符串，每个位置都有"有预算""无预算""还没计费"三条规则各自的用例。`formatGoalState` 还额外钉住了停机原因仍然排在 usage 行下面。

要看实时效果，设一个会跑几轮的 Goal，然后看底栏。

### 证据（Before & After）

**改动前。** 两个界面都不显示这对数字；`tokensUsed` 在这两个包的生产代码里一处都没有：

```
$ git grep -l tokensUsed -- packages/cli/src/ui packages/web-shell/client
packages/cli/src/ui/commands/goalCommand.test.ts
packages/cli/src/ui/components/GoalPill.test.tsx
packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
packages/cli/src/ui/hooks/use-llm-stream.test.tsx
packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
packages/web-shell/client/e2e/visuals/screenshots.spec.ts
```

每一处命中都是测试夹具。底栏当时读作 `◎ /goal active (19s)`，卡片读作 `1 turn · 21.7s`。

**改动后 —— 底栏 pill，真实 TUI**，随着 Goal 干活往上涨：

```
➜ work · qwen3.8-max · 1.0m Context 2.9% used          ◎︎ /goal active (19s · 87.2k/30.0m)
➜ work · qwen3.8-max · 1.0m Context 3% used           ◎︎ /goal active (28s · 147.0k/30.0m)
```

**改动后 —— 状态卡片，真实 TUI：**

```
✓︎ Goal complete · 1 turn · 21.7s · 80.7k/30.0m tokens
  Goal: Read a.txt, b.txt and c.txt with your file tools and quote the exact contents of each.
  Reason: The delivered output quotes the exact contents of all three files...
```

**改动后 —— headless TEXT**，续上一个 Goal 已经跑过轮的会话：

```
$ qwen -c -p '/goal'
Goal complete: Read a.txt, b.txt and c.txt with your file tools and quote the exact contents of each.
Usage: 1 turn · 63,214 of 30,000,000 tokens
Reason: All three files were read using the read_file tool (evidence f05eb286, cf501e22, 287fcc24)...
```

**改动后 —— 还没计过费的 Goal**，也就是 `/goal set` 在第一轮开始前打出来的东西：

```
$ qwen -p '/goal set Read a.txt and report its exact contents, then stop.'
Goal active: Read a.txt and report its exact contents, then stop.
```

没有 usage 行，符合预期。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Linux，`npm run build`，在 tmux 里以 120x34 跑交互式 TUI，以及 `--output-format text` 的 headless，均对真实模型。

## 风险与范围

- 主要风险或权衡：pill 在本来就紧张的底栏里最多长出 11 个字符。"还没计费不显示"这条规则让它不会出现在刚创建的 Goal 上，缩写形式也让它保持简短，但在很窄的终端上，它确实是又一个在争这一行的东西。
- 未验证 / 范围外：Web Shell，它需要先改 SDK 类型，是单独的一次改动。计量口径本身没有变，仍然不含子代理与 verifier 自己的检查，用户文档现在把这一点写明了。
- 破坏性变更 / 迁移说明：没有。纯展示，读的是记录上本来就有的两个字段。`formatGoalState` 变成导出。

## 关联 Issue

属于 #4228 的一部分。

</details>

