### PR TITLE
fix(ci): reap leaked E2E sandbox containers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,6 +117,8 @@ jobs:
     # and show misleading red status. Same-repo PRs run normally.
     if: |-
       ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    env:
+      E2E_CONTAINER_OWNER: '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}'
     strategy:
       # One failing shard must not cancel the others: a partial matrix hides the
       # rest of the suite and reports an incomplete failure set.
@@ -256,8 +258,23 @@ jobs:
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
           QWEN_SANDBOX: "${{ matrix.sandbox == 'sandbox:docker' && 'docker' || 'false' }}"
           BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
+          SANDBOX_FLAGS: '--label org.qwen-code.ci.kind=e2e --label org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}'
         run: |-
           set -euo pipefail
+
+          cleanup_e2e_job() {
+            if [ '${{ matrix.sandbox }}' = 'sandbox:docker' ]; then
+              container_ids="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}" 2>/dev/null)" || container_ids=''
+              if [ -n "$container_ids" ]; then
+                printf '%s\n' "$container_ids" | xargs -r timeout 60 docker rm -f > /dev/null 2>&1 || echo "::warning::failed to remove E2E containers for ${E2E_CONTAINER_OWNER}"
+              fi
+            fi
+            if [ -n "${QWEN_CI_TMPDIR:-}" ]; then
+              rm -rf "$QWEN_CI_TMPDIR" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_e2e_job EXIT
+          trap 'exit 1' INT TERM
 
           if [ '${{ matrix.sandbox }}' = 'sandbox:docker' ]; then
             sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-e2e-${GITHUB_SHA}"
@@ -337,7 +354,6 @@ jobs:
             if [ -n "$QWEN_CI_TMPDIR" ]; then
               TMPDIR="$QWEN_CI_TMPDIR"
               export TMPDIR
-              trap 'rm -rf "$TMPDIR" 2>/dev/null || true' EXIT
             fi
           fi
           # QWEN_E2E_RENDERER=ink pins the baseline leg of the renderer
@@ -378,6 +394,21 @@ jobs:
               echo "::warning::sandbox:none shard failed on ${RUNNER_NAME:-this runner} after ${elapsed}s; retrying once (transient shared-host pressure class)"
               run_shard
             }
+          fi
+
+      - name: 'Remove job-owned E2E containers'
+        if: |-
+          ${{ always() && matrix.sandbox == 'sandbox:docker' && runner.environment == 'self-hosted' }}
+        run: |-
+          set -euo pipefail
+          container_ids="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}")"
+          if [ -n "$container_ids" ]; then
+            printf '%s\n' "$container_ids" | xargs -r timeout 60 docker rm -f > /dev/null
+          fi
+          remaining="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}")"
+          if [ -n "$remaining" ]; then
+            echo "::error::E2E containers remain for ${E2E_CONTAINER_OWNER}: ${remaining//$'\n'/,}"
+            exit 1
           fi
 
       # Commit-qualified CI images are pruned under the exclusive daemon lock

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -258,7 +258,7 @@ jobs:
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
           QWEN_SANDBOX: "${{ matrix.sandbox == 'sandbox:docker' && 'docker' || 'false' }}"
           BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
-          SANDBOX_FLAGS: '--label org.qwen-code.ci.kind=e2e --label org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}'
+          SANDBOX_FLAGS: '--label org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}'
         run: |-
           set -euo pipefail
 
@@ -403,7 +403,7 @@ jobs:
           set -euo pipefail
           container_ids="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}")"
           if [ -n "$container_ids" ]; then
-            printf '%s\n' "$container_ids" | xargs -r timeout 60 docker rm -f > /dev/null
+            printf '%s\n' "$container_ids" | xargs -r timeout 60 docker rm -f > /dev/null || true
           fi
           remaining="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}")"
           if [ -n "$remaining" ]; then

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -98,7 +98,6 @@ describe('e2e workflow', () => {
       );
 
       expect(yml.jobs['e2e-test-linux'].env.E2E_CONTAINER_OWNER).toBe(owner);
-      expect(runStep.env.SANDBOX_FLAGS).toContain('org.qwen-code.ci.kind=e2e');
       expect(runStep.env.SANDBOX_FLAGS).toContain(
         'org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}',
       );
@@ -111,7 +110,7 @@ describe('e2e workflow', () => {
       expect(cleanupStep.run).toContain(
         '--filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}"',
       );
-      expect(cleanupStep.run).toContain('docker rm -f');
+      expect(cleanupStep.run).toContain('docker rm -f > /dev/null || true');
       expect(cleanupStep.run.match(/docker ps -aq/g)).toHaveLength(2);
       expect(cleanupStep.run).toContain('E2E containers remain');
     });

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -90,6 +90,32 @@ describe('e2e workflow', () => {
       expect(runStep.env.VERBOSE).toBe('true');
     });
 
+    it('reaps only the sandbox containers owned by its matrix job', () => {
+      const owner =
+        '${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}';
+      const cleanupStep = steps.find(
+        (step) => step.name === 'Remove job-owned E2E containers',
+      );
+
+      expect(yml.jobs['e2e-test-linux'].env.E2E_CONTAINER_OWNER).toBe(owner);
+      expect(runStep.env.SANDBOX_FLAGS).toContain('org.qwen-code.ci.kind=e2e');
+      expect(runStep.env.SANDBOX_FLAGS).toContain(
+        'org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}',
+      );
+      expect(runStep.run).toContain('trap cleanup_e2e_job EXIT');
+      expect(runStep.run).toContain("trap 'exit 1' INT TERM");
+      expect(runStep.run).toContain(
+        '--filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}"',
+      );
+      expect(cleanupStep.if).toContain('always()');
+      expect(cleanupStep.run).toContain(
+        '--filter "label=org.qwen-code.ci.owner=${E2E_CONTAINER_OWNER}"',
+      );
+      expect(cleanupStep.run).toContain('docker rm -f');
+      expect(cleanupStep.run.match(/docker ps -aq/g)).toHaveLength(2);
+      expect(cleanupStep.run).toContain('E2E containers remain');
+    });
+
     it('never waits on a lock another run holds through its tests', () => {
       // Run 33637097713 lost two Docker shards to the #10605 protocol on one
       // host: shard 1/3 held the per-commit coordinator lock and polled 30
@@ -357,6 +383,6 @@ describe('e2e workflow', () => {
       (step) => step.name === 'Run E2E tests',
     );
     expect(runStep.run).toContain('mktemp -d /var/tmp/qwen-ci-XXXXXX');
-    expect(runStep.run).toContain('trap \'rm -rf "$TMPDIR"');
+    expect(runStep.run).toContain('rm -rf "$QWEN_CI_TMPDIR"');
   });
 });


### PR DESCRIPTION
## What this PR does

Assigns every Docker E2E matrix job a unique owner label, then force-removes only containers carrying that label when the test shell exits. A separate `always()` step repeats the owner-scoped cleanup on persistent self-hosted runners and fails if any owned container remains.

The existing Linux scratch-directory cleanup is folded into the same exit handler so the two cleanup responsibilities cannot overwrite each other's shell trap.

## Why it's needed

The persistent ECS runners accumulated hundreds of running `qwen-code-integration-test-*` containers. One sandbox from the successful `E2E Test (Linux) - sandbox:docker - shard 2/3` job in run [33972931298](https://github.com/QwenLM/qwen-code/actions/runs/33972931298/job/101330116322) was still consuming about one CPU core roughly 37 hours after the job had completed successfully.

The sandbox uses `docker run --rm`, but `--rm` only removes a container after that container exits. If the attached Docker client or its PTY dies without stopping the daemon-owned container, the container keeps running and retains its mounted integration-test directory. Image pruning cannot reclaim it. Because several runner registrations share one Docker daemon, cleanup must be scoped to an exact matrix-job owner rather than a broad container-name prefix.

## Reviewer Test Plan

### How to verify

Run the E2E workflow from this branch. During a Docker shard, confirm its sandbox containers carry the job-specific `org.qwen-code.ci.owner` value. After the shard completes or fails, `docker ps -aq --filter label=org.qwen-code.ci.owner=<owner>` should return no containers. Containers with a different owner label must remain untouched.

The focused workflow regression test should pass and should fail if the runtime label, exit trap, `always()` cleanup, owner filter, removal command, or post-cleanup assertion is removed.

### Evidence (Before & After)

N/A — non-UI CI change. A Docker probe confirmed that killing an attached Docker client can leave its container running, and that exact owner-label cleanup removes the owned container while preserving an unrelated running container. The full branch [E2E run 34086645223](https://github.com/QwenLM/qwen-code/actions/runs/34086645223) passed. All three Docker shards and their owner-scoped cleanup steps passed; queries on the actual ECS Docker daemons returned zero containers for all three owners after completion. Two injected owner-labelled probes on the shared Runner5 daemon were also removed, leaving zero probe and newly labelled E2E containers.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS, Node.js 22.22.0, Docker client 28.0.0 with Docker server 27.4.0. The focused workflow test, ESLint, Prettier, actionlint, and Bash syntax checks pass locally. The full self-hosted Linux E2E workflow passed on the ECS pool.

## Risk & Scope

- Main risk or tradeoff: cleanup uses `docker rm -f`, but only against an exact owner label unique to the workflow run, attempt, and Docker shard; concurrent jobs use different owners.
- Not validated / out of scope: a runner process killed with SIGKILL, a lost ECS host, or an unavailable Docker daemon can prevent both job-level cleanup paths from running. A host-level age-based janitor is still needed for that failure class.
- Breaking changes / migration notes: none. Production sandbox behavior is unchanged; this only adds CI labels and cleanup.

## Linked Issues

Related: #8816, #10971, #11001

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给每一个 Docker E2E 矩阵任务分配唯一的 owner 标签，并在测试 shell 退出时，只强制删除带有这个标签的容器。另一个带 `always()` 条件的步骤会在持久化的 self-hosted runner 上再次执行按 owner 限定的清理；如果清理后仍有本任务的容器残留，任务会明确失败。

现有的 Linux 临时目录清理也合并到同一个退出处理函数中，避免两项清理逻辑设置的 shell trap 互相覆盖。

## 为什么需要它

持久化 ECS runner 上累积了数百个仍在运行的 `qwen-code-integration-test-*` 容器。运行记录 [33972931298](https://github.com/QwenLM/qwen-code/actions/runs/33972931298/job/101330116322) 中成功结束的 `E2E Test (Linux) - sandbox:docker - shard 2/3` 任务留下了一个 sandbox；任务成功结束约 37 小时后，这个容器仍在消耗大约一个 CPU 核。

sandbox 使用了 `docker run --rm`，但 `--rm` 只会在容器退出后删除容器。如果与容器连接的 Docker client 或它的 PTY 在没有停止 daemon 侧容器的情况下退出，容器会继续运行，并继续占用挂载的 integration-test 目录。镜像清理无法回收这种容器。由于多个 runner 注册实例共用同一个 Docker daemon，清理必须使用精确的矩阵任务 owner，不能使用宽泛的容器名称前缀。

## Reviewer 测试计划

### 如何验证

从本分支运行 E2E workflow。Docker shard 运行期间，确认它的 sandbox 容器带有任务专属的 `org.qwen-code.ci.owner`。该 shard 成功或失败结束后，执行 `docker ps -aq --filter label=org.qwen-code.ci.owner=<owner>` 应当查不到任何容器。带有不同 owner 标签的容器必须保持不变。

定向 workflow 回归测试应当通过；删除 runtime 标签、退出 trap、`always()` 清理、owner 过滤、删除命令或清理后的残留断言中的任意一项，都应使测试失败。

### 证据（前后对比）

不适用 —— 这是非 UI 的 CI 改动。Docker 探针已确认：杀死连接中的 Docker client 可能让容器继续运行；精确 owner 标签清理只会删除属于该 owner 的容器，同时保留另一个无关的运行中容器。完整的分支 [E2E 运行记录 34086645223](https://github.com/QwenLM/qwen-code/actions/runs/34086645223) 已通过。三个 Docker shard 及各自按 owner 限定的 cleanup step 全部成功；运行结束后，在实际 ECS Docker daemon 上查询三个 owner，结果均为零。Runner5 共用 daemon 上注入的两个 owner 探针也都被删除，最终探针数和新标签 E2E 容器数均为零。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

macOS，Node.js 22.22.0，Docker client 28.0.0，Docker server 27.4.0。本地已通过定向 workflow 测试、ESLint、Prettier、actionlint 和 Bash 语法检查。完整 self-hosted Linux E2E workflow 已在 ECS runner 池中通过。

## 风险与范围

- 主要风险或取舍：清理使用 `docker rm -f`，但目标只限于与当前 workflow run、attempt 和 Docker shard 唯一对应的精确 owner 标签；并发任务使用不同 owner。
- 未验证 / 范围之外：runner 进程被 SIGKILL、ECS 主机丢失或 Docker daemon 不可用时，两条任务级清理路径都可能无法执行。这个故障类别仍需要主机级、按存活时间清理的 janitor。
- 破坏性变更 / 迁移说明：无。生产 sandbox 行为没有改变；本 PR 只增加 CI 标签与清理。

## 关联 Issue

相关：#8816、#10971、#11001

</details>
