### PR TITLE
fix(core): keep branch commits made by a failing post-checkout hook

### DIFF
--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -599,6 +599,29 @@ describe('gitCreateBranch rollback (R12)', () => {
     const branches = git(dir, 'branch', '--format=%(refname:short)');
     expect(branches.split('\n').map((s) => s.trim())).not.toContain('topic');
   });
+
+  it('keeps a branch that a failing post-checkout hook committed to', async () => {
+    const dir = makeRepo();
+    const before = currentBranch(dir);
+    const hookDir = path.join(dir, '.git', 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, 'post-checkout'),
+      '#!/bin/sh\necho hook-change >> file.txt\ngit add file.txt\ngit commit --no-verify -qm "hook-created commit"\nexit 1\n',
+      { mode: 0o755 },
+    );
+
+    await expect(gitCreateBranch(dir, 'topic')).rejects.toThrow();
+
+    // HEAD is restored, but the branch is kept because the hook created a
+    // commit on it — force-deleting would discard that commit.
+    expect(currentBranch(dir)).toBe(before);
+    const branches = git(dir, 'branch', '--format=%(refname:short)');
+    expect(branches.split('\n').map((s) => s.trim())).toContain('topic');
+    // The hook-created commit is still reachable from the branch.
+    const topicLog = git(dir, 'log', '--oneline', 'topic');
+    expect(topicLog).toContain('hook-created commit');
+  });
 });
 
 describe('gitPush', () => {

--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -8,7 +8,20 @@ import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDebugLogger = vi.hoisted(() => ({
+  isEnabled: vi.fn(() => true),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('./debugLogger.js', () => ({
+  createDebugLogger: () => mockDebugLogger,
+}));
+
 import {
   fetchGitBranches,
   gitCheckout,
@@ -36,6 +49,7 @@ function makeRepo(): string {
   git(dir, 'config', 'user.email', 'test@example.com');
   git(dir, 'config', 'user.name', 'Test');
   git(dir, 'config', 'commit.gpgsign', 'false');
+  git(dir, 'config', 'tag.gpgsign', 'false');
   git(dir, 'config', 'core.hooksPath', path.join(dir, '.git', 'hooks'));
   fs.writeFileSync(path.join(dir, 'a.txt'), 'one\n');
   git(dir, 'add', '.');
@@ -579,6 +593,10 @@ describe('gitCreateBranch', () => {
 });
 
 describe('gitCreateBranch rollback (R12)', () => {
+  beforeEach(() => {
+    mockDebugLogger.warn.mockClear();
+  });
+
   it('rolls back a branch created before a failing post-checkout hook', async () => {
     const dir = makeRepo();
     const before = currentBranch(dir);
@@ -598,6 +616,9 @@ describe('gitCreateBranch rollback (R12)', () => {
     expect(currentBranch(dir)).toBe(before);
     const branches = git(dir, 'branch', '--format=%(refname:short)');
     expect(branches.split('\n').map((s) => s.trim())).not.toContain('topic');
+    expect(mockDebugLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('keeping branch "topic"'),
+    );
   });
 
   it('rolls back a branch created from an annotated tag before a failing post-checkout hook', async () => {
@@ -623,6 +644,9 @@ describe('gitCreateBranch rollback (R12)', () => {
     expect(currentBranch(dir)).toBe(before);
     const branches = git(dir, 'branch', '--format=%(refname:short)');
     expect(branches.split('\n').map((s) => s.trim())).not.toContain('topic');
+    expect(mockDebugLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('keeping branch "topic"'),
+    );
   });
 
   it('keeps a branch that a failing post-checkout hook committed to', async () => {
@@ -646,6 +670,9 @@ describe('gitCreateBranch rollback (R12)', () => {
     // The hook-created commit is still reachable from the branch.
     const topicLog = git(dir, 'log', '--oneline', 'topic');
     expect(topicLog).toContain('hook-created commit');
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('keeping branch "topic"'),
+    );
   });
 
   it('keeps hook commits when an empty start point defaults to HEAD', async () => {
@@ -666,7 +693,41 @@ describe('gitCreateBranch rollback (R12)', () => {
     expect(branches.split('\n').map((s) => s.trim())).toContain('topic');
     const topicLog = git(dir, 'log', '--oneline', 'topic');
     expect(topicLog).toContain('hook-created commit');
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('keeping branch "topic"'),
+    );
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps hook commits when resolving the start commit fails',
+    async () => {
+      const dir = makeRepo();
+      const before = currentBranch(dir);
+      const hookDir = path.join(dir, '.git', 'hooks');
+      fs.mkdirSync(hookDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(hookDir, 'post-checkout'),
+        '#!/bin/sh\necho hook-change >> file.txt\ngit add file.txt\ngit commit --no-verify -qm "hook-created commit"\nexit 1\n',
+        { mode: 0o755 },
+      );
+      const env = gitShim(hermeticEnv(), [
+        { match: '"rev-parse --verify "*', script: 'exit 128' },
+      ]);
+
+      await expect(
+        gitCreateBranch(dir, 'topic', undefined, env),
+      ).rejects.toThrow();
+
+      expect(currentBranch(dir)).toBe(before);
+      const branches = git(dir, 'branch', '--format=%(refname:short)');
+      expect(branches.split('\n').map((s) => s.trim())).toContain('topic');
+      const topicLog = git(dir, 'log', '--oneline', 'topic');
+      expect(topicLog).toContain('hook-created commit');
+      expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('keeping branch "topic"'),
+      );
+    },
+  );
 });
 
 describe('gitPush', () => {

--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -604,6 +604,9 @@ describe('gitCreateBranch rollback (R12)', () => {
     const dir = makeRepo();
     const before = currentBranch(dir);
     git(dir, 'tag', '-a', 'v1.0', '-m', 'annotated start');
+    fs.writeFileSync(path.join(dir, 'b.txt'), 'two\n');
+    git(dir, 'add', '.');
+    git(dir, 'commit', '-q', '-m', 'second');
     expect(git(dir, 'cat-file', '-t', 'v1.0').trim()).toBe('tag');
     const hookDir = path.join(dir, '.git', 'hooks');
     fs.mkdirSync(hookDir, { recursive: true });
@@ -641,6 +644,26 @@ describe('gitCreateBranch rollback (R12)', () => {
     const branches = git(dir, 'branch', '--format=%(refname:short)');
     expect(branches.split('\n').map((s) => s.trim())).toContain('topic');
     // The hook-created commit is still reachable from the branch.
+    const topicLog = git(dir, 'log', '--oneline', 'topic');
+    expect(topicLog).toContain('hook-created commit');
+  });
+
+  it('keeps hook commits when an empty start point defaults to HEAD', async () => {
+    const dir = makeRepo();
+    const before = currentBranch(dir);
+    const hookDir = path.join(dir, '.git', 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, 'post-checkout'),
+      '#!/bin/sh\necho hook-change >> file.txt\ngit add file.txt\ngit commit --no-verify -qm "hook-created commit"\nexit 1\n',
+      { mode: 0o755 },
+    );
+
+    await expect(gitCreateBranch(dir, 'topic', '')).rejects.toThrow();
+
+    expect(currentBranch(dir)).toBe(before);
+    const branches = git(dir, 'branch', '--format=%(refname:short)');
+    expect(branches.split('\n').map((s) => s.trim())).toContain('topic');
     const topicLog = git(dir, 'log', '--oneline', 'topic');
     expect(topicLog).toContain('hook-created commit');
   });

--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -600,6 +600,28 @@ describe('gitCreateBranch rollback (R12)', () => {
     expect(branches.split('\n').map((s) => s.trim())).not.toContain('topic');
   });
 
+  it('rolls back a branch created from an annotated tag before a failing post-checkout hook', async () => {
+    const dir = makeRepo();
+    const before = currentBranch(dir);
+    git(dir, 'tag', '-a', 'v1.0', '-m', 'annotated start');
+    expect(git(dir, 'cat-file', '-t', 'v1.0').trim()).toBe('tag');
+    const hookDir = path.join(dir, '.git', 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, 'post-checkout'),
+      '#!/bin/sh\nexit 1\n',
+      {
+        mode: 0o755,
+      },
+    );
+
+    await expect(gitCreateBranch(dir, 'topic', 'v1.0')).rejects.toThrow();
+
+    expect(currentBranch(dir)).toBe(before);
+    const branches = git(dir, 'branch', '--format=%(refname:short)');
+    expect(branches.split('\n').map((s) => s.trim())).not.toContain('topic');
+  });
+
   it('keeps a branch that a failing post-checkout hook committed to', async () => {
     const dir = makeRepo();
     const before = currentBranch(dir);

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -445,7 +445,7 @@ export async function gitCreateBranch(
   const startCommit = (
     await runGit(
       cwd,
-      ['rev-parse', '--verify', `${startPoint ?? 'HEAD'}^{commit}`],
+      ['rev-parse', '--verify', `${startPoint || 'HEAD'}^{commit}`],
       env,
     ).catch(() => '')
   ).trim();

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -478,7 +478,7 @@ export async function gitCreateBranch(
           () => '',
         )
       ).trim();
-      if (newHead && startCommit && newHead !== startCommit) {
+      if (newHead && newHead !== startCommit) {
         debugLogger.warn(
           `gitCreateBranch: keeping branch "${name}" because it contains commits created after checkout (likely by a failing post-checkout hook)`,
         );

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -443,7 +443,11 @@ export async function gitCreateBranch(
   // otherwise the current HEAD. Used on rollback to detect commits a failing
   // post-checkout hook may have created on the new branch.
   const startCommit = (
-    await runGit(cwd, ['rev-parse', startPoint ?? 'HEAD'], env).catch(() => '')
+    await runGit(
+      cwd,
+      ['rev-parse', '--verify', `${startPoint ?? 'HEAD'}^{commit}`],
+      env,
+    ).catch(() => '')
   ).trim();
   try {
     await runGit(cwd, args, env);
@@ -470,7 +474,9 @@ export async function gitCreateBranch(
       // those commits, so keep the branch when its HEAD has moved past the
       // start commit instead of force-deleting it.
       const newHead = (
-        await runGit(cwd, ['rev-parse', name], env).catch(() => '')
+        await runGit(cwd, ['rev-parse', `refs/heads/${name}`], env).catch(
+          () => '',
+        )
       ).trim();
       if (newHead && startCommit && newHead !== startCommit) {
         debugLogger.warn(

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -9,6 +9,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import { isValidGitSha, isValidRefName } from './gitDirect.js';
+import { createDebugLogger } from './debugLogger.js';
+
+const debugLogger = createDebugLogger('GIT_BRANCHES');
 
 const execFileAsync = promisify(execFile);
 
@@ -436,6 +439,12 @@ export async function gitCreateBranch(
   const originalCommit = originalRef
     ? ''
     : (await runGit(cwd, ['rev-parse', 'HEAD'], env).catch(() => '')).trim();
+  // The commit the new branch starts from: the resolved startPoint when given,
+  // otherwise the current HEAD. Used on rollback to detect commits a failing
+  // post-checkout hook may have created on the new branch.
+  const startCommit = (
+    await runGit(cwd, ['rev-parse', startPoint ?? 'HEAD'], env).catch(() => '')
+  ).trim();
   try {
     await runGit(cwd, args, env);
   } catch (err) {
@@ -456,7 +465,20 @@ export async function gitCreateBranch(
           env,
         ).catch(() => {});
       }
-      await runGit(cwd, ['branch', '-D', name], env).catch(() => {});
+      // A failing post-checkout hook may have created commits on the new
+      // branch (the ref points at them). Deleting the branch would discard
+      // those commits, so keep the branch when its HEAD has moved past the
+      // start commit instead of force-deleting it.
+      const newHead = (
+        await runGit(cwd, ['rev-parse', name], env).catch(() => '')
+      ).trim();
+      if (newHead && startCommit && newHead !== startCommit) {
+        debugLogger.warn(
+          `gitCreateBranch: keeping branch "${name}" because it contains commits created after checkout (likely by a failing post-checkout hook)`,
+        );
+      } else {
+        await runGit(cwd, ['branch', '-D', name], env).catch(() => {});
+      }
     }
     throw err;
   }


### PR DESCRIPTION
## What this PR does

Fixes a data-loss path in branch creation rollback. `gitCreateBranch` treats any non-zero `git checkout -b` result as a half-created branch and unconditionally runs `git branch -D <name>` during rollback. But `git checkout -b` creates the ref and switches HEAD before running the `post-checkout` hook, so a failing hook leaves the workspace already on the new branch — and if that hook created a commit there, the force-delete discards it (`git fsck --unreachable` then reports the commit as unreachable from any ref).

On rollback, the new branch's HEAD is now compared against the start commit (the resolved `startPoint`, or the pre-checkout `HEAD`). The branch is only force-deleted when its HEAD has not moved; when a failing hook has moved it (created commits), the branch is kept and a `debugLogger.warn` is emitted instead.

## Why it's needed

A failing `post-checkout` hook currently causes `gitCreateBranch` to delete a branch that may already carry hook-created commits, silently losing that work. Raw `git checkout -b <name> --` with the same failing hook leaves the branch checked out and keeps the commit, so the rollback was stricter than git itself.

## Reviewer Test Plan

### How to verify

Install a `post-checkout` hook that commits then exits non-zero, then call `gitCreateBranch(repo, 'topic')`:

- Before: the call rejects, HEAD is restored, and `topic` is force-deleted — the hook-created commit becomes unreachable.
- After: the call still rejects and HEAD is restored, but `topic` is kept because it carries the hook-created commit, which stays reachable from the branch.

Covered by `packages/core/src/utils/git-branches.test.ts`: the new `keeps a branch that a failing post-checkout hook committed to` fails before this change and passes after; the existing `rolls back a branch created before a failing post-checkout hook` (hook makes no commit) still passes, confirming the no-commit path is unchanged.

### Evidence (Before & After)

N/A (core git utility; unit tests above). Verified locally on Windows with the minimal hook from the issue: `git checkout -b topic --` exits `1` with the branch already created and pointing at the hook-created commit, and the old rollback deleted it (`git fsck --unreachable` confirmed the commit was orphaned).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

N/A — unit tests only (`npx vitest run src/utils/git-branches.test.ts`).

## Risk & Scope

- Main risk or tradeoff: a kept branch whose hook failed remains in the branch list; callers that assume a thrown error means "no branch exists" would now see it. The branch picker listing is not re-read after a failed create.
- Not validated / out of scope: the rollback's restore-checkout re-runs the failing hook against the original branch (pre-existing behavior); the kept-branch signal is not surfaced to callers beyond the log warning.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11253

<details>
<summary>中文说明</summary>

本 PR 修复分支创建回滚中的一处数据丢失。`gitCreateBranch` 把任何非零的 `git checkout -b` 结果都当作"半创建分支"，回滚时无条件执行 `git branch -D`。但 `git checkout -b` 会先创建 ref 并切换 HEAD、再运行 `post-checkout` 钩子，所以钩子失败时工作区其实已在新分支上——若钩子已在新分支上创建了提交，强制删除会丢弃该提交（`git fsck --unreachable` 会显示它不再可从任何引用到达）。

修复后，回滚时比较新分支的 HEAD 与起点 commit（解析后的 `startPoint`，或 checkout 前的 `HEAD`）：仅当 HEAD 未移动时才强制删除分支；若失败的钩子已移动它（创建了提交），则保留分支并通过 `debugLogger.warn` 记录，而不是丢弃这些工作。

之所以需要：当前失败的 `post-checkout` 钩子会让 `gitCreateBranch` 删掉一个可能已带钩子提交的分支，静默丢失工作。原生 `git checkout -b <name> --` 在同样的钩子失败下会保留分支和提交，因此原回滚比 git 本身更激进。

验证方式：安装一个"先提交再以非零退出"的 `post-checkout` 钩子，然后调用 `gitCreateBranch(repo, 'topic')`。修复前：调用拒绝、HEAD 恢复、`topic` 被强删、钩子提交变为不可达；修复后：调用仍拒绝、HEAD 恢复，但 `topic` 因携带钩子提交而被保留、提交仍可达。新增测试 `keeps a branch that a failing post-checkout hook committed to` 修复前失败、修复后通过；既有测试（钩子不产生提交时删除分支）前后均通过。已在 Windows 上用 issue 中的最小钩子实测复现。

</details>
