### PR TITLE
chore(release): bump node repl to 0.1.3

### DIFF
--- a/docs/users/features/computer-use.md
+++ b/docs/users/features/computer-use.md
@@ -25,7 +25,7 @@ Node.js 22 or later and npm are required.
 When first used, the skill runs these commands itself:
 
 ```bash
-qwen mcp add --scope user node-repl npx -y @qwen-code/node-repl-mcp@0.1.2
+qwen mcp add --scope user node-repl npx -y @qwen-code/node-repl-mcp@0.1.3
 npm install --no-save --package-lock=false @qwen-code/cua-sdk@0.20.4
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28920,7 +28920,7 @@
     },
     "packages/node-repl": {
       "name": "@qwen-code/node-repl-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/core/src/skills/bundled/computer-use/SKILL.md
+++ b/packages/core/src/skills/bundled/computer-use/SKILL.md
@@ -16,7 +16,7 @@ description: Control local desktop applications through Computer Use for tasks t
 If `node_repl` is unavailable, run:
 
 ```bash
-qwen mcp add --scope user node-repl npx -y @qwen-code/node-repl-mcp@0.1.2
+qwen mcp add --scope user node-repl npx -y @qwen-code/node-repl-mcp@0.1.3
 npm install --no-save --package-lock=false @qwen-code/cua-sdk@0.20.4
 ```
 

--- a/packages/node-repl/package.json
+++ b/packages/node-repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/node-repl-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Standalone MCP server exposing a session-persistent Node.js REPL (node_repl) — independent of qwen-code core.",
   "repository": {
     "type": "git",

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -79,7 +79,7 @@ const liveHostOssWorkflow = readFileSync(
 describe('CUA release workflow', () => {
   it('keeps the Node REPL package independently versioned', () => {
     expect(nodeReplPackage.name).toBe('@qwen-code/node-repl-mcp');
-    expect(nodeReplPackage.version).toBe('0.1.2');
+    expect(nodeReplPackage.version).toBe('0.1.3');
     expect(cuaReleaseWorkflow).toContain(
       "node_repl_version: '${{ steps.release.outputs.node_repl_version }}'",
     );


### PR DESCRIPTION
## What this PR does

Advances the independently versioned Node REPL MCP package from 0.1.2 to 0.1.3 and keeps the Computer Use bootstrap instructions and release-contract assertion on the same exact version.

## Why it's needed

The Node REPL runtime shipped from current `main` has changed since 0.1.2 was published. npm versions are immutable, so the CUA 0.20.4 production workflow correctly rejects the new tarball as different content under an existing version. Publishing it as 0.1.3 removes that release blocker without changing runtime behavior in this PR.

## Reviewer Test Plan

### How to verify

Run the standalone Node REPL build, typecheck, unit tests, and three smoke suites; all should pass under version 0.1.3. Run the package verifier and confirm it produces one clean-installable 0.1.3 tarball containing 26 files. Run the release-workflow contract test and confirm the package version and both Computer Use bootstrap pins agree.

### Evidence (Before & After)

N/A — release metadata and documentation only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.23.1 on macOS. Node REPL: 152/152 unit tests plus standalone, MCP-wire, and lifecycle smoke suites passed. Bundled Computer Use Skill: 6/6 tests passed. Release workflow contract: 48 passed, 1 expected skip. The package verifier completed publish dry-run and clean install for the 26-file 0.1.3 tarball.

## Risk & Scope

- Main risk or tradeoff: A stale version pin would make the production release fail or install the previous Node REPL package; the release-contract tests and package verifier cover both cases.
- Not validated / out of scope: This PR does not modify or revalidate the already-merged Node REPL runtime changes, and it does not itself run the production release.
- Breaking changes / migration notes: No API change. Computer Use bootstrap now installs `@qwen-code/node-repl-mcp@0.1.3`.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

将独立版本管理的 Node REPL MCP 包从 0.1.2 升级到 0.1.3，并让 Computer Use 引导安装指令和发布契约断言继续引用同一个精确版本。

## 为什么需要

当前 `main` 中发布的 Node REPL 运行时内容相较已发布的 0.1.2 发生了变化。npm 版本不可覆盖，因此 CUA 0.20.4 生产发布 workflow 会正确拒绝以既有版本发布不同 tarball。将其发布为 0.1.3 可以解除该发布阻塞，同时本 PR 不改变任何运行时行为。

## Reviewer 测试计划

### 验证方式

运行独立 Node REPL 的构建、类型检查、单元测试及三个 smoke 套件，预期均在 0.1.3 版本下通过。运行包验证器，确认生成唯一一个可干净安装的 0.1.3 tarball，且包含 26 个文件。运行 release workflow 契约测试，确认包版本以及两处 Computer Use 引导安装 pin 完全一致。

### 前后证据

N/A——仅涉及发布元数据和文档。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS，Node.js 22.23.1。Node REPL：152/152 单元测试以及 standalone、MCP wire、lifecycle smoke 均通过。内置 Computer Use Skill：6/6 测试通过。Release workflow 契约：48 passed、1 个预期 skip。包验证器完成了 26 文件的 0.1.3 tarball 的 publish dry-run 与干净安装。

## 风险与范围

- 主要风险或取舍：过期版本 pin 会使生产发布失败或安装旧 Node REPL 包；release 契约测试和包验证器覆盖了这两种情况。
- 未验证或范围外：本 PR 不修改也不重新验证已合并的 Node REPL 运行时改动，并且不会自行执行生产发布。
- Breaking change / 迁移说明：没有 API 变化。Computer Use bootstrap 现在安装 `@qwen-code/node-repl-mcp@0.1.3`。

## 关联 Issue

N/A。

</details>
