### PR TITLE
docs(mesh): record live ping-pong budget result

### DIFF
--- a/docs/plans/2026-09-06-multi-agent-board-collaboration.md
+++ b/docs/plans/2026-09-06-multi-agent-board-collaboration.md
@@ -135,8 +135,10 @@ child completion already reports to the parent. Re-running with fresh bodies
 removed the unintended bookings and completed the loop.
 
 **Still unverified.** Running-delivery miss reconciliation, the 12-turn
-ping-pong gate, restart and stall recovery, daemon host replacement/reaper,
-bare-mode tool exposure, and notifications have not been run end to end.
+ping-pong gate, stall recovery, daemon host replacement/reaper, bare-mode tool
+exposure, and notifications have not been run end to end. Daemon restart and
+accepted-but-unconsumed replay have been observed with the same run recovering
+on attempt 2, as recorded in the acceptance document.
 Production paths now exist for correlated running delivery, delivery-race
 rebooking, one retry after restart or a three-minute no-activity stall, stale
 host replacement after a definitive resume failure, source-first cancellation,
@@ -145,6 +147,17 @@ been tested locally while the demo path is being completed. Cancellation,
 transcript slicing, blocked-question rendering, inline children, and
 deleted-agent tombstones have been exercised through the real daemon and
 browser.
+
+The first deliberate live ping-pong attempt also showed that the two settled
+default gates cannot both be reached with the current model footprint. Alice
+and Bob produced three unattended deliveries before the thread reached 428,636
+accounted tokens; the 200,000-token gate therefore pre-empted the 12-turn gate.
+Both agents did run concurrently, and a coalesced mid-run delivery was accepted
+and consumed, but the receiving model closed without producing another reply.
+This is an observed acceptance constraint, not evidence that the turn gate is
+broken. A full 12-turn runtime proof needs either a cheaper/minimal model frame
+or an explicit scenario-only token-limit override; changing the product's
+200,000-token ceiling is not implied.
 
 **How to re-check the Multica claims.** Clone `github.com/multica-ai/multica`
 and read `server/internal/daemon/types.go`, `server/internal/daemon/prompt.go`,

--- a/docs/plans/2026-09-07-mesh-implementation-acceptance.md
+++ b/docs/plans/2026-09-07-mesh-implementation-acceptance.md
@@ -128,6 +128,17 @@ the aggregate thread reached `in_review`. This proves the accepted direct-input
 path and concurrent agents on one shared thread; it does not prove the forced
 enqueue-miss recovery path.
 
+**Deliberate ping-pong observation (2026-09-07).** Thread
+`th_ea937a51-1e41-406c-b328-878fcab0b06e` launched Alice and Bob concurrently
+and recorded three unattended deliveries. The second Alice post coalesced into
+Bob's running attempt; its id appears in both `acceptedMessageIds` and
+`consumedMessageIds`. Bob then closed without emitting another reply. The three
+runs accounted 428,636 tokens, so the 200,000-token gate pre-empts a 12-turn
+live loop with this model footprint. The run therefore does not satisfy the
+12-turn gate. Reaching that gate without changing product semantics requires a
+minimal model frame or a scenario-only token-limit override; the ordinary
+runtime correctly keeps the settled token ceiling in force.
+
 ### Step 8 — Dispatcher reliability
 
 Lands: `delivery_race` detach/rebook; `launch_failed` with `failureStage`; done/cancel (`cancelling` state, runtime abort); restart recovery (`running` → reconcile → resume once → terminal on second failure); stale host-session binding replacement after a definitive resume failure; stall sweeper; full outbox replay on startup.


### PR DESCRIPTION
## What this PR does

Records the latest real-model ping-pong acceptance result and corrects the stale claim that restart replay was still unverified.

## Why it's needed

The live run showed that the settled 200,000-token gate fires before this model can reach twelve unattended deliveries. The acceptance record must distinguish an unreachable scenario from a broken turn gate.

## Reviewer Test Plan

### How to verify

Read the recorded thread id and confirm the observation names the three deliveries, accepted/consumed coalesce, and 428,636 accounted tokens without claiming the twelve-turn gate passed.

### Evidence (Before & After)

Before: the document listed the twelve-turn run as simply unexecuted and still called restart replay unverified. After: it records the observed constraint and the already-completed crash replay.

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ✅ real daemon and model |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: none; documentation only.
- Not validated / out of scope: changing either product budget.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #11206.

<details>
<summary>中文说明</summary>

记录最新的真模型防乒乓验收结果，并修正文档里“重启重放仍未验证”的旧说法。真实运行表明当前模型在 3 次自动投递后已累计 428,636 token，因此 200,000 token gate 会先于 12-turn gate 触发；本提交只记录事实，不修改产品预算。

</details>
