### PR TITLE
test(integration): assert successful /compress token reduction

### DIFF
--- a/integration-tests/interactive/context-compress-interactive.test.ts
+++ b/integration-tests/interactive/context-compress-interactive.test.ts
@@ -16,6 +16,19 @@ import {
   fakeServerHostOptions,
 } from '../test-helper.js';
 
+// Keep fake-server request indexes structural: seed request 0 is followed by
+// the /compress side-query at request 1, without a memory extractor in between.
+const SUITE_SETTINGS = {
+  memory: {
+    enableManagedAutoMemory: false,
+  },
+  security: {
+    auth: {
+      selectedType: 'openai',
+    },
+  },
+};
+
 describe('Interactive Mode', () => {
   let rig: TestRig;
   let fakeServer: FakeOpenAIServer | undefined;
@@ -58,17 +71,31 @@ describe('Interactive Mode', () => {
     );
   }
 
+  function expectSuccessfulCompression() {
+    const compressionEvent = rig.readTelemetryEvent('chat_compression');
+    const tokensBefore = compressionEvent?.attributes?.['tokens_before'];
+    const tokensAfter = compressionEvent?.attributes?.['tokens_after'];
+    const outputTokens =
+      compressionEvent?.attributes?.['compression_output_token_count'];
+    const cacheSharing = compressionEvent?.attributes?.['cache_sharing_used'];
+
+    expect(
+      typeof tokensBefore === 'number' &&
+        typeof tokensAfter === 'number' &&
+        tokensBefore > tokensAfter,
+      'chat_compression event recorded no token reduction: ' +
+        `tokens_before=${String(tokensBefore)}, ` +
+        `tokens_after=${String(tokensAfter)}, ` +
+        `output=${String(outputTokens)}, ` +
+        `cache_sharing=${String(cacheSharing)}`,
+    ).toBe(true);
+  }
+
   it.skipIf(process.platform === 'win32')(
     'should trigger chat compression with /compress command',
     async () => {
       await rig.setup('interactive-compress-test', {
-        settings: {
-          security: {
-            auth: {
-              selectedType: 'openai',
-            },
-          },
-        },
+        settings: SUITE_SETTINGS,
       });
 
       const { ptyProcess } = await runInteractiveWithFakeModel();
@@ -107,18 +134,13 @@ describe('Interactive Mode', () => {
       expect(foundEvent, 'chat_compression telemetry event was not found').toBe(
         true,
       );
+      expectSuccessfulCompression();
     },
   );
 
   it.skip('should handle compression failure on token inflation', async () => {
     await rig.setup('interactive-compress-test', {
-      settings: {
-        security: {
-          auth: {
-            selectedType: 'openai',
-          },
-        },
-      },
+      settings: SUITE_SETTINGS,
     });
 
     const { ptyProcess } = rig.runInteractive();
@@ -154,13 +176,7 @@ describe('Interactive Mode', () => {
     'should forward /compress instructions through to the side-query',
     async () => {
       await rig.setup('interactive-compress-instructions-test', {
-        settings: {
-          security: {
-            auth: {
-              selectedType: 'openai',
-            },
-          },
-        },
+        settings: SUITE_SETTINGS,
       });
 
       const { ptyProcess } = await runInteractiveWithFakeModel();
@@ -187,11 +203,10 @@ describe('Interactive Mode', () => {
       const seedCompleted = await rig.waitForText('einstein');
       expect(seedCompleted, 'seed response did not complete').toBe(true);
 
-      // Fire /compress with a trailing instruction. We are not asserting on
-      // summary CONTENT (model behaviour) — only that the wiring runs
-      // end-to-end and the compression telemetry event lands. Earlier unit
-      // tests cover the prompt-composition path; this is the smoke test that
-      // the args plumbing reaches the side-query.
+      // Fire /compress with a trailing instruction. We do not assert summary
+      // content, but do require the deterministic fixture to reduce tokens.
+      // Earlier unit tests cover prompt composition; this pins the end-to-end
+      // argument path and a successful compression result.
       await type(ptyProcess, '/compress focus on the scientist mentioned');
       await new Promise((resolve) => setTimeout(resolve, 100));
       await type(ptyProcess, '\r');
@@ -203,6 +218,7 @@ describe('Interactive Mode', () => {
       expect(foundEvent, 'chat_compression telemetry event was not found').toBe(
         true,
       );
+      expectSuccessfulCompression();
     },
   );
 });

--- a/integration-tests/test-helper.test.ts
+++ b/integration-tests/test-helper.test.ts
@@ -110,4 +110,52 @@ describe('TestRig', () => {
       expect(poll).toHaveBeenCalled();
     },
   );
+
+  describe('readTelemetryEvent', () => {
+    it('returns the latest matching event with its attributes', async () => {
+      const rig = new TestRig();
+      await rig.setup('read telemetry event latest');
+      rig.createFile(
+        'telemetry.log',
+        [
+          JSON.stringify({
+            attributes: {
+              'event.name': 'qwen-code.chat_compression',
+              tokens_before: 1000,
+              tokens_after: 900,
+            },
+          }),
+          JSON.stringify({
+            attributes: { 'event.name': 'qwen-code.api_request' },
+          }),
+          JSON.stringify({
+            attributes: {
+              'event.name': 'qwen-code.chat_compression',
+              tokens_before: 28891,
+              tokens_after: 27128,
+            },
+          }),
+          JSON.stringify({
+            attributes: { 'event.name': 'qwen-code.api_request' },
+          }),
+        ].join('\n'),
+      );
+
+      const event = rig.readTelemetryEvent('chat_compression');
+
+      expect(event?.attributes?.['tokens_before']).toBe(28891);
+      expect(event?.attributes?.['tokens_after']).toBe(27128);
+
+      await rig.cleanup();
+    });
+
+    it('returns null when the event never landed', async () => {
+      const rig = new TestRig();
+      await rig.setup('read telemetry event absent');
+
+      expect(rig.readTelemetryEvent('chat_compression')).toBeNull();
+
+      await rig.cleanup();
+    });
+  });
 });

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -891,6 +891,18 @@ export class TestRig {
     return apiRequests.pop() || null;
   }
 
+  // Unlike waitForTelemetryEvent's boolean poll, this exposes the latest
+  // matching payload so integration tests can assert event semantics.
+  readTelemetryEvent(eventName: string): ParsedLog | null {
+    const logs = this._readAndParseTelemetryLog();
+    const events = logs.filter(
+      (logData) =>
+        logData.attributes &&
+        logData.attributes['event.name'] === `qwen-code.${eventName}`,
+    );
+    return events.pop() || null;
+  }
+
   readMetric(metricName: string): Record<string, unknown> | null {
     const logs = this._readAndParseTelemetryLog();
     for (const logData of logs) {


### PR DESCRIPTION
## What this PR does

- Adds a telemetry reader for integration tests that returns the latest event matching an exact event name, together with focused coverage for latest-match and absent-event behavior.
- Makes the `/compress` fake-server fixture deterministic by disabling managed auto-memory, so the side-query remains at the expected request index.
- Strengthens both active `/compress` end-to-end cases to require an actual token reduction (`tokens_before > tokens_after`) and reports the compression output-token count and cache-sharing state when the assertion fails.

## Why it's needed

The deterministic fake-server coverage added in #11175 currently proves that a `chat_compression` event landed, but event presence alone does not prove that compression succeeded. The same event contains the result needed to distinguish a genuine reduction from a failed or token-inflating path. Reading the latest exact-name match also prevents a trailing unrelated telemetry record from being mistaken for the target event. This completes the `/compress` follow-up deferred from #11094 and tracked in #11213.

## Reviewer Test Plan

### How to verify

1. Run `npx cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests ./test-helper.test.ts`; all 9 tests should pass.
2. Run `QWEN_CODE_LANG=en QWEN_SANDBOX=false npx vitest run --root ./integration-tests interactive/context-compress-interactive.test.ts`; both active `/compress` cases should pass and the existing token-inflation case should remain skipped.
3. Run `npm run typecheck:integration`, targeted ESLint, and targeted Prettier checks; each should pass.
4. To validate the guard itself, temporarily remove the exact event-name predicate from the telemetry reader and rerun its focused test. The latest-match test should fail because the trailing `api_request` fixture has no compression attributes; restoring the predicate makes it pass.

Observed fake-server telemetry was deterministic: the basic case made 2 API requests and reduced tokens from 1825 to 71; the instruction-forwarding case made 2 API requests and reduced tokens from 1832 to 71. Neither case emitted a managed-memory event. Both reported `compression_output_token_count=0` and `cache_sharing_used=false`. The exact `tokens_before` values vary with the environment (the tracked finding observed 3607), so the assertion intentionally pins the invariant reduction rather than literal counts.

### Evidence (Before & After)

N/A (test-infrastructure-only change). Before, the suite accepted any landed `chat_compression` event. After, it accepts only a matching event whose numeric token counts demonstrate a reduction, with actionable diagnostics on failure.

### Tested on

| OS | Status |
| :--: | :--: |
| macOS | Tested |
| Windows | Not tested locally |
| Linux | Not tested locally |

### Environment (optional)

macOS, Node.js v25.9.0, `QWEN_SANDBOX=false`, local `FakeOpenAIServer` fixture.

## Risk & Scope

- Main risk or tradeoff: This intentionally disables managed auto-memory only in the `/compress` integration suite so background extraction cannot shift fake-server request indexes.
- Not validated / out of scope: Production compression behavior and the existing skipped token-inflation scenario are unchanged; Windows and Linux were not run locally and remain covered by CI.
- Breaking changes / migration notes: None. This changes test infrastructure and assertions only.

## Linked Issues

Refs #11213

<details>
<summary>中文说明</summary>

## 本 PR 的改动

- 为集成测试新增遥测事件读取方法，返回事件名精确匹配的最新事件，并通过聚焦测试覆盖“返回最新匹配项”和“事件不存在”两种行为。
- 在 `/compress` 的假服务器测试配置中禁用托管自动记忆，使压缩侧查询稳定地位于预期请求序号。
- 强化两个启用中的 `/compress` 端到端用例，要求压缩后确实减少 token（`tokens_before > tokens_after`）；断言失败时同时输出压缩结果 token 数和缓存共享状态。

## 为什么需要这项改动

#11175 新增的确定性假服务器测试目前只能证明 `chat_compression` 事件已经写入，但事件存在本身不能证明压缩成功。该事件已经包含区分真实压缩、压缩失败或 token 膨胀所需的结果数据。读取事件名精确匹配的最新记录，也可避免把尾部无关遥测记录误当成目标事件。本 PR 完成了 #11094 延后处理、并由 #11213 跟踪的 `/compress` 后续工作。

## 审阅者测试计划

### 验证方法

1. 运行 `npx cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests ./test-helper.test.ts`；9 个测试应全部通过。
2. 运行 `QWEN_CODE_LANG=en QWEN_SANDBOX=false npx vitest run --root ./integration-tests interactive/context-compress-interactive.test.ts`；两个启用中的 `/compress` 用例应通过，现有 token 膨胀用例仍保持跳过。
3. 运行 `npm run typecheck:integration`、针对改动文件的 ESLint 和 Prettier 检查；均应通过。
4. 如需验证保护机制本身，可临时移除遥测读取方法中的精确事件名条件并重新运行其聚焦测试。由于末尾的 `api_request` 固定数据不含压缩属性，“最新匹配项”测试应失败；恢复条件后测试通过。

实际观察到的假服务器遥测结果保持确定性：基础用例发起 2 次 API 请求，token 从 1825 降至 71；指令转发用例发起 2 次 API 请求，token 从 1832 降至 71。两个用例都未产生托管记忆事件，并且都报告 `compression_output_token_count=0`、`cache_sharing_used=false`。具体的 `tokens_before` 数值会随环境变化（跟踪项中观测到的是 3607），因此断言有意固定“压缩后减少”这一不变量，而不写死具体数值。

### 前后对比证据

不适用（仅改动测试基础设施）。改动前，测试接受任意已写入的 `chat_compression` 事件；改动后，只有事件名匹配且数值型 token 计数表明确实减少时才会通过，并在失败时提供可操作的诊断信息。

### 测试平台

| 操作系统 | 状态 |
| :--: | :--: |
| macOS | 已测试 |
| Windows | 未在本地测试 |
| Linux | 未在本地测试 |

### 环境（可选）

macOS、Node.js v25.9.0、`QWEN_SANDBOX=false`、本地 `FakeOpenAIServer` 固定测试环境。

## 风险与范围

- 主要风险或权衡：仅在 `/compress` 集成测试套件中有意禁用托管自动记忆，避免后台记忆抽取改变假服务器请求序号。
- 未验证或范围外事项：生产环境压缩行为及现有跳过的 token 膨胀场景均未改变；Windows 和 Linux 未在本地运行，仍由 CI 覆盖。
- 破坏性变更或迁移说明：无。本 PR 只修改测试基础设施和断言。

## 关联 Issue

Refs #11213

</details>
