### PR TITLE
fix(mesh): deny shell without filesystem isolation

### DIFF
--- a/docs/plans/2026-09-06-multi-agent-board-collaboration.md
+++ b/docs/plans/2026-09-06-multi-agent-board-collaboration.md
@@ -87,8 +87,8 @@ continuations already emit `EXTERNAL_MESSAGE`, and cold revival explicitly
 seeds the continuation prompt in the transcript. Mesh still uses structured
 input because correlation, not transcript presence, is the missing contract.
 
-**Verified locally in steps 2-4.** The capability table and
-shell predicate pass their named tests. The versioned store tests exercise
+**Verified locally in steps 2-4.** The capability table denies shell and MCP
+tools and passes its named test. The versioned store tests exercise
 newer-version refusal, v0 migration and backup recovery, two-process sequence
 allocation, source-first outbox replay, persisted admission outcomes, and
 tree-wide token accounting. The step-4 tests exercise invocation-time tool
@@ -206,7 +206,7 @@ Recorded so implementation does not relitigate them.
 | #   | Decision                                                                                                                                                                           | Consequence                                                                                                                                                            |
 | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | **v1 agents are read-only.** No file writes, no worktrees, no branches.                                                                                                            | Removes all concurrent-write design. The deliverable of a thread is a conclusion, not a diff.                                                                          |
-| 2   | Read-only means **files + read-only shell**, against a **built-in allowlist**. `save_memory`, context-file writes, and every other persistent-write tool are outside that ceiling. | `run_shell_command` can write, so "no writes but any command" is a false boundary. The allowlist is the hard ceiling; agent definitions may narrow it, never widen it. |
+| 2   | Read-only means **workspace file-reading tools only**. Shell, MCP, `save_memory`, context-file writes, and every other persistent-write or host-wide tool are outside that ceiling. | A read-only shell classifier does not confine absolute paths, so it cannot protect secrets outside the workspace. Shell stays denied until execution has a real filesystem sandbox. Agent definitions may narrow the ceiling, never widen it. |
 | 3   | Tool sets otherwise **follow a required agent definition**.                                                                                                                        | No second permission model. An enabled mesh agent with a missing definition is unavailable, never silently replaced by a generic persona.                              |
 | 4   | Agents are **scoped to one workspace**.                                                                                                                                            | Trust and permissions follow the workspace. Five repos means five rosters.                                                                                             |
 
@@ -624,12 +624,10 @@ Dependencies, with an early vertical proof before reliability and UI breadth.
 1. **Local admission foundation** — landed in this PR: storage validation,
    mention routing, budget gates, coalescing, retention, and atomic per-thread
    booking. It still has no launcher or dispatcher.
-2. **Capability boundary** — built-in read-only shell allowlist intersected
-   with the agent definition. Explicitly exclude `save_memory`, context-file
-   writes, and every persistent-write tool. This step proves the classification
-   and shell predicate. Step 4/5 wires the predicate at invocation time and
-   proves refused commands cannot execute, because the existing name-level
-   execution allowlist cannot inspect command arguments.
+2. **Capability boundary** — built-in workspace file-reading allowlist
+   intersected with the agent definition. Explicitly exclude shell, MCP,
+   `save_memory`, context-file writes, and every persistent-write or host-wide
+   tool. The name-level execution allowlist enforces this ceiling.
 3. **Versioned storage protocol** — add `schemaVersion`, the workspace mutation
    lock, lock-issued run queue sequence, atomic same-thread booking, parent/
    notification outbox replay, and fail-closed migration before any new process

--- a/docs/plans/2026-09-07-mesh-implementation-acceptance.md
+++ b/docs/plans/2026-09-07-mesh-implementation-acceptance.md
@@ -25,12 +25,11 @@ Evidence: the test names covering each clause. Currently 38 tests; keep the coun
 
 ### Step 2 — Read-only capability boundary
 
-Lands: a built-in allowlist for `run_shell_command`, intersected with the agent definition's tool list; an explicit deny list containing `save_memory`, `write_file`, `edit`, and every tool that persists outside the process; `thread_*` tools are added on top of the definition, never taken from it.
-Gate: a table-driven test enumerates every registered tool name in core and asserts it is either allowed, denied, or `thread_*`; adding a new tool to core without classifying it fails the test. The shell predicate refuses every command the AST classifier does not return `read-only` for, with tests for allowed and refused commands.
-Deferred to step 4/5: proving the refusal happens in the tool layer. `executionAllowedTools` is name-level, so a per-command predicate needs an invocation-time hook that arrives with the launcher (see the steps 2-3 brief §2).
+Lands: a built-in workspace file-reading allowlist intersected with the agent definition's tool list; shell, MCP, `save_memory`, `write_file`, `edit`, and every persistent or host-wide tool are denied; `thread_*` tools are added on top of the definition, never taken from it.
+Gate: a table-driven test enumerates every registered tool name in core and asserts it is either allowed, denied, or `thread_*`; adding a new tool to core without classifying it fails the test. The tool configuration and invocation guard both deny shell by name.
 Evidence: the classification table, committed as data, not prose.
 
-Supporting local observation: `capability.test.ts`, 10 tests passed. The step
+Supporting local observation before the shell boundary correction: `capability.test.ts`, 10 tests passed. The step
 is not complete until #11206 CI passes after the child PR merges.
 
 ### Step 3 — Versioned storage protocol

--- a/docs/plans/2026-09-07-mesh-steps-2-3-brief.md
+++ b/docs/plans/2026-09-07-mesh-steps-2-3-brief.md
@@ -21,11 +21,7 @@
 
 - `MESH_TOOL_CLASSIFICATION: Record<string, 'allow' | 'deny' | 'thread'>` keyed by tool name, covering every `ToolNames` value; `classifyMeshTool(name)` returns the entry or `'deny'` for anything unlisted (MCP tools included).
 - `buildMeshToolConfig(definitionTools?)` → `ToolConfig` with `tools = (definition ∩ allow) ∪ thread_*` (a `'*'` or absent definition list means the full allow set), `executionAllowedTools` equal to that list, `disallowedTools` equal to the deny set. The launcher passes it as `toolConfigOverride`.
-- `checkMeshShellCommand(command, cwd)` → allowed only when classification is `'read-only'`; `'unknown'` is refused and the reason says which of write/unknown it was.
-
-**Confirmed v1 classification:** allow `read_file`, `grep_search`, `glob`, `list_directory`, `zoom_image`, `display_image`, `skill`, `tool_search`, `structured_output`, `get_goal`, `run_shell_command` (guarded). Deny `edit`, `write_file`, `notebook_edit`, `save_memory`, `web_fetch`, `web_search`, `lsp`, `monitor`, `read_mcp_resource`, `ask_user_question`, `enter_plan_mode`, `exit_plan_mode`, `image_gen`, `update_goal`, `propose_goal`, `report_findings`, and everything in `EXCLUDED_TOOLS_FOR_SUBAGENTS`. MCP names also fail closed. A later release may admit only MCP tools whose policy can prove they are read-only; server ownership or naming alone is insufficient.
-
-**What step 2 can and cannot prove.** The acceptance doc's step-2 gate says "a shell command not on the allowlist is refused before execution, in the tool layer". `executionAllowedTools` cannot express a per-command predicate, so the refusal needs a hook at tool-invocation time: either the `PreToolUse` hook path AgentCore already carries (`this.hooks`) or a wrapped shell tool in the launcher's registry. That wiring belongs to step 4/5 with the launcher. Step 2 delivers the predicate, the table, and their tests; the acceptance gate for step 2 is amended to "predicate and table proven; tool-layer refusal proven in step 4".
+**Confirmed v1 classification:** allow `read_file`, `grep_search`, `glob`, `list_directory`, `zoom_image`, `display_image`, `skill`, `tool_search`, `structured_output`, and `get_goal`. Deny `run_shell_command`, `edit`, `write_file`, `notebook_edit`, `save_memory`, `web_fetch`, `web_search`, `lsp`, `monitor`, `read_mcp_resource`, `ask_user_question`, `enter_plan_mode`, `exit_plan_mode`, `image_gen`, `update_goal`, `propose_goal`, `report_findings`, and everything in `EXCLUDED_TOOLS_FOR_SUBAGENTS`. MCP names also fail closed. Shell can return only with a filesystem sandbox that confines reads to the canonical workspace root; classifying a command as read-only does not provide that boundary.
 
 **Resolved by the owner.** V1 mesh agents get no MCP tools. Future admission requires an explicit policy that proves the individual tool is read-only; the definition may narrow that policy but cannot widen it.
 
@@ -49,7 +45,7 @@
 
 **Named tests and what each proves.**
 
-- `capability.test.ts`: every `ToolNames` value is classified; unlisted name → deny; `'*'` and narrowing definitions; shell: `cat`, `git status`, `grep -r` allowed; `rm -rf`, `echo > f`, `git push`, `unknownbin --x` refused with reason.
+- `capability.test.ts`: every `ToolNames` value is classified; unlisted name → deny; `'*'` and narrowing definitions; shell is absent from tool configuration and refused by the invocation guard.
 - `mesh-store.test.ts`: newer `schemaVersion` on thread, agents, and workspace each fail closed; v0 fixtures (bare agents array; thread without version but with messages and runs) migrate with sequences assigned in order and the backup removed; deletion refused with a pending event; a thread-write crash after allocation leaves a run-sequence gap; crash injection — `apply` writes the target then throws, second run finds the message by `originEventId`, event acknowledged with `attempts === 2`, exactly one target message; depth-3 tree with a stale `tokensUsed` on the root gates on the true sum.
 - `workspace-lock.test.ts`: two `tsx` child processes allocate N `queueSequence` each; all 2N unique, each process strictly increasing.
 - `thread-actions.test.ts`: fixtures gain the new fields; message `sequence` monotonic; `queueSequence` increasing across two threads; outcomes persisted on the message; `queue_full` computed from disk.
@@ -68,4 +64,4 @@ A worktree at the branch head with `node_modules` and `packages/core/node_module
 
 ## 6. Still unexecuted after steps 2-3
 
-`queueExternalInput(false)` detach/rebook (step 6/7); shell refusal in the tool layer (step 4/5); assignment trigger through admission (decision 21, step 5/6); creating and reviving the hidden host session recorded by `workspace.json` (step 4).
+`queueExternalInput(false)` detach/rebook (step 6/7); assignment trigger through admission (decision 21, step 5/6); creating and reviving the hidden host session recorded by `workspace.json` (step 4).

--- a/packages/core/src/agents/mesh/capability.test.ts
+++ b/packages/core/src/agents/mesh/capability.test.ts
@@ -4,25 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ToolNames } from '../../tools/tool-names.js';
-import { _resetParser, initParser } from '../../utils/shellAstParser.js';
 import {
   buildMeshToolConfig,
-  checkMeshShellCommand,
   classifyMeshTool,
   createMeshToolInvocationGuard,
   MESH_THREAD_TOOL_NAMES,
   MESH_TOOL_CLASSIFICATION,
 } from './capability.js';
-
-beforeAll(async () => {
-  await initParser();
-});
-
-afterAll(() => {
-  _resetParser();
-});
 
 describe('mesh capability boundary', () => {
   it('classifies every core and mesh thread tool exactly once', () => {
@@ -50,7 +40,7 @@ describe('mesh capability boundary', () => {
     });
 
     expect(wildcard).toEqual(full);
-    expect(full.tools).toContain(ToolNames.SHELL);
+    expect(full.tools).not.toContain(ToolNames.SHELL);
     expect(full.tools).not.toContain(ToolNames.MEMORY);
     expect(full.disallowedTools).toEqual(
       expect.arrayContaining([
@@ -74,35 +64,10 @@ describe('mesh capability boundary', () => {
       disallowedTools: [ToolNames.READ_FILE, 'thread_post'],
     });
 
-    expect(narrowed.tools).toEqual([
-      ToolNames.SHELL,
-      ...MESH_THREAD_TOOL_NAMES,
-    ]);
+    expect(narrowed.tools).toEqual([...MESH_THREAD_TOOL_NAMES]);
     expect(narrowed.executionAllowedTools).toEqual(narrowed.tools);
     expect(narrowed.disallowedTools).not.toContain('thread_post');
     expect(narrowed.disallowedTools).toContain(ToolNames.READ_FILE);
-  });
-
-  it.each(['cat package.json', 'git status', 'grep -r TODO packages/core'])(
-    'allows read-only shell command %s',
-    async (command) => {
-      await expect(
-        checkMeshShellCommand(command, process.cwd()),
-      ).resolves.toEqual({ allowed: true });
-    },
-  );
-
-  it.each([
-    ['rm -rf temp', 'write'],
-    ['echo text > file', 'write'],
-    ['git push', 'write'],
-    ['unknownbin --x', 'unknown'],
-  ])('refuses shell command %s classified as %s', async (command, safety) => {
-    const decision = await checkMeshShellCommand(command, process.cwd());
-    expect(decision).toEqual({
-      allowed: false,
-      reason: expect.stringContaining(safety),
-    });
   });
 
   it('enforces the boundary at invocation time', async () => {
@@ -131,6 +96,6 @@ describe('mesh capability boundary', () => {
         args: { command: 'git status' },
         cwd: process.cwd(),
       }),
-    ).resolves.toEqual({ allowed: true });
+    ).resolves.toEqual(expect.objectContaining({ allowed: false }));
   });
 });

--- a/packages/core/src/agents/mesh/capability.ts
+++ b/packages/core/src/agents/mesh/capability.ts
@@ -10,7 +10,6 @@ import {
   type ToolInvocationGuard,
 } from '../../core/tool-invocation-guard.js';
 import { ToolNames } from '../../tools/tool-names.js';
-import { classifyShellCommandSafetyInDirectory } from '../../utils/shellAstParser.js';
 
 export type MeshToolClassification = 'allow' | 'deny' | 'thread';
 
@@ -33,7 +32,7 @@ export const MESH_TOOL_CLASSIFICATION = {
   [ToolNames.ZOOM_IMAGE]: 'allow',
   [ToolNames.GREP]: 'allow',
   [ToolNames.GLOB]: 'allow',
-  [ToolNames.SHELL]: 'allow',
+  [ToolNames.SHELL]: 'deny',
   [ToolNames.TODO_WRITE]: 'deny',
   [ToolNames.MEMORY]: 'deny',
   [ToolNames.AGENT]: 'deny',
@@ -133,19 +132,6 @@ export function buildMeshToolConfig(definition?: ToolConfig): ToolConfig {
   };
 }
 
-export async function checkMeshShellCommand(
-  command: string,
-  cwd: string,
-): Promise<{ allowed: true } | { allowed: false; reason: string }> {
-  const safety = await classifyShellCommandSafetyInDirectory(command, cwd);
-  return safety === 'read-only'
-    ? { allowed: true }
-    : {
-        allowed: false,
-        reason: `You may only run read-only shell commands; this one is classified as ${safety}.`,
-      };
-}
-
 export function createMeshToolInvocationGuard(
   upstream?: ToolInvocationGuard,
 ): ToolInvocationGuard {
@@ -165,23 +151,6 @@ export function createMeshToolInvocationGuard(
         reason: `Tool "${context.toolName}" is outside the mesh read-only capability boundary.`,
       };
     }
-    if (context.toolName !== ToolNames.SHELL) return { allowed: true };
-    if (context.args['is_background'] === true) {
-      return {
-        allowed: false,
-        reason: 'You may not start background shell processes.',
-      };
-    }
-    const command = context.args['command'];
-    if (typeof command !== 'string') {
-      return { allowed: false, reason: 'Mesh shell command is missing.' };
-    }
-    const directory = context.args['directory'];
-    return checkMeshShellCommand(
-      command,
-      typeof directory === 'string'
-        ? directory
-        : (context.cwd ?? process.cwd()),
-    );
+    return { allowed: true };
   };
 }


### PR DESCRIPTION
## What this PR does

Removes shell access from mesh agents and keeps their capability ceiling to workspace-scoped read tools plus shared-thread tools. It also updates the mesh design and acceptance documents to record that a read-only command classifier is not a filesystem boundary.

## Why it's needed

The previous guard could distinguish commands that write from commands that only read, but an allowed command such as `cat /absolute/path` could still read host secrets outside the workspace. Shell must remain unavailable until execution is confined by a real filesystem sandbox.

## Reviewer Test Plan

### How to verify

Create a mesh tool configuration with wildcard tools and confirm shell is absent. Invoke the mesh guard with a shell command and confirm it is denied by name.

### Evidence (Before & After)

Before: read-only shell commands were admitted even when their absolute paths escaped the workspace. After: shell is absent from the mesh tool set and the invocation guard denies it.

No local test, lint, typecheck, build, or CI run was performed for this demo-first follow-up.

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: mesh agents lose shell-based repository inspection for v1.
- Not validated / out of scope: adding an OS-level filesystem sandbox.
- Breaking changes / migration notes: existing agent definitions that request shell are narrowed automatically.

## Linked Issues

Part of #11206.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

从 mesh Agent 的能力中移除 shell，只保留工作区范围的读取工具和共享线程工具；同时更新设计与验收文档，明确“只读命令分类”不等于文件系统隔离。

## 为什么需要

原来的 guard 能区分写命令和只读命令，但 `cat /absolute/path` 之类被允许的命令仍能读取工作区外的主机秘密。在具备真正的文件系统沙箱前，shell 必须保持禁用。

## Reviewer 验证计划

### 如何验证

用通配符创建 mesh 工具配置，确认其中没有 shell；用 shell 命令调用 mesh guard，确认按工具名拒绝。

### 证据（前后对比）

Before：只读 shell 命令即使绝对路径逃出工作区也会被准入。After：shell 不再出现在 mesh 工具集中，调用 guard 也会被拒绝。

本次是 demo 优先的收口修改，没有本地运行测试、lint、typecheck、build 或 CI。

### 测试平台

| OS | 状态 |
| :--: | :--: |
| 🍏 macOS | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

## 风险与范围

- 主要代价：v1 mesh Agent 暂时失去基于 shell 的仓库检查能力。
- 未验证 / 范围外：增加操作系统级文件系统沙箱。
- 破坏性变更 / 迁移：现有请求 shell 的 Agent 定义会被自动收窄。

## 关联 Issue

属于 #11206。

</details>
