### PR TITLE
ci: forward-port Linux E2E Vitest forks to main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,13 +127,10 @@ jobs:
         sandbox:
           - 'sandbox:none'
           - 'sandbox:docker'
-        # The suite is ~16min of wall clock on one runner, dominated by a long
-        # tail of sdk-typescript files. vitest assigns files to shards by path
-        # hash, so those spread out instead of clustering in one shard.
+        # Keep three-way test concurrency inside one runner so each sandbox
+        # shares setup work instead of occupying three pool runners.
         shard:
-          - '1/3'
-          - '2/3'
-          - '3/3'
+          - '1/1'
         node-version:
           - '22.x'
     steps:
@@ -362,10 +359,10 @@ jobs:
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}' 9>&-
+            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}' 9>&-
           else
             run_shard() {
-              QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}'
+              QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}'
             }
             # One bounded retry: pool runners' sandbox:none shards die under
             # shared-host pressure with every test green and no vitest FAIL

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -34,6 +34,18 @@ describe('e2e workflow', () => {
     expect(group).toContain('github.head_ref || github.ref_name');
   });
 
+  it('runs three Vitest forks on one Linux runner per sandbox', () => {
+    const linuxJob = yml.jobs['e2e-test-linux'];
+    const runStep = linuxJob.steps.find(
+      (step) => step.name === 'Run E2E tests',
+    );
+
+    expect(linuxJob.strategy.matrix.shard).toEqual(['1/1']);
+    expect(runStep.run.match(/--poolOptions\.forks\.maxForks=3/g)).toHaveLength(
+      2,
+    );
+  });
+
   describe('sandbox image preparation', () => {
     const steps = yml.jobs['e2e-test-linux'].steps;
     const setupStep = steps.find((step) => step.name === 'Set up Docker');
@@ -193,7 +205,7 @@ describe('e2e workflow', () => {
       // shard and exclude coverage lives only in this argument list. The
       // excludes are shared verbatim with the docker leg above.
       expect(runStep.run).toContain(
-        "npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --shard='${{ matrix.shard }}'",
+        "npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/chat-transcript-document.test.ts' --poolOptions.forks.maxForks=3 --shard='${{ matrix.shard }}'",
       );
     });
 


### PR DESCRIPTION
## What this PR does

Forward-ports #11290 onto `main`. That PR was merged after its stacked base, #11264, had already landed, so GitHub merged it into the old stack branch instead of `main`.

The behavior is unchanged from #11290: each Linux sandbox now runs the full E2E suite in one job with up to three Vitest forks, replacing three statically sharded jobs while keeping the same test-level concurrency.

## Why it's needed

`main` still runs the `1/3`, `2/3`, and `3/3` Linux shards, so the runner reduction validated in #11290 never landed. This PR carries only that already-reviewed two-file patch; its stable patch ID matches the squash commit produced by #11290.

## Reviewer Test Plan

### How to verify

Confirm that each sandbox creates one Linux job, both sandbox modes pass `--poolOptions.forks.maxForks=3`, and the E2E workflow remains green. The original full Linux run for the same patch passed in #11290.

### Evidence (Before & After)

N/A — CI-only change with no user-interface impact.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Focused workflow tests: 30 passed. ESLint, Prettier, actionlint, repository build, and typecheck passed. The same patch completed the full Linux E2E workflow in #11290.

## Risk & Scope

- Main risk or tradeoff: three forks share CPU, memory, ports, and Docker resources inside one runner; the original full E2E run exercised both sandbox modes successfully.
- Not validated / out of scope: performance measurements are unchanged from #11290 and still come from a noisy shared runner pool.
- Breaking changes / migration notes: none.

## Linked Issues

Forward-port of #11290 after #11264 landed.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

将 #11290 的改动补到 `main`。该 PR 在其堆叠基础 #11264 已经合入后才被点击合并，因此 GitHub 将它合进了旧的 stack 分支，而不是 `main`。

行为与 #11290 保持一致：每种 Linux sandbox 使用一个 job 运行完整 E2E 测试集，并最多启用三个 Vitest fork，以替代三个静态 shard，同时保持相同的测试级并发量。

## 为什么需要

`main` 仍在运行 `1/3`、`2/3` 和 `3/3` 三个 Linux shard，因此 #11290 已验证的 runner 缩减并未真正落地。本 PR 只携带已经 review 过的两文件补丁，其 stable patch ID 与 #11290 生成的 squash commit 一致。

## Reviewer 测试计划

### 如何验证

确认每种 sandbox 只创建一个 Linux job，两种 sandbox 模式都传递 `--poolOptions.forks.maxForks=3`，并且 E2E workflow 保持全绿。同一补丁已经在 #11290 的完整 Linux 运行中通过。

### 证据（修改前后）

不适用——这是仅影响 CI 的改动，没有用户界面变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

定向 workflow 测试 30 个通过。ESLint、Prettier、actionlint、仓库 build 和 typecheck 均通过。同一补丁已在 #11290 中完成完整 Linux E2E workflow。

## 风险与范围

- 主要风险或取舍：三个 fork 会在一个 runner 内共享 CPU、内存、端口和 Docker 资源；原完整 E2E 运行已成功覆盖两种 sandbox 模式。
- 未验证 / 范围外：性能数据与 #11290 相同，仍来自有噪声的共享 runner 池。
- 破坏性变更 / 迁移说明：无。

## 关联事项

在 #11264 落地后补入 #11290。

</details>
