### PR TITLE
ci: run Linux E2E with Vitest forks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,13 +127,10 @@ jobs:
         sandbox:
           - 'sandbox:none'
           - 'sandbox:docker'
-        # The suite is ~16min of wall clock on one runner, dominated by a long
-        # tail of sdk-typescript files. vitest assigns files to shards by path
-        # hash, so those spread out instead of clustering in one shard.
+        # Benchmark one runner with three Vitest forks against the existing
+        # three-runner, one-fork-per-shard baseline.
         shard:
-          - '1/3'
-          - '2/3'
-          - '3/3'
+          - '1/1'
         node-version:
           - '22.x'
     steps:
@@ -362,10 +359,10 @@ jobs:
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}' 9>&-
+            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}' 9>&-
           else
             run_shard() {
-              QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}'
+              QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}'
             }
             # One bounded retry: pool runners' sandbox:none shards die under
             # shared-host pressure with every test green and no vitest FAIL

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,8 +127,8 @@ jobs:
         sandbox:
           - 'sandbox:none'
           - 'sandbox:docker'
-        # Benchmark one runner with three Vitest forks against the existing
-        # three-runner, one-fork-per-shard baseline.
+        # Keep three-way test concurrency inside one runner so each sandbox
+        # shares setup work instead of occupying three pool runners.
         shard:
           - '1/1'
         node-version:

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -34,7 +34,7 @@ describe('e2e workflow', () => {
     expect(group).toContain('github.head_ref || github.ref_name');
   });
 
-  it('benchmarks three Vitest forks on one Linux runner per sandbox', () => {
+  it('runs three Vitest forks on one Linux runner per sandbox', () => {
     const linuxJob = yml.jobs['e2e-test-linux'];
     const runStep = linuxJob.steps.find(
       (step) => step.name === 'Run E2E tests',

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -34,6 +34,18 @@ describe('e2e workflow', () => {
     expect(group).toContain('github.head_ref || github.ref_name');
   });
 
+  it('benchmarks three Vitest forks on one Linux runner per sandbox', () => {
+    const linuxJob = yml.jobs['e2e-test-linux'];
+    const runStep = linuxJob.steps.find(
+      (step) => step.name === 'Run E2E tests',
+    );
+
+    expect(linuxJob.strategy.matrix.shard).toEqual(['1/1']);
+    expect(runStep.run.match(/--poolOptions\.forks\.maxForks=3/g)).toHaveLength(
+      2,
+    );
+  });
+
   describe('sandbox image preparation', () => {
     const steps = yml.jobs['e2e-test-linux'].steps;
     const setupStep = steps.find((step) => step.name === 'Set up Docker');
@@ -193,7 +205,7 @@ describe('e2e workflow', () => {
       // shard and exclude coverage lives only in this argument list. The
       // excludes are shared verbatim with the docker leg above.
       expect(runStep.run).toContain(
-        "npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}'",
+        "npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}'",
       );
     });
 


### PR DESCRIPTION
## What this PR does

This replaces the three Linux E2E shards per sandbox with one job running the full suite with up to three Vitest forks. It keeps the same test-level concurrency while sharing setup work and reducing the Linux self-hosted runner requirement from six to two. The test set, sandbox matrix, macOS jobs, and OpenTUI job stay unchanged.

## Why it's needed

The existing static shards repeat job setup and can become imbalanced under shared-pool pressure. A paired run from the same source commit completed faster with fewer runner-minutes when concurrency moved inside Vitest.

| Metric | Three shards per sandbox | One job with three forks | Change |
| --- | ---: | ---: | ---: |
| Linux self-hosted runners | 6 | 2 | -67% |
| Linux critical path | 35m 09s | 19m 00s | -46% |
| Linux runner time | 139m 10s | 33m 49s | -76% |
| Full E2E workflow | 41m 40s | 24m 27s | -41% |

Both runs covered the same 76 files and 464 tests per sandbox.

## Reviewer Test Plan

### How to verify

Compare baseline run https://github.com/QwenLM/qwen-code/actions/runs/34094994389 with the updated run https://github.com/QwenLM/qwen-code/actions/runs/34101867981. Confirm that each sandbox runs one Linux job, each job covers all 76 files and 464 tests, and all E2E jobs pass.

### Evidence (Before & After)

Before: six Linux self-hosted runners, 35m 09s critical path, 139m 10s runner time. After: two Linux self-hosted runners, 19m critical path, 33m 49s runner time.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

The workflow structure test passes locally: 30/30. The full E2E workflow passes on GitHub Actions.

## Risk & Scope

- Main risk or tradeoff: three forks share CPU, memory, ports, and Docker resources inside one runner; the completed E2E run exercised both sandbox modes successfully.
- Not validated / out of scope: performance measurements come from one paired run on a noisy shared pool.
- Breaking changes / migration notes: none.

## Linked Issues

Built on QwenLM/qwen-code#11264.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

把每种 sandbox 的三个 Linux E2E shard 改为一个 job，并在完整测试集上最多运行三个 Vitest fork。测试级并发量保持不变，同时共享初始化工作，把 Linux self-hosted runner 需求从六个降为两个。测试集合、sandbox matrix、macOS job 和 OpenTUI job 均保持不变。

## 为什么需要

现有静态 shard 会重复执行 job 初始化，并且在共享 runner 池压力下可能出现负载不均。同一源码提交上的配对测试表明，把并发下沉到 Vitest 后，执行更快且 runner-minutes 更少。

| 指标 | 每种 sandbox 三个 shard | 一个 job、三个 fork | 变化 |
| --- | ---: | ---: | ---: |
| Linux self-hosted runner | 6 | 2 | -67% |
| Linux 关键路径 | 35分09秒 | 19分00秒 | -46% |
| Linux runner 时间 | 139分10秒 | 33分49秒 | -76% |
| 完整 E2E workflow | 41分40秒 | 24分27秒 | -41% |

两次运行中，每种 sandbox 均覆盖相同的 76 个文件和 464 个测试。

## Reviewer Test Plan

### 如何验证

对比基线 run https://github.com/QwenLM/qwen-code/actions/runs/34094994389 和修改后 run https://github.com/QwenLM/qwen-code/actions/runs/34101867981。确认每种 sandbox 只运行一个 Linux job、每个 job 覆盖全部 76 个文件和 464 个测试，并且所有 E2E job 通过。

### 证据（Before & After）

修改前：六个 Linux self-hosted runner，关键路径 35分09秒，runner 时间 139分10秒。修改后：两个 Linux self-hosted runner，关键路径 19分钟，runner 时间 33分49秒。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

workflow 结构测试在本地通过：30/30。完整 E2E workflow 在 GitHub Actions 上通过。

## 风险与范围

- 主要风险或取舍：三个 fork 会在单个 runner 内共享 CPU、内存、端口和 Docker 资源；已完成的 E2E run 成功覆盖两种 sandbox 模式。
- 未验证或超出范围：性能数据来自共享 runner 池上的一次配对运行。
- 破坏性变更或迁移说明：无。

## 关联事项

基于 QwenLM/qwen-code#11264。

</details>
