### PR TITLE
fix(mesh): keep the existence check when filtering host sessions out of search

### DIFF
--- a/packages/cli/src/serve/server/session-list.ts
+++ b/packages/cli/src/serve/server/session-list.ts
@@ -1586,7 +1586,11 @@ export async function searchWorkspaceSessionsForResponse(
     for (const hit of hits) {
       readOptions.signal?.throwIfAborted();
       const item = await sessionService.getSessionListItem(hit.sessionId);
-      if (item?.sourceType !== MESH_HOST_SESSION_SOURCE_TYPE)
+      // Both conditions, and in this order. `item?.sourceType !== X` is true
+      // when the read found nothing, so folding the existence check into the
+      // optional chain lets a session that vanished between the search hit and
+      // this read through as an undefined summary.
+      if (item && item.sourceType !== MESH_HOST_SESSION_SOURCE_TYPE)
         bySessionId.set(
           hit.sessionId,
           applyOrganization(


### PR DESCRIPTION
## What this PR does

One line: restores the existence check that #11225 folded into an optional chain in `session-list.ts`.

## Why it's needed

**It is why every build on the mesh branch is red.** `tsc --build` fails on `packages/cli`:

```
src/serve/server/session-list.ts(1593,23): error TS2345:
Argument of type 'SessionListItem | undefined' is not assignable to parameter of type '{ sessionId: string; ... }'
```

Test, Lint & Static, and Integration Tests all fail at "Install dependencies", which runs the build, so nothing downstream of it has run since #11225 merged.

The change was `if (item)` → `if (item?.sourceType !== MESH_HOST_SESSION_SOURCE_TYPE)`. When the read finds nothing, `item?.sourceType` is `undefined`, and `undefined !== 'mesh'` is true — so the branch runs with no item at all. This would have been a regression even if it had compiled: a session that disappeared between the search hit and this read used to be skipped, and would now be added to the map as an undefined summary. The guard that was replaced existed for exactly that case.

Fix: both conditions, in this order.

## Reviewer Test Plan

### How to verify

```bash
npm run build --workspace=packages/cli
```

Expect it to pass. On the branch without this commit it fails at the line above.

### Evidence (Before & After)

Before: `tsc --build` fails, so Test / Lint / Integration never start. After: the build proceeds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Checked with `tsc --noEmit` on the single file; the full workspace build is CI's to confirm.

## Risk & Scope

- Main risk or tradeoff: none. It restores behaviour that existed before #11225 and adds the mesh filter beside it rather than instead of it.
- Not validated / out of scope: no test covers a session vanishing between the search hit and the read. Worth adding, but this PR is deliberately the smallest thing that unblocks CI.
- Breaking changes / migration notes: none.

## Linked Issues

Parent delivery PR: #11206. Regression from #11225.