### PR TITLE
fix(mesh): bind resident turns to stored transcripts

### DIFF
--- a/docs/plans/2026-09-06-multi-agent-board-collaboration.md
+++ b/docs/plans/2026-09-06-multi-agent-board-collaboration.md
@@ -1,10 +1,10 @@
 # Multi-agent collaboration on a shared thread
 
-> Status: Implemented through the runtime wiring needed for the live slice;
-> the end-to-end model run remains unverified.
+> Status: The two-agent happy-path live slice is verified; dispatcher
+> reliability, daemon integration, Web Shell, and notifications remain.
 > Baseline: `origin/main` @ `703678136a` (2026-09-06)
-> Verification: targeted tests, build, typecheck, and lint are recorded in §0.2;
-> no agent has run this design end to end
+> Verification: §0.2 separates earlier targeted checks from the first live
+> two-agent run and from everything still unverified
 > Supersedes the Agent-Team-first direction in [`2026-09-06-agent-team-webshell-gap.md`](./2026-09-06-agent-team-webshell-gap.md) §6
 > Related: #9402 (board storage), #10078 (session boundary), #10247 §5, #11072, #11140
 
@@ -84,7 +84,7 @@ continuations already emit `EXTERNAL_MESSAGE`, and cold revival explicitly
 seeds the continuation prompt in the transcript. Mesh still uses structured
 input because correlation, not transcript presence, is the missing contract.
 
-**Verified locally in steps 2-4, not yet end to end.** The capability table and
+**Verified locally in steps 2-4.** The capability table and
 shell predicate pass their named tests. The versioned store tests exercise
 newer-version refusal, v0 migration and backup recovery, two-process sequence
 allocation, source-first outbox replay, persisted admission outcomes, and
@@ -93,13 +93,31 @@ refusal, typed launcher outcomes, a singleton hidden host, default-catalog
 exclusion, and host reload before a subsequent launch. The ACP bridge and child
 handler have focused route tests. These are local observations only until the
 merged step is green in #11206; the reload test runs the real bridge reaper
-in-process with a fake ACP child, not a daemon process, and no mesh agent or
-dispatcher has run against a live model.
+in-process with a fake ACP child, not a daemon process.
 
-**Still never prototyped end to end.** No mesh agent has been launched, no
-thread has been dispatched, no prompt in §6 has been sent to a model. The
-dispatch rules in §4 are reasoned from Multica's and Agent Team's failure modes,
-not from observed behaviour of this system.
+**Verified in the first live happy-path slice (2026-09-07).** A normal,
+non-bare host launched Alice on an assigned root thread. Alice used
+`thread_create` to assign Bob and ended with `thread_wait`; Bob posted three
+results and ended the child with `thread_review`; the durable parent report was
+applied in 13 ms; the same resident Alice body resumed on the root, summarized
+Bob's work, and ended with `thread_review`. The child and root both finished
+`in_review`, and Alice's two runs persisted `waiting` then `review`. All six
+advertised `thread_*` tools were present in the model's function declarations.
+No §6 prompt text changed to obtain this result.
+
+The live run found one runtime-path defect: the continuation binder looked for
+the agent sidecar below the workspace checkout, while background-agent
+transcripts live below `Config.storage.getProjectDir()`. Consequently the first
+parent wake failed before the resident continuation. Using the same storage
+root as the launcher fixed the next run. A separate first attempt mentioned
+both `@alice` and `@bob` in the human instruction and correctly woke both; the
+demo input was corrected to address only Alice, with no routing-rule change.
+
+**Still unverified.** Running-delivery miss reconciliation, the 12-turn
+ping-pong gate, restart and stall recovery, the real daemon host/reaper path,
+bare-mode tool exposure, REST/Web Shell, and notifications have not been run
+end to end. The negative paths in §4 therefore remain reasoned and locally
+checked contracts, not live-system evidence.
 
 **How to re-check the Multica claims.** Clone `github.com/multica-ai/multica`
 and read `server/internal/daemon/types.go`, `server/internal/daemon/prompt.go`,
@@ -618,6 +636,11 @@ Dependencies, with an early vertical proof before reliability and UI breadth.
    against two live agents before building the full daemon; this is the first
    proof that the chosen reuse seam, prompt contract, and delegation close loop
    work together.
+   Observed on 2026-09-07 with two real agents: Alice closed `waiting`, Bob
+   closed the child `review`, the parent report applied in 13 ms, and the same
+   Alice body continued and closed the root `review`. The first continuation
+   attempt exposed and fixed the sidecar storage-root mismatch described in
+   §0.2.
 8. **Dispatcher reliability** — direct running delivery,
    acceptance recording, completion reconciliation, launch failure, done/
    cancellation, restart and stall recovery, and full outbox replay.
@@ -688,8 +711,9 @@ npx vitest run src/serve/scheduled-task-keepalive.test.ts \
 
 The earlier foundation's targeted lint and core typecheck passed. Step 4's
 targeted `acp-bridge` package build passed; whole-branch compile/style health
-still waits for #11206 CI. None of these checks validates a mesh turn against a
-live model. Update the test counts above when the implementation changes.
+still waits for #11206 CI. Separately, the §0.2 two-agent live run validates the
+minimal delegation and return path; it did not run the negative reliability
+cases below. Update the test counts above when the implementation changes.
 
 Future unit coverage is required for: all twelve admission outcomes; unknown
 mention suppressing assignee fallback; assignment and parent-dependency triggers;
@@ -1041,6 +1065,6 @@ write code, which decision 1 defers until isolation is settled.
 
 **规则修正**：turn gate 改为每线程，token gate 保持根树维度；子线程继承父线程当前 turn 计数；running coalesce 也计 turn；未知 @ 不再误唤醒 assignee；无目标、agent unavailable、capacity wait、launch failure、done/cancel、assignment trigger 都有明确语义；跨线程 queued run 按锁内分配的 `(queueSequence, runId)` 全局 FIFO，`queuedAt` 只用于显示。全局锁只处理并发，跨文件父报告和通知由可重放 outbox 保证，token 则从各 run 的逐轮 usage 推导；`blocked/in_review` 按所有 agent 的 run 聚合，不再由最后一个 agent 覆盖。
 
-**验证边界**：当前规则、存储、capability 和 launcher 路径已有定向测试与编译证据；隐藏 host 的 reload 测试使用注入 bridge，mesh agent 尚未对真实模型运行。线程工具、dispatcher、delivery watermark、恢复、REST、Web Shell、通知都还没端到端跑通。§5.2 把 live vertical slice 提前，§9 记录仍需产品或存储取舍的问题。
+**验证边界**：两名真实 agent 的最小闭环已经跑通：Alice 拆子线程并 `thread_wait`，Bob `thread_review`，父报告 13ms 写回，同一个 Alice 长期执行体续跑并把根线程 `thread_review` 到 `in_review`。这次运行发现并修复了续跑时 agent sidecar 使用错误存储根目录的问题，没有为了跑通修改 §6 提示词。运行中投递丢失、12 轮防乒乓、重启/卡死恢复、真实 daemon host、bare 模式、REST、Web Shell 和通知仍未端到端验证。
 
 </details>

--- a/docs/plans/2026-09-07-mesh-implementation-acceptance.md
+++ b/docs/plans/2026-09-07-mesh-implementation-acceptance.md
@@ -94,9 +94,29 @@ Writing the production port corrected the design's four-branch idle path to thre
 
 ### Step 7 — Live vertical slice (first integration gate)
 
-Lands: nothing new; this is a run.
+Lands: normally nothing; the first run may carry only defects that directly
+block the slice. This run corrected the resident-continuation sidecar lookup to
+use the same storage root as the background-agent launcher.
 Gate: the §8 demo steps 1-5 complete against two real agents on a build-capable machine, plus: a forced `queueExternalInput` miss (kill the agent between its last tool round and finish) is rebooked and delivered on the next run; a synthetic ping-pong between two _running_ agents on one thread stops at 12 with `turn_budget_exhausted` in the thread and one channel-less notification record.
 Evidence: the thread JSON files after the run, the two agents' transcript slices, the observed wall-clock between the child's `thread_review` and the parent's wake, and the host reaper timeout plus daemon-observed reload latency. If any prompt in §6 had to change to make the model close its run explicitly, the changed prompt and the failure it fixed.
+
+**Happy-path observation (2026-09-07).** On a normal non-bare host, Alice was
+the only target of the root post, created and assigned Bob's child, and closed
+`waiting`. Bob posted three concrete checks and closed `review`. The parent
+report applied after 13 ms; the same resident Alice body continued, summarized
+the child, and closed the root `review`. Final status was `in_review` on both
+threads; Alice's two runs were `completed/waiting` and `completed/review`, and
+Bob's was `completed/review`. All six thread tools were in the real model tool
+surface. No §6 prompt change was needed. The first continuation attempt failed
+because `dispatch-port.ts` derived the sidecar path from the checkout rather
+than `Config.storage.getProjectDir()`; the correction above made the next live
+run pass. A first demo input also mentioned Bob directly and therefore woke him
+according to the real routing rule; addressing only Alice fixed the driver, not
+the product.
+
+This proves the demo steps 1-5 only. The forced delivery miss, 12-turn
+ping-pong, daemon reaper/reload observation, and bare-mode exposure remain
+unrun, so the full step-7 gate is not yet claimed.
 
 ### Step 8 — Dispatcher reliability
 

--- a/packages/core/src/agents/mesh/dispatch-port.ts
+++ b/packages/core/src/agents/mesh/dispatch-port.ts
@@ -132,7 +132,7 @@ function bindNextTurn(
   binding: MeshRunContext,
 ): void {
   const metaPath = getAgentMetaPath(
-    config.getProjectRoot(),
+    config.storage.getProjectDir(),
     config.getSessionId(),
     meshBackgroundAgentId(agent),
   );


### PR DESCRIPTION
## What this PR does

This stacked child of #11206 fixes resident-agent continuation so the next mesh run is bound through the same persisted transcript location used when the background agent was launched. It also records the first two-agent live happy-path observation in the design and acceptance documents.

## Why it's needed

The first live parent wake found that continuation looked for agent metadata below the checkout instead of the runtime project-artifact directory. The first Alice run and Bob child run completed, but Alice's second run failed before her resident body could continue. Aligning the lookup with the launcher removes that blocker.

## Reviewer Test Plan

### How to verify

Create a root thread addressed only to Alice. Ask Alice to create and assign a child to Bob and wait. Bob should post his result and hand the child to review; the parent report should book Alice again; the same resident Alice body should summarize Bob's result and hand the root to review. Confirm the root and child both end in review, with Alice's closes recorded as waiting then review and Bob's close recorded as review.

### Evidence (Before & After)

Before: Bob completed the child and the parent report was persisted, but Alice's second run failed while binding its persisted runtime context because the metadata lookup used the checkout path.

After: Alice completed waiting, Bob completed review, the parent report was applied after 13 ms, and the same Alice body completed review on its second turn. Both threads ended in review. All six mesh thread tools were present in the real model tool surface. No mesh prompt change was required.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ live two-agent demo |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local TypeScript source execution with the configured OpenAI-compatible provider and two real `general-purpose` background agents. No build, lint, typecheck, CI, or unit-test command was run for this child PR.

## Risk & Scope

- Main risk or tradeoff: This is one runtime-path correction backed by the observed live path; it does not broaden dispatcher behavior.
- Not validated / out of scope: Forced running-delivery misses, ping-pong limits, daemon reaping/reload, bare-mode tool exposure, restart recovery, Web Shell, and notifications.
- Breaking changes / migration notes: None.

## Linked Issues

Part of #11206.

<details>
<summary>中文说明</summary>

## 这个 PR 做什么

这是 #11206 的 stacked 子 PR。它修复长期驻留 agent 续跑时的绑定路径，让下一次 mesh run 从后台 agent 启动时使用的同一个持久 transcript 位置读取元数据；同时把第一次双 agent 真实 happy path 的观测写回设计和验收文档。

## 为什么需要

第一次真实父线程唤醒暴露出：续跑在 checkout 下寻找 agent 元数据，而不是 runtime 的项目产物目录。Alice 第一轮和 Bob 子线程都成功完成，但 Alice 第二轮在长期执行体继续之前失败。让查找路径与 launcher 一致即可消除这个阻塞。

## Reviewer Test Plan

### 如何验证

创建一个只 @Alice 的根线程，让 Alice 新建并指派 Bob 的子线程后等待。Bob 应发回结果并把子线程交回 review；父报告应再次预约 Alice；同一个长期驻留的 Alice 执行体应汇总 Bob 的结果并把根线程交回 review。确认根线程与子线程最终都是 in_review，Alice 两次收尾依次记录为 waiting 和 review，Bob 记录为 review。

### 证据（修改前后）

修改前：Bob 已完成子线程，父报告也已持久化，但 Alice 第二次 run 在绑定持久运行上下文时失败，因为元数据查找使用了 checkout 路径。

修改后：Alice 完成 waiting，Bob 完成 review，父报告 13ms 后写入，同一个 Alice 执行体第二轮完成 review；两个线程都进入 in_review。真实模型工具面包含全部六个 mesh thread 工具。无需修改 mesh prompt。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 真实双 agent demo |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境

本地直接运行 TypeScript 源码，使用已配置的 OpenAI-compatible provider 和两个真实 `general-purpose` 后台 agent。本子 PR 没有运行 build、lint、typecheck、CI 或单元测试命令。

## 风险与范围

- 主要风险或取舍：这是由真实运行验证的一处 runtime 路径修正，不扩展 dispatcher 行为。
- 未验证 / 不在范围：运行中投递 miss、ping-pong 上限、daemon 回收与重载、bare 模式工具暴露、重启恢复、Web Shell、通知。
- Breaking change / 迁移：无。

## 关联

属于 #11206。

</details>
