### PR TITLE
fix(cli): stop housekeeping hanging on a deleted bind mount

### DIFF
--- a/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
+++ b/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
@@ -196,4 +196,42 @@ describe('runThrottledOnce', () => {
     expect(fs.statSync(markerPath).isDirectory()).toBe(true);
     expect(fs.existsSync(lockPath)).toBe(false);
   });
+
+  it('creates the lock directory when it does not exist yet', async () => {
+    const qwenDir = path.join(tempDir, 'qwen-dir');
+    const task = vi.fn(async () => {});
+
+    const result = await runThrottledOnce(
+      {
+        name: 'test',
+        markerPath: path.join(qwenDir, '.marker'),
+        lockPath: path.join(qwenDir, '.marker.lock'),
+      },
+      task,
+    );
+
+    expect(result).toEqual({ status: 'completed' });
+    expect(task).toHaveBeenCalledOnce();
+    const stat = fs.statSync(qwenDir);
+    expect(stat.isDirectory()).toBe(true);
+    // No group/other access, per the ~/.qwen/ convention. Asserting the
+    // absence of those bits rather than an exact mode keeps this umask-proof.
+    expect(stat.mode & 0o077).toBe(0);
+  });
+
+  // Regression: this mkdir used to pass `recursive: true`. On a bind mount
+  // whose source directory was deleted, the mountpoint still stats as a
+  // directory but rejects creates with ENOENT, and Node's recursive mkdir
+  // retries the parent forever without ever settling its promise — wedging the
+  // housekeeping chain and spinning a core per orphaned CI sandbox container.
+  it('never asks for a recursive mkdir', async () => {
+    const task = vi.fn(async () => {});
+
+    await runThrottledOnce({ name: 'test', markerPath, lockPath }, task);
+
+    expect(fsPromises.mkdir).toHaveBeenCalled();
+    for (const [, options] of vi.mocked(fsPromises.mkdir).mock.calls) {
+      expect(options).not.toMatchObject({ recursive: true });
+    }
+  });
 });

--- a/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
+++ b/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
@@ -216,7 +216,11 @@ describe('runThrottledOnce', () => {
     expect(stat.isDirectory()).toBe(true);
     // No group/other access, per the ~/.qwen/ convention. Asserting the
     // absence of those bits rather than an exact mode keeps this umask-proof.
-    expect(stat.mode & 0o077).toBe(0);
+    // On Windows mkdir's mode is a no-op and libuv duplicates owner bits to
+    // group/other, so only POSIX platforms can pin the 0o700 convention.
+    if (process.platform !== 'win32') {
+      expect(stat.mode & 0o077).toBe(0);
+    }
   });
 
   // Regression: this mkdir used to pass `recursive: true`. On a bind mount
@@ -233,5 +237,27 @@ describe('runThrottledOnce', () => {
     for (const [, options] of vi.mocked(fsPromises.mkdir).mock.calls) {
       expect(options).not.toMatchObject({ recursive: true });
     }
+  });
+
+  // Effect-shaped companion to the option-shape regression above: pin what
+  // the deleted-mount state actually does. The non-recursive mkdir cannot
+  // create a directory whose own parent is missing, and the lock open must
+  // surface that ENOENT on the first attempt — not settle as 'locked'
+  // (misread as contention by the scheduler), and never bootstrap the parent.
+  it('surfaces ENOENT instead of bootstrapping a missing parent', async () => {
+    const missingDir = path.join(tempDir, 'nope', 'nested');
+    const task = vi.fn(async () => {});
+
+    await expect(
+      runThrottledOnce(
+        {
+          name: 'test',
+          markerPath: path.join(missingDir, '.marker'),
+          lockPath: path.join(missingDir, '.marker.lock'),
+        },
+        task,
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(task).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/utils/housekeeping/throttledOnce.ts
+++ b/packages/cli/src/utils/housekeeping/throttledOnce.ts
@@ -47,9 +47,20 @@ export async function runThrottledOnce(
   // matches the rest of the codebase's convention for ~/.qwen/ subdirs
   // (e.g., file-token-storage.ts, sharedTokenManager.ts) so a slow main-app
   // initialization doesn't get races us into creating a world-readable dir.
-  await mkdir(dirname(opts.lockPath), { recursive: true, mode: 0o700 }).catch(
-    () => {},
-  );
+  //
+  // Deliberately NOT recursive. On a bind mount whose source directory was
+  // deleted underneath us, the mountpoint still stats as a directory while
+  // creating entries inside it fails with ENOENT. Node's recursive mkdir reads
+  // that ENOENT as "parent is missing", creates the parent (EEXIST), confirms
+  // it is a directory, retries the leaf, gets ENOENT again — forever. The
+  // returned promise never settles, so the `.catch` below never runs and this
+  // `await` wedges the whole housekeeping chain for the life of the process.
+  // CI hit exactly that: orphaned e2e sandbox containers whose workspace had
+  // already been cleaned up each burned a core on ~2.5k failing mkdir/s.
+  //
+  // One level is all this needs: every caller puts lockPath directly in the
+  // global qwen dir, whose own parent is $HOME.
+  await mkdir(dirname(opts.lockPath), { mode: 0o700 }).catch(() => {});
 
   const firstFreshForMs = await markerFreshForMs(
     opts.markerPath,


### PR DESCRIPTION
## What this PR does

Housekeeping ensures its lock directory exists before taking the once-per-interval lock. That call asked for a recursive create; this PR makes it create a single level instead, so a create that cannot succeed fails fast rather than retrying forever.

## Why it's needed

When the global qwen dir lives inside a bind mount whose source directory has since been deleted, the mountpoint still stats as a directory while creating entries inside it returns `ENOENT`. Node's recursive mkdir interprets that `ENOENT` as "the parent is missing", creates the parent (`EEXIST`), stats it to confirm it is a directory, retries the leaf, gets `ENOENT` again — with no retry cap and no backoff. The returned promise therefore never settles, which has two consequences: the existing `.catch(() => {})` never runs, so nothing is logged and nothing degrades gracefully; and the `await` wedges the housekeeping chain for the remaining lifetime of the process.

This is not theoretical — it was the amplifier behind a CPU overload on the self-hosted ECS runner pool. E2E sandbox containers that outlived their host-side `docker run` client kept running after their job had already deleted the workspace those containers had bind-mounted. Roughly a minute later each container's housekeeping timer fired, hit this path, and started spinning. Measured on one 64-core host: 177 such processes, `~2.5k` failing `mkdir/s` each, `~67%` system time fleet-wide, and 45 CPU-hours accumulated by the oldest single process. Across five hosts the orphaned containers were consuming about 232 of 320 cores. Reaping the containers dropped one host's load average from 213 to 12.

Container leakage itself is being addressed separately in #11264; this PR removes the CLI-side amplifier so that an orphaned or otherwise wedged sandbox costs approximately nothing instead of a full core.

A single level is sufficient here: all three `runThrottledOnce` call sites put `lockPath` directly in the global qwen dir, whose own parent is `$HOME`. When the directory genuinely cannot be created the subsequent lock acquisition surfaces the error, so housekeeping degrades to a skip — the intended behaviour — instead of hanging.

## Reviewer Test Plan

### How to verify

The unit tests cover the invariant and the preserved behaviour: `cd packages/cli && npx vitest run src/utils/housekeeping/throttledOnce.test.ts`. Two tests are added — one asserts the lock directory is still created (with no group/other permission bits) when it does not exist yet, and one asserts no `mkdir` call requests `recursive: true`. To confirm the second test is a real guard rather than a tautology, temporarily restore `recursive: true` in `throttledOnce.ts`; it fails with `expected { recursive: true, mode: 448 } to not match object { recursive: true }`.

To reproduce the underlying condition on Linux (needs root for `mount`; `unshare -m` keeps the bind mount in a private namespace so nothing leaks to the host):

```bash
unshare -m bash -c '
  B=/tmp/verify.$$; mkdir -p "$B/src/qhome" "$B/mnt"
  mount --bind "$B/src" "$B/mnt"
  rm -rf "$B/src"    # source deleted; mountpoint is now //deleted
  node -e "
    const fs = require(\"fs/promises\");
    const t = process.argv[1];
    let a = null, b = null;
    fs.mkdir(t, { recursive: true, mode: 0o700 }).then(() => (a = \"RESOLVED\"), e => (a = \"REJECTED \" + e.code));
    fs.mkdir(t, { mode: 0o700 }).then(() => (b = \"RESOLVED\"), e => (b = \"REJECTED \" + e.code));
    setTimeout(() => { console.log(\"recursive:true  ->\", a ?? \"STILL PENDING\"); console.log(\"recursive:false ->\", b ?? \"STILL PENDING\"); process.exit(0); }, 6000);
  " "$B/mnt/qhome"
  umount "$B/mnt"; rm -rf "$B"
'
```

Expected: the recursive form is still pending after six seconds while the single-level form has already rejected with `ENOENT`. Wrapping each form in `/usr/bin/time` shows the recursive form burning `103%` CPU against `0%` for the single-level form.

### Evidence (Before & After)

Not a user-visible or TUI change. Behavioural evidence is the reproduction above, measured on one of the affected Linux hosts:

```
mountinfo: /tmp/verify.2928891/src//deleted /tmp/verify.2928891/mnt ext4

before (recursive:true)   ->  *** STILL PENDING (never settles) ***   cpu=103%
after  (recursive:false)  ->  REJECTED ENOENT                        cpu=0%
```

For reference, the syscall signature observed on a live wedged process before the fix — `mkdir` failing 100% of the time, at roughly 2.5k calls per second:

```
% time     calls    errors  syscall
 84.27    135267      9788  futex
  9.51     76112            epoll_pwait
  1.53     25428     25428  mkdir
  0.96     12714            statx
```

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |       ✅       |
| 🪟 Windows |       ⚠️       |
|  🐧 Linux  |       ✅       |

macOS: unit tests — `throttledOnce.test.ts` 13 passed, and the full housekeeping surface (`src/utils/housekeeping` plus `src/services/housekeeping`) 80 passed. Linux: the bind-mount reproduction and before/after measurement above. Windows: not tested; the failure mode is Linux bind-mount specific, and the change itself is platform-neutral.

### Environment (optional)

Unit tests only, plus a root shell on an affected Linux host for the mount-level reproduction.

## Risk & Scope

- Main risk or tradeoff: if a caller ever passes a `lockPath` whose parent directory does not already exist, the directory is no longer created for it and housekeeping skips that pass instead of silently bootstrapping the tree. All three current call sites resolve to the global qwen dir, so none are affected; a new call site with a deeper path would need to create its own parent.
- Not validated / out of scope: I could not explain why the same never-settling call presents as a hot `mkdir` loop in some processes (production, and a standalone Node repro at 103% CPU) but as a quiet hang with no `mkdir` syscalls at all in others (the real CLI under my reproduction — promise still pending, 0% CPU, idle libuv workers). Both variants are removed by this change, but the trigger that selects between them is unknown; a plausible but unverified factor is the extra nested bind mount present in the CI layout. Container leakage itself is out of scope and handled by #11264. No Windows verification.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #11264, which stops the E2E sandbox containers from leaking in the first place. This PR is independent and complementary: it removes the CLI-side cost of a container that has already been orphaned, whatever the cause.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

housekeeping 在获取「每周期一次」的锁之前，会先确保锁目录存在。原先这个调用用的是递归创建；本 PR 改为只创建一层，这样当创建注定无法成功时会快速失败，而不是无限重试。

## 为什么需要

当全局 qwen 目录位于某个 bind mount 内、而该挂载的源目录已被删除时，挂载点本身仍然能被 stat 成目录，但在其内部创建条目会返回 `ENOENT`。Node 的递归 mkdir 把这个 `ENOENT` 理解为「父目录缺失」，于是去创建父目录（得到 `EEXIST`）、stat 确认它是目录、重试叶子节点、再次得到 `ENOENT` —— 没有重试上限，也没有退避。因此返回的 promise 永远不会 settle，带来两个后果：现有的 `.catch(() => {})` 永远不会执行，既没有日志也没有优雅降级；同时这个 `await` 会把整条 housekeeping 链卡死到进程生命周期结束。

这不是理论推演 —— 它正是自建 ECS runner 集群一次 CPU 过载的放大器。E2E sandbox 容器在宿主机侧的 `docker run` 客户端被回收后仍在运行，而对应 job 早已删除了这些容器 bind mount 进去的工作目录。大约一分钟后，每个容器的 housekeeping 定时器触发、命中这条路径并开始空转。在一台 64 核宿主机上实测：177 个这样的进程，每个每秒约 2500 次失败的 `mkdir`，全机 system time 约 67%，其中最老的单个进程累计消耗 45 CPU 小时。五台宿主机上，这些孤儿容器合计占用了约 320 核中的 232 核。回收容器后，其中一台的 load average 从 213 降到 12。

容器泄漏本身由 #11264 单独处理；本 PR 移除 CLI 侧的放大器，使得一个已经变成孤儿或以其它方式卡死的 sandbox 的开销接近于零，而不是吃满一个核。

这里只创建一层就足够了：`runThrottledOnce` 的三个调用点都把 `lockPath` 直接放在全局 qwen 目录下，而该目录的父目录是 `$HOME`。当目录确实无法创建时，后续的加锁步骤会把错误暴露出来，于是 housekeeping 降级为跳过 —— 这正是预期行为 —— 而不是挂死。

## 评审验证方案

### 如何验证

单元测试覆盖了这个不变量以及被保留的行为：`cd packages/cli && npx vitest run src/utils/housekeeping/throttledOnce.test.ts`。新增两个测试 —— 一个断言锁目录在不存在时仍会被创建（且不带 group/other 权限位），另一个断言没有任何 `mkdir` 调用请求 `recursive: true`。为了确认第二个测试是真正的护栏而不是同义反复，可以临时把 `throttledOnce.ts` 里的 `recursive: true` 加回去；它会失败并报出 `expected { recursive: true, mode: 448 } to not match object { recursive: true }`。

在 Linux 上复现底层条件（`mount` 需要 root；`unshare -m` 把 bind mount 隔离在私有命名空间内，不会泄漏到宿主机）：使用上面英文部分给出的脚本。

预期结果：递归形式在六秒后仍处于 pending，而单层形式已经以 `ENOENT` 拒绝。用 `/usr/bin/time` 分别包裹两种形式可以看到，递归形式烧掉 `103%` CPU，单层形式为 `0%`。

### 证据（前后对比）

不是用户可见或 TUI 变更。行为证据即上面的复现，在一台受影响的 Linux 宿主机上实测：改动前（`recursive:true`）六秒后仍未 settle、CPU 103%；改动后（`recursive:false`）以 `ENOENT` 拒绝、CPU 0%。作为参考，修复前在一个活体卡死进程上抓到的系统调用特征是 `mkdir` 100% 失败、每秒约 2500 次，详见英文部分表格。

### 测试平台

macOS：单元测试 —— `throttledOnce.test.ts` 13 项通过，housekeeping 全量（`src/utils/housekeeping` 加 `src/services/housekeeping`）80 项通过。Linux：上述 bind mount 复现与前后对比测量。Windows：未测试；该故障模式是 Linux bind mount 特有的，而改动本身与平台无关。

### 环境（可选）

仅单元测试，另加一台受影响 Linux 宿主机上的 root shell 用于挂载层面的复现。

## 风险与范围

- 主要风险或权衡：如果将来有调用方传入父目录尚不存在的 `lockPath`，该目录将不再被自动创建，housekeeping 会跳过这一轮而不是静默地把整棵目录树补齐。当前三个调用点都指向全局 qwen 目录，因此都不受影响；若新增更深路径的调用点，需要自行创建其父目录。
- 未验证 / 超出范围：我无法解释为什么同一个永不 settle 的调用，在部分进程中表现为 `mkdir` 热循环（生产环境，以及一个 103% CPU 的独立 Node 复现），而在另一些进程中表现为安静挂起、完全没有 `mkdir` 系统调用（真实 CLI 在我的复现下 —— promise 仍 pending、CPU 0%、libuv worker 全空闲）。本改动会消除这两种表现，但决定走向哪一种的触发条件尚不清楚；一个合理但未经验证的猜测是 CI 布局中多出的一层嵌套 bind mount。容器泄漏本身超出本 PR 范围，由 #11264 处理。没有 Windows 验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

与 #11264 相关，后者从源头阻止 E2E sandbox 容器泄漏。本 PR 与其独立且互补：无论成因如何，它消除的是一个已经变成孤儿的容器在 CLI 侧带来的开销。

</details>
