### PR TITLE
fix(channels): restore worktree-task routes through the managed load path

### DIFF
--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -2634,6 +2634,51 @@ describe('SessionRouter', () => {
       });
     });
 
+    it('releases the binding when a managed restore is invalidated mid-load', async () => {
+      const { persistPath } = setup();
+      let finishLoad!: (sessionId: string) => void;
+      let bindingToken: object | undefined;
+      let released = false;
+      bridge = {
+        ...mockBridge(),
+        listSessions: vi
+          .fn()
+          .mockReturnValue([worktreeAttestation('worktree-session')]),
+        loadSession: vi.fn(
+          (
+            _sessionId: string,
+            _cwd: string,
+            _options: unknown,
+            token?: object,
+          ) =>
+            new Promise<string>((resolve) => {
+              bindingToken = token;
+              finishLoad = resolve;
+            }),
+        ),
+        // Token-guarded like the real bridges: a mismatched expected
+        // token releases nothing, so this stays green only when the
+        // invalidation cleanup discards without a token.
+        discardSession: vi.fn(async (_sessionId: string, expected?: object) => {
+          if (expected !== undefined && expected !== bindingToken) return;
+          released = true;
+        }),
+      } satisfies ChannelAgentBridge;
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      const restore = router.restoreSessions();
+      await Promise.resolve();
+      router.removeSession('ch', 'alice', 'chat1');
+      finishLoad('worktree-session');
+
+      await expect(restore).resolves.toEqual({ restored: 0, failed: 1 });
+      expect(bridge.discardSession).toHaveBeenCalledWith('worktree-session');
+      expect(released).toBe(true);
+      expect(router.isSessionLive('worktree-session')).toBe(false);
+      expect(router.getTarget('worktree-session')).toBeUndefined();
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
+    });
+
     it('routes the replacement when the restored session was superseded', async () => {
       const { persistPath } = setup();
       bridge = {

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -2750,6 +2750,23 @@ describe('SessionRouter', () => {
       expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
     });
 
+    it('clears restore metadata when the session is removed by id', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));
+      tempDirs.push(dir);
+      const persistPath = join(dir, 'sessions.json');
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      router.activateManagedSession(
+        'worktree-session',
+        target,
+        '/tmp/worktree-task',
+        { isolation: 'worktree', workspaceCwd: '/tmp' },
+      );
+      expect(router.removeSessionId('worktree-session')).toBe(true);
+
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
+    });
+
     it('requires a workspace cwd for worktree managed sessions', () => {
       const router = new SessionRouter(bridge, '/tmp', 'user');
 

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -2725,6 +2725,81 @@ describe('SessionRouter', () => {
       });
     });
 
+    it('persists a superseded redirect before any later route change', async () => {
+      const { persistPath } = setup();
+      bridge = {
+        ...mockBridge(),
+        listSessions: vi
+          .fn()
+          .mockReturnValue([worktreeAttestation('replacement-session')]),
+        loadSession: vi.fn(async (sessionId: string) => {
+          if (sessionId === 'worktree-session') {
+            throw daemonHttpError('worktree_session_superseded', {
+              replacementSessionId: 'replacement-session',
+            });
+          }
+          return sessionId;
+        }),
+      } satisfies ChannelAgentBridge;
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      await expect(router.restoreSessions()).resolves.toEqual({
+        restored: 1,
+        failed: 0,
+      });
+
+      // Read the file before any later activation rewrites it: the
+      // redirect must already be durable.
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({
+        'ch:alice:chat1': {
+          sessionId: 'replacement-session',
+          target,
+          cwd: '/tmp/worktree-task',
+          isolation: 'worktree',
+          workspaceCwd: '/tmp',
+        },
+      });
+    });
+
+    it('migrates a metadata-free route on the next managed activation', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));
+      tempDirs.push(dir);
+      const persistPath = join(dir, 'sessions.json');
+      // Pre-PR shape: a worktree-task route persisted without metadata.
+      writeFileSync(
+        persistPath,
+        JSON.stringify({
+          'ch:alice:chat1': {
+            sessionId: 'worktree-session',
+            target,
+            cwd: '/tmp/worktree-task',
+          },
+        }),
+      );
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath, {
+        recoveryMode: 'lazy',
+      });
+      expect(router.restoreRoutes()).toEqual({ restored: 1, dropped: 0 });
+
+      // Same key, same session, first activation carrying metadata.
+      router.activateManagedSession(
+        'worktree-session',
+        target,
+        '/tmp/worktree-task',
+        { isolation: 'worktree', workspaceCwd: '/tmp' },
+      );
+
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({
+        'ch:alice:chat1': {
+          sessionId: 'worktree-session',
+          target,
+          cwd: '/tmp/worktree-task',
+          isolation: 'worktree',
+          workspaceCwd: '/tmp',
+        },
+      });
+    });
+
     it('drops a worktree route whose managed restore fails attestation', async () => {
       const { persistPath } = setup();
       bridge = {

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -2538,6 +2538,256 @@ describe('SessionRouter', () => {
     });
   });
 
+  describe('restoreSessions with managed worktree routes', () => {
+    const target = {
+      channelName: 'ch',
+      senderId: 'alice',
+      chatId: 'chat1',
+    };
+
+    function writeWorktreeRoute(persistPath: string): void {
+      writeFileSync(
+        persistPath,
+        JSON.stringify({
+          'ch:alice:chat1': {
+            sessionId: 'worktree-session',
+            target,
+            cwd: '/tmp/worktree-task',
+            isolation: 'worktree',
+            workspaceCwd: '/tmp',
+          },
+        }),
+      );
+    }
+
+    function worktreeAttestation(sessionId: string) {
+      return {
+        sessionId,
+        workspaceCwd: '/tmp',
+        hasActivePrompt: false,
+        worktree: {
+          slug: 'task',
+          path: '/tmp/worktree-task',
+          branch: 'task',
+        },
+        worktreeState: 'persisted-v1' as const,
+      };
+    }
+
+    function setup(): { persistPath: string } {
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));
+      tempDirs.push(dir);
+      const persistPath = join(dir, 'sessions.json');
+      writeWorktreeRoute(persistPath);
+      return { persistPath };
+    }
+
+    it('restores a worktree route through the managed load path', async () => {
+      const { persistPath } = setup();
+      bridge = {
+        ...mockBridge(),
+        listSessions: vi
+          .fn()
+          .mockReturnValue([worktreeAttestation('worktree-session')]),
+      } satisfies ChannelAgentBridge;
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      await expect(router.restoreSessions()).resolves.toEqual({
+        restored: 1,
+        failed: 0,
+      });
+
+      // The managed path loads by workspace root; the persisted worktree
+      // cwd never reaches the daemon as a workspace.
+      expect(bridge.loadSession).toHaveBeenCalledWith(
+        'worktree-session',
+        '/tmp',
+        { sourceId: 'ch' },
+        expect.any(Object),
+      );
+      expect(router.getSession('ch', 'alice', 'chat1')).toBe(
+        'worktree-session',
+      );
+      expect(router.getSessionCwd('worktree-session')).toBe(
+        '/tmp/worktree-task',
+      );
+
+      // A later persist keeps the restore metadata on the route.
+      router.activateManagedSession(
+        'other-session',
+        { channelName: 'ch', senderId: 'bob', chatId: 'chat2' },
+        '/tmp',
+      );
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({
+        'ch:alice:chat1': {
+          sessionId: 'worktree-session',
+          target,
+          cwd: '/tmp/worktree-task',
+          isolation: 'worktree',
+          workspaceCwd: '/tmp',
+        },
+        'ch:bob:chat2': {
+          sessionId: 'other-session',
+          target: { channelName: 'ch', senderId: 'bob', chatId: 'chat2' },
+          cwd: '/tmp',
+        },
+      });
+    });
+
+    it('routes the replacement when the restored session was superseded', async () => {
+      const { persistPath } = setup();
+      bridge = {
+        ...mockBridge(),
+        listSessions: vi
+          .fn()
+          .mockReturnValue([worktreeAttestation('replacement-session')]),
+        loadSession: vi.fn(async (sessionId: string) => {
+          if (sessionId === 'worktree-session') {
+            throw daemonHttpError('worktree_session_superseded', {
+              replacementSessionId: 'replacement-session',
+            });
+          }
+          return sessionId;
+        }),
+      } satisfies ChannelAgentBridge;
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      await expect(router.restoreSessions()).resolves.toEqual({
+        restored: 1,
+        failed: 0,
+      });
+
+      expect(router.getSession('ch', 'alice', 'chat1')).toBe(
+        'replacement-session',
+      );
+      expect(router.getSessionCwd('replacement-session')).toBe(
+        '/tmp/worktree-task',
+      );
+
+      // The replacement inherits the route's restore metadata.
+      router.activateManagedSession(
+        'other-session',
+        { channelName: 'ch', senderId: 'bob', chatId: 'chat2' },
+        '/tmp',
+      );
+      const data = JSON.parse(readFileSync(persistPath, 'utf-8'));
+      expect(data['ch:alice:chat1']).toEqual({
+        sessionId: 'replacement-session',
+        target,
+        cwd: '/tmp/worktree-task',
+        isolation: 'worktree',
+        workspaceCwd: '/tmp',
+      });
+    });
+
+    it('drops a worktree route whose managed restore fails attestation', async () => {
+      const { persistPath } = setup();
+      bridge = {
+        ...mockBridge(),
+        listSessions: vi.fn().mockReturnValue([]),
+      } satisfies ChannelAgentBridge;
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      await expect(router.restoreSessions()).resolves.toEqual({
+        restored: 0,
+        failed: 1,
+      });
+
+      expect(router.getSession('ch', 'alice', 'chat1')).toBeUndefined();
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
+    });
+
+    it('drops a worktree entry missing its workspace cwd as malformed', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));
+      tempDirs.push(dir);
+      const persistPath = join(dir, 'sessions.json');
+      writeFileSync(
+        persistPath,
+        JSON.stringify({
+          'ch:alice:chat1': {
+            sessionId: 'worktree-session',
+            target,
+            cwd: '/tmp/worktree-task',
+            isolation: 'worktree',
+          },
+        }),
+      );
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      await expect(router.restoreSessions()).resolves.toEqual({
+        restored: 0,
+        failed: 0,
+      });
+
+      expect(bridge.loadSession).not.toHaveBeenCalled();
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
+    });
+
+    it('persists worktree restore metadata with the route', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));
+      tempDirs.push(dir);
+      const persistPath = join(dir, 'sessions.json');
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath);
+
+      router.activateManagedSession(
+        'worktree-session',
+        target,
+        '/tmp/worktree-task',
+        { isolation: 'worktree', workspaceCwd: '/tmp' },
+      );
+
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({
+        'ch:alice:chat1': {
+          sessionId: 'worktree-session',
+          target,
+          cwd: '/tmp/worktree-task',
+          isolation: 'worktree',
+          workspaceCwd: '/tmp',
+        },
+      });
+
+      router.forgetManagedSession('worktree-session');
+      expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({});
+    });
+
+    it('requires a workspace cwd for worktree managed sessions', () => {
+      const router = new SessionRouter(bridge, '/tmp', 'user');
+
+      expect(() =>
+        router.activateManagedSession(
+          'worktree-session',
+          target,
+          '/tmp/worktree-task',
+          { isolation: 'worktree', workspaceCwd: '' },
+        ),
+      ).toThrow('workspace cwd');
+    });
+
+    it('rehydrates worktree metadata in lazy route restore', () => {
+      const { persistPath } = setup();
+      const router = new SessionRouter(bridge, '/tmp', 'user', persistPath, {
+        recoveryMode: 'lazy',
+      });
+
+      expect(router.restoreRoutes()).toEqual({ restored: 1, dropped: 0 });
+
+      // A later persist keeps the rehydrated metadata on the route.
+      router.activateManagedSession(
+        'other-session',
+        { channelName: 'ch', senderId: 'bob', chatId: 'chat2' },
+        '/tmp',
+      );
+      const data = JSON.parse(readFileSync(persistPath, 'utf-8'));
+      expect(data['ch:alice:chat1']).toEqual({
+        sessionId: 'worktree-session',
+        target,
+        cwd: '/tmp/worktree-task',
+        isolation: 'worktree',
+        workspaceCwd: '/tmp',
+      });
+    });
+  });
+
   describe('persistence safety', () => {
     it('quarantines invalid JSON and starts with no routes', () => {
       const dir = mkdtempSync(join(tmpdir(), 'qwen-router-'));

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -22,6 +22,11 @@ interface PersistedEntry {
   sessionId: string;
   target: SessionTarget;
   cwd: string;
+  // Present only for managed worktree routes: the generic restore cannot
+  // resolve a worktree cwd to its workspace, so cold-start restore must
+  // re-attach these through the managed load path with the workspace root.
+  isolation?: 'worktree';
+  workspaceCwd?: string;
 }
 
 interface SessionReservation {
@@ -115,6 +120,10 @@ export class SessionRouter {
   private toSession: Map<string, string> = new Map(); // routing key → session ID
   private toTarget: Map<string, SessionTarget> = new Map(); // session ID → target
   private toCwd: Map<string, string> = new Map(); // session ID → cwd
+  private toManagedMeta: Map<
+    string,
+    { isolation: 'worktree'; workspaceCwd: string }
+  > = new Map();
   private creatingSessions: Map<string, SessionOperation> = new Map();
   private sessionLoadWindows: Set<SessionLoadWindow> = new Set();
   private readonly liveSessionIds = new Set<string>();
@@ -690,6 +699,14 @@ export class SessionRouter {
     }
     changed = this.toTarget.delete(oldSessionId) || changed;
     changed = this.toCwd.delete(oldSessionId) || changed;
+    const managedMeta = this.toManagedMeta.get(oldSessionId);
+    if (managedMeta !== undefined) {
+      // The replacement owns the same worktree, so the route's restore
+      // metadata follows it.
+      this.toManagedMeta.set(newSessionId, managedMeta);
+      this.toManagedMeta.delete(oldSessionId);
+      changed = true;
+    }
     this.liveSessionIds.delete(oldSessionId);
     this.staleBridgeBindings.delete(oldSessionId);
     if (changed) this.persist();
@@ -817,14 +834,34 @@ export class SessionRouter {
     sessionId: string,
     target: SessionTarget,
     cwd: string,
+    managed?: { isolation: ManagedSessionIsolation; workspaceCwd: string },
   ): void {
+    if (managed?.isolation === 'worktree' && !managed.workspaceCwd) {
+      throw new Error('A worktree managed session requires its workspace cwd.');
+    }
+    const previousMeta = this.toManagedMeta.get(sessionId);
+    if (managed?.isolation === 'worktree') {
+      this.toManagedMeta.set(sessionId, {
+        isolation: 'worktree',
+        workspaceCwd: managed.workspaceCwd,
+      });
+    } else {
+      this.toManagedMeta.delete(sessionId);
+    }
+    const metaChanged =
+      managed?.isolation === 'worktree'
+        ? previousMeta?.workspaceCwd !== managed.workspaceCwd
+        : previousMeta !== undefined;
     const key = this.routingKey(
       target.channelName,
       target.senderId,
       target.chatId,
       target.threadId,
     );
-    if (this.toSession.get(key) === sessionId) return;
+    if (this.toSession.get(key) === sessionId) {
+      if (metaChanged) this.persist();
+      return;
+    }
     this.invalidateRouteOperation(key);
     this.toSession.set(key, sessionId);
     this.toTarget.set(sessionId, target);
@@ -842,6 +879,7 @@ export class SessionRouter {
     }
     changed = this.toTarget.delete(sessionId) || changed;
     changed = this.toCwd.delete(sessionId) || changed;
+    changed = this.toManagedMeta.delete(sessionId) || changed;
     changed = this.liveSessionIds.delete(sessionId) || changed;
     this.staleBridgeBindings.delete(sessionId);
     if (changed) this.persist();
@@ -953,6 +991,7 @@ export class SessionRouter {
     this.toSession.delete(key);
     this.toTarget.delete(sessionId);
     this.toCwd.delete(sessionId);
+    this.toManagedMeta.delete(sessionId);
     this.liveSessionIds.delete(sessionId);
     return sessionId;
   }
@@ -996,6 +1035,12 @@ export class SessionRouter {
       this.toSession.set(key, entry.sessionId);
       this.toTarget.set(entry.sessionId, entry.target);
       this.toCwd.set(entry.sessionId, entry.cwd);
+      if (entry.isolation === 'worktree' && entry.workspaceCwd !== undefined) {
+        this.toManagedMeta.set(entry.sessionId, {
+          isolation: 'worktree',
+          workspaceCwd: entry.workspaceCwd,
+        });
+      }
       restored++;
     }
     if (persisted.dropped > 0) this.persist();
@@ -1053,6 +1098,43 @@ export class SessionRouter {
         try {
           this.assertOperationCurrent(operation);
           const options = this.sessionOptions(entry.target.channelName);
+          if (
+            entry.isolation === 'worktree' &&
+            entry.workspaceCwd !== undefined
+          ) {
+            // The generic restore cannot resolve a persisted worktree cwd
+            // (the daemon exact-matches registered workspace roots), so
+            // re-attach through the managed path: load by workspace root and
+            // re-validate the daemon's worktree attestation. A superseded
+            // id redirects to its replacement inside the managed load.
+            const managed = await this.loadManagedSession(
+              entry.sessionId,
+              entry.target,
+              entry.workspaceCwd,
+              entry.cwd,
+              'worktree',
+            );
+            try {
+              this.assertOperationCurrent(operation);
+            } catch (error) {
+              this.scheduleDiscardInvalidatedSession(
+                managed.sessionId,
+                operation,
+              );
+              throw error;
+            }
+            this.toSession.set(key, managed.sessionId);
+            this.toManagedMeta.set(managed.sessionId, {
+              isolation: 'worktree',
+              workspaceCwd: entry.workspaceCwd,
+            });
+            reservation.resolve(managed.sessionId);
+            if (managed.sessionId !== entry.sessionId) {
+              changed = true;
+            }
+            restored++;
+            continue;
+          }
           const sessionId = await this.bridge.loadSession(
             entry.sessionId,
             entry.cwd,
@@ -1118,6 +1200,7 @@ export class SessionRouter {
     this.toSession.clear();
     this.toTarget.clear();
     this.toCwd.clear();
+    this.toManagedMeta.clear();
     this.creatingSessions.clear();
     this.sessionLoadWindows.clear();
     this.liveSessionIds.clear();
@@ -1194,7 +1277,7 @@ export class SessionRouter {
     const target = entry['target'];
     if (typeof target !== 'object' || target === null) return false;
     const typedTarget = target as Record<string, unknown>;
-    return (
+    const wellFormed =
       typeof entry['sessionId'] === 'string' &&
       entry['sessionId'].length > 0 &&
       typeof entry['cwd'] === 'string' &&
@@ -1205,7 +1288,13 @@ export class SessionRouter {
       (typedTarget['threadId'] === undefined ||
         typeof typedTarget['threadId'] === 'string') &&
       (typedTarget['isGroup'] === undefined ||
-        typeof typedTarget['isGroup'] === 'boolean')
+        typeof typedTarget['isGroup'] === 'boolean');
+    if (!wellFormed) return false;
+    if (entry['isolation'] === undefined) return true;
+    return (
+      entry['isolation'] === 'worktree' &&
+      typeof entry['workspaceCwd'] === 'string' &&
+      entry['workspaceCwd'].length > 0
     );
   }
 
@@ -1220,6 +1309,7 @@ export class SessionRouter {
         sessionId,
         target,
         cwd: this.toCwd.get(sessionId) ?? this.defaultCwd,
+        ...(this.toManagedMeta.get(sessionId) ?? {}),
       };
     }
 

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -1126,10 +1126,19 @@ export class SessionRouter {
             try {
               this.assertOperationCurrent(operation);
             } catch (error) {
-              this.scheduleDiscardInvalidatedSession(
-                managed.sessionId,
-                operation,
-              );
+              // loadManagedSession binds with its own token, so an
+              // operation-keyed discard can never match here; release
+              // tokenless and roll back the maps the load committed.
+              // No persist — the loop's guarded final write owns the file.
+              if (![...this.toSession.values()].includes(managed.sessionId)) {
+                void this.bridge
+                  .discardSession?.(managed.sessionId)
+                  .catch(() => undefined);
+                this.toTarget.delete(managed.sessionId);
+                this.toCwd.delete(managed.sessionId);
+                this.toManagedMeta.delete(managed.sessionId);
+                this.liveSessionIds.delete(managed.sessionId);
+              }
               throw error;
             }
             this.toSession.set(key, managed.sessionId);

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -961,6 +961,9 @@ export class SessionRouter {
     if (this.toCwd.delete(sessionId)) {
       removed = true;
     }
+    if (this.toManagedMeta.delete(sessionId)) {
+      removed = true;
+    }
     this.liveSessionIds.delete(sessionId);
     if (!removed && this.sessionLoadWindows.size > 0) {
       for (const loadWindow of this.sessionLoadWindows) {
@@ -1107,6 +1110,12 @@ export class SessionRouter {
             // re-attach through the managed path: load by workspace root and
             // re-validate the daemon's worktree attestation. A superseded
             // id redirects to its replacement inside the managed load.
+            // Death-during-restore is deliberately not re-checked here the
+            // way the generic branch does: the managed load's internal
+            // window already covers the load itself, and nothing below
+            // yields between its return and the route set, so a death
+            // notification cannot interleave (run-to-completion). The next
+            // death event lands after routing and is handled normally.
             const managed = await this.loadManagedSession(
               entry.sessionId,
               entry.target,

--- a/packages/channels/base/src/named-session-manager.test.ts
+++ b/packages/channels/base/src/named-session-manager.test.ts
@@ -825,6 +825,31 @@ describe('NamedSessionManager', () => {
     });
   });
 
+  it('persists the selected worktree task route with restore metadata', async () => {
+    const routesPath = join(dir, 'routes.json');
+    router = new SessionRouter(bridge, '/workspace', 'user', routesPath, {
+      recoveryMode: 'lazy',
+    });
+    const named = manager();
+    const created = await named.create(alice, 'feature', 'worktree');
+
+    const routes = Object.values(
+      JSON.parse(readFileSync(routesPath, 'utf8')),
+    ) as Array<{
+      sessionId: string;
+      cwd: string;
+      isolation?: string;
+      workspaceCwd?: string;
+    }>;
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toMatchObject({
+      sessionId: created.sessionId,
+      cwd: canonicalizeWorkspacePath(`/worktrees/${created.sessionId}`),
+      isolation: 'worktree',
+      workspaceCwd: '/workspace',
+    });
+  });
+
   it('resets a worktree task onto a fresh session that keeps the worktree', async () => {
     const named = manager();
     const created = await named.create(alice, 'feature', 'worktree');

--- a/packages/channels/base/src/named-session-manager.ts
+++ b/packages/channels/base/src/named-session-manager.ts
@@ -342,7 +342,10 @@ export class NamedSessionManager {
           .catch(() => undefined);
         throw error;
       }
-      this.router.activateManagedSession(sessionId, target, task.cwd);
+      this.router.activateManagedSession(sessionId, target, task.cwd, {
+        isolation: task.isolation,
+        workspaceCwd: this.cwd,
+      });
       return this.selection(nextOwner, task);
     });
   }
@@ -392,6 +395,7 @@ export class NamedSessionManager {
         loadResult.sessionId,
         updatedTask.target,
         updatedTask.cwd,
+        { isolation: updatedTask.isolation, workspaceCwd: this.cwd },
       );
       return this.selection(nextOwner, updatedTask);
     });
@@ -478,6 +482,7 @@ export class NamedSessionManager {
           replacementSessionId ?? replacement.sessionId,
           replacement.target,
           replacement.cwd,
+          { isolation: replacement.isolation, workspaceCwd: this.cwd },
         );
       }
       try {
@@ -506,6 +511,7 @@ export class NamedSessionManager {
             restored.sessionId,
             task.target,
             task.cwd,
+            { isolation: task.isolation, workspaceCwd: this.cwd },
           );
         }
         throw new Error(`Failed to close task "${task.name}".`, {
@@ -568,6 +574,7 @@ export class NamedSessionManager {
           sessionId,
           updatedTask.target,
           updatedTask.cwd,
+          { isolation: updatedTask.isolation, workspaceCwd: this.cwd },
         );
         this.router.forgetManagedSession(task.sessionId);
         this.repointSupersededSessionIds(task.sessionId, sessionId);
@@ -604,6 +611,7 @@ export class NamedSessionManager {
         sessionId,
         updatedTask.target,
         updatedTask.cwd,
+        { isolation: updatedTask.isolation, workspaceCwd: this.cwd },
       );
       this.router.forgetManagedSession(task.sessionId);
       this.repointSupersededSessionIds(task.sessionId, sessionId);
@@ -730,6 +738,7 @@ export class NamedSessionManager {
         result.sessionId,
         task.target,
         task.cwd,
+        { isolation: task.isolation, workspaceCwd: this.cwd },
       );
       return result.sessionId;
     } catch (error) {


### PR DESCRIPTION
## What this PR does

Cold-start session restoration in channel workers now re-attaches persisted worktree-task routes through the managed load path (workspace root + daemon worktree attestation) instead of the generic load path. To make that possible, selecting a named task now records two extra pieces of metadata next to its route — the worktree isolation marker and the workspace root — and lazy route restore rehydrates the same metadata. Routes persisted without the metadata keep today's behavior, so nothing changes for shared tasks or older route files.

## Why it's needed

When a channel worker restarted, its cold-start session restore replayed every persisted route through the generic daemon load with the route's recorded cwd. For worktree tasks that cwd is the worktree path itself, which the daemon cannot resolve to a registered workspace, so the load failed with `workspace_mismatch` and the route was silently dropped from the route store — every worktree-task route disappeared on each worker restart. The sessions themselves were never damaged and the named-session manager could heal a route lazily on the next message, but any flow that relied on the restored route table (eager restore semantics, proactive delivery) lost the task. This was deferred from the Part 4A review (#10643) as a Critical finding and is tracked as one of the two items in #11024.

## Reviewer Test Plan

### How to verify

Reproduce the original failure on main: create a channel worktree session against a real daemon (`POST /session` with `worktree: {}`), write a route file whose worktree route records the worktree path as its cwd, run cold-start route restoration, and observe the restore fail with `workspace_mismatch` and the route dropped. On this branch the same scenario restores `{restored: 2, failed: 0}`, the daemon only ever sees the workspace root as the request cwd, and the route file keeps its restore metadata afterwards. A superseded worktree session (after a worktree reset) redirects to its replacement during cold-start restore and the route file is rewritten with the replacement id. Unit coverage: `packages/channels/base` suite (192 tests in the two touched files, 1331 in the package) passes, including eight new cases covering managed restore, superseded redirect, attestation failure, malformed metadata, metadata persistence, and lazy-mode rehydration.

### Evidence (Before & After)

N/A — daemon/channel behavior change verified by real-daemon A/B: before, cold-start restore dropped every worktree-task route with HTTP 400 `workspace_mismatch`; after, the same routes restore through the managed path with zero failures. Full before/after logs are in the issue thread for #11024.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Real daemon (`node dist/cli.js serve`) + real channel router driven over the HTTP API; unit tests via vitest.

## Risk & Scope

- Main risk or tradeoff: route files written by this build carry extra metadata that older builds ignore — an older build reading a new route file falls back to the old drop-then-lazy-heal behavior, so mixed-version workers degrade rather than break.
- Not validated / out of scope: routes persisted by older builds (no metadata) still drop once at the first cold start and heal lazily through the named-session manager — a documented one-time migration cost.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #11024 (item 2 — the deferred `SessionRouter.ts:487` Critical finding from #10643)

<details>
<summary>中文说明</summary>

## 本 PR 的内容

Channel worker 的冷启动会话恢复现在通过 managed 加载路径（workspace 根 + daemon worktree 证明）重新挂接已持久化的 worktree 任务路由，而不是走通用加载路径。为此，选中命名任务时会在其路由旁额外记录两项元数据——worktree 隔离标记与 workspace 根——lazy 路由恢复也会同步再水合这些元数据。没有元数据的历史路由保持原有行为，因此共享任务与旧路由文件完全不受影响。

## 为什么需要

Channel worker 重启时，其冷启动会话恢复会用路由记录的 cwd 通过通用 daemon 加载重放每一条持久化路由。对 worktree 任务而言该 cwd 就是 worktree 路径本身，daemon 无法将其解析到已注册的 workspace，加载以 `workspace_mismatch` 失败，路由被静默地从路由表中丢弃——每次 worker 重启，所有 worktree 任务路由都会消失。会话本身从未受损，named-session manager 也能在下一条消息时懒恢复路由，但任何依赖恢复后路由表的流程（eager 恢复语义、主动消息投递）都会丢失任务。这是 Part 4A 评审（#10643）遗留的 Critical 发现，作为 #11024 的两个事项之一被跟踪。

## 评审者测试计划

### 如何验证

在 main 上复现原始故障：对真实 daemon 创建一个 channel worktree 会话（`POST /session` 带 `worktree: {}`），写一个 worktree 路由 cwd 为 worktree 路径的路由文件，执行冷启动路由恢复，观察恢复以 `workspace_mismatch` 失败且路由被丢弃。在本分支上，同场景恢复结果为 `{restored: 2, failed: 0}`，daemon 侧收到的请求 cwd 只有 workspace 根，路由文件在恢复后仍保留恢复元数据。被取代的 worktree 会话（经历 worktree reset 后）在冷启动恢复中会重定向到替换会话，路由文件被改写为替换 id。单元覆盖：`packages/channels/base` 测试套件（两个改动文件 192 个测试、全包 1331 个）通过，含 8 个新用例：managed 恢复、superseded 重定向、证明失败、畸形元数据、元数据持久化、lazy 模式再水合。

### 证据（前后对比）

N/A——daemon/channel 行为变化，已通过真 daemon A/B 验证：修复前冷启动恢复对每个 worktree 任务路由以 HTTP 400 `workspace_mismatch` 失败并丢弃；修复后相同路由经 managed 路径零失败恢复。完整前后日志见 #11024 的 issue 讨论。

### 测试平台

Linux 已测试；macOS / Windows 未测试（CI 覆盖）。

### 环境（可选）

真实 daemon（`node dist/cli.js serve`）+ 通过 HTTP API 驱动的真实 channel 路由；单元测试使用 vitest。

## 风险与范围

- 主要风险/取舍：本构建写入的路由文件带有额外元数据，旧构建读取时忽略这些字段——旧构建读新路由文件会退化为旧的"丢弃后懒自愈"行为，混合版本部署是降级而非故障。
- 未验证/超出范围：旧构建持久化的路由（无元数据）在首次冷启动时仍会被丢弃一次，随后由 named-session manager 懒自愈——已文档化的一次性迁移成本。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Refs #11024（事项 2——#10643 遗留的 `SessionRouter.ts:487` Critical 发现）

</details>
