### PR TITLE
docs(mesh): record crash recovery evidence

### DIFF
--- a/docs/plans/2026-09-06-multi-agent-board-collaboration.md
+++ b/docs/plans/2026-09-06-multi-agent-board-collaboration.md
@@ -1064,10 +1064,12 @@ remain genuinely open:
    consistent, but token usage becomes known only after a run. Several agents in
    the same thread tree can already be executing when the root reaches 200k.
    Decide whether 200k is a hard reservation limit (reserve estimated tokens at
-   booking) or an accounting limit with bounded overshoot. Runtime compaction
-   calls and usage emitted before a provider retry are not represented by
-   `USAGE_METADATA`; the UI/accounting contract must either accept that
-   undercount or add a broader usage source.
+   booking) or an accounting limit with run-bounded overshoot. The latter is not
+   a tight ceiling: one manually crash-replayed run completed at
+   `666,749 / 200,000` accounted tokens because no new admission occurred while
+   it kept taking tool rounds. Runtime compaction calls and usage emitted before
+   a provider retry are not represented by `USAGE_METADATA`; the UI/accounting
+   contract must either accept that undercount or add a broader usage source.
 6. **Selective forgetting.** Deleting a thread removes its record but cannot
    remove facts already compacted into a cross-thread agent body. Decision 8 can
    guarantee forgetting only by deleting the whole agent and transcript; whether
@@ -1135,6 +1137,6 @@ write code, which decision 1 defers until isolation is settled.
 
 **规则修正**：turn gate 改为每线程，token gate 保持根树维度；子线程继承父线程当前 turn 计数；running coalesce 也计 turn；未知 @ 不再误唤醒 assignee；无目标、agent unavailable、capacity wait、launch failure、done/cancel、assignment trigger 都有明确语义；跨线程 queued run 按锁内分配的 `(queueSequence, runId)` 全局 FIFO，`queuedAt` 只用于显示。全局锁只处理并发，跨文件父报告和通知由可重放 outbox 保证，token 则从各 run 的逐轮 usage 推导；`blocked/in_review` 按所有 agent 的 run 聚合，不再由最后一个 agent 覆盖。
 
-**验证边界**：两名真实 agent 的最小闭环已经跑通：Alice 拆子线程并 `thread_wait`，Bob `thread_review`，父报告 13ms 写回，同一个 Alice 长期执行体续跑并把根线程 `thread_review` 到 `in_review`。真实 daemon + Web Shell 的 demo 路径也已跑通 roster/create/list/detail、实时派发和父级续跑，最终根线程进入 `in_review`，树内计费 186,317/200,000。浏览器首轮同时发现 result 文本里的 peer mention 会按规则继续 booking 并形成回环，因此 §6 补了「at-sign address 等于 booking，子线程完成已自动回报父级」约束；fresh agent 重跑后没有多余 booking。后续同一真实环境又跑通 running → stopping → cancelled、`thread_block` 问题与聚合原因、精确 run transcript byte range、inline child、mark done，以及删除 agent 后保留 `name (removed)` 历史署名。最新真实 run 还证明了两件事：人在 Alice `running` 时追加的消息被同一个 run 接受并消费，Alice 的最终 `thread_review` 明确纳入追加要求；Alice 与 Bob 在同一线程相差 138ms 进入 `running`，各自提交 review 后线程聚合为 `in_review`。运行中投递丢失、12 轮防乒乓、重启/卡死恢复、host 替换/reaper、bare 模式、视觉 CI 和通知仍未端到端验证。
+**验证边界**：两名真实 agent 的最小闭环已经跑通：Alice 拆子线程并 `thread_wait`，Bob `thread_review`，父报告 13ms 写回，同一个 Alice 长期执行体续跑并把根线程 `thread_review` 到 `in_review`。真实 daemon + Web Shell 的 demo 路径也已跑通 roster/create/list/detail、实时派发和父级续跑，最终根线程进入 `in_review`，树内计费 186,317/200,000。浏览器首轮同时发现 result 文本里的 peer mention 会按规则继续 booking 并形成回环，因此 §6 补了「at-sign address 等于 booking，子线程完成已自动回报父级」约束；fresh agent 重跑后没有多余 booking。后续同一真实环境又跑通 running → stopping → cancelled、`thread_block` 问题与聚合原因、精确 run transcript byte range、inline child、mark done，以及删除 agent 后保留 `name (removed)` 历史署名。最新真实 run 还证明了两件事：人在 Alice `running` 时追加的消息被同一个 run 接受并消费，Alice 的最终 `thread_review` 明确纳入追加要求；Alice 与 Bob 在同一线程相差 138ms 进入 `running`，各自提交 review 后线程聚合为 `in_review`。两个 `SIGKILL` 场景也已跑通：running run 以同一 run id 的第二次 attempt 恢复并完成；一条已 accepted、未 consumed 的插话在重启后被消费，最终结果包含重放标记。`queueExternalInput` 返回 false 后的持久重订、12 轮防乒乓、卡死恢复、host 替换/reaper、bare 模式、视觉 CI 和通知仍未端到端验证。
 
 </details>

--- a/docs/plans/2026-09-07-mesh-implementation-acceptance.md
+++ b/docs/plans/2026-09-07-mesh-implementation-acceptance.md
@@ -114,8 +114,8 @@ run pass. A first demo input also mentioned Bob directly and therefore woke him
 according to the real routing rule; addressing only Alice fixed the driver, not
 the product.
 
-This proves the demo steps 1-5 only. The forced delivery miss, 12-turn
-ping-pong, daemon reaper/reload observation, and bare-mode exposure remain
+This proves the demo steps 1-5 only. The forced `queueExternalInput` miss,
+12-turn ping-pong, daemon reaper replacement, and bare-mode exposure remain
 unrun, so the full step-7 gate is not yet claimed.
 
 **Direct steering and concurrency observation (2026-09-07).** In thread
@@ -174,6 +174,21 @@ rejected before later launch or dispatch; generation checks bracket host claims
 and releases, and a raced stale spawn is cleaned up. Reusing the same bridge
 object cannot keep the old owner alive. This path was source-inspected only
 under the same demo-first constraint.
+
+**Crash-recovery observation (2026-09-07).** A real daemon was killed with
+`SIGKILL` while run `rn_4bd80535-7fe6-4024-aeac-70dbaf338fea` was `running`.
+Restart recovery kept the run id, advanced it to attempt 2, consumed its durable
+trigger, and completed it with `thread_review`. A second run,
+`rn_04d3aa17-39d1-4ddc-958f-38c5f003c537`, was killed after message
+`ms_d4fe89c5-ecaa-4a87-a7c2-6c6f451c2476` appeared in
+`acceptedMessageIds` but before it appeared in `consumedMessageIds`. On restart,
+the same run advanced to attempt 2, consumed that delivery, and its final review
+contained both requested replay markers. This manually proves running-run
+restart and accepted-but-unconsumed replay; it does not prove enqueue returning
+false, transcript-written-before-consumed recovery, stale-host replacement, or
+the watchdog. The long replay run also exposed the conservative accounting
+policy visibly: it closed at `666,749 / 200,000` tokens because the limit is
+checked at admission, not between tool rounds.
 
 ### Step 9 — REST and Web Shell
 


### PR DESCRIPTION
## What this PR does

Records real-daemon crash-recovery evidence for a running mesh run and an accepted-but-not-yet-consumed human interjection.

## Why it's needed

Restart and delivery replay were implemented but still described only from source inspection. This pass killed the daemon at the two durable states and observed the recovered run through completion.

## Reviewer Test Plan

### How to verify

Review the recorded run and message ids and confirm the document distinguishes the observed restart paths from the still-unverified enqueue-false, transcript race, stale-host, and watchdog paths.

### Evidence (Before & After)

Before: restart replay was implemented but had no real daemon evidence.

After: a running run survived daemon SIGKILL as the same run id on attempt 2 and completed review. A second run was killed with one message accepted but not consumed; attempt 2 consumed it and produced both requested replay markers. The same run exposed that the conservative accounting limit can overshoot to 666,749 / 200,000 tokens without a new admission.

No unit tests, lint, typecheck, build, or CI wait were run. This PR changes acceptance evidence only.

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ✅ real daemon and real model |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: none; documentation only.
- Not validated / out of scope: enqueue returning false, transcript-written-before-consumed recovery, stale-host replacement, watchdog recovery, bare mode, visual CI, and notification delivery.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #11206.
