### PR TITLE
fix(ci): isolate E2E directories across Vitest forks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -249,9 +249,9 @@ jobs:
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
           KEEP_OUTPUT: 'true'
           VERBOSE: 'true'
-          # Mapped for integration-tests/vitest.config.ts, which caps each
-          # shared-pool shard at one fork and exempts pressure-flake unhandled
-          # errors.
+          # Mapped for integration-tests/vitest.config.ts, which exempts
+          # pressure-flake unhandled errors on shared-pool runners. The test
+          # commands below override its one-fork default for this job.
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
           QWEN_SANDBOX: "${{ matrix.sandbox == 'sandbox:docker' && 'docker' || 'false' }}"
           BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
@@ -302,8 +302,8 @@ jobs:
                 echo "::error::docker daemon read lock not acquired within 30 minutes"
                 exit 1
               fi
-              # Per-commit coordinator: one shard per host builds the image,
-              # its siblings wait here and then find it present.
+              # Per-commit coordinator: one job builds the image; a concurrent
+              # run at the same SHA waits here and then finds it present.
               exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-e2e-${GITHUB_SHA}.lock"
               if ! flock --wait 1800 8; then
                 echo "::error::docker build coordinator lock not acquired within 30 minutes"

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -225,8 +225,11 @@ export class TestRig {
   ) {
     this.testName = testName;
     const sanitizedName = sanitizeTestName(testName);
-    this.testDir = join(env['INTEGRATION_TEST_FILE_DIR']!, sanitizedName);
-    // Two cases that set up under the same name share this directory, and
+    this.testDir = join(
+      env['INTEGRATION_TEST_FILE_DIR']!,
+      `${sanitizedName}-${process.pid}`,
+    );
+    // Same-name cases in one worker share this directory, and
     // cleanup() below keeps it whenever KEEP_OUTPUT is set — which CI always
     // sets. Reset it so a case never inherits the previous one's files; see the
     // SDK helper, where exactly that made a suite pass locally and fail in CI.

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -41,8 +41,11 @@ describe('e2e workflow', () => {
     );
 
     expect(linuxJob.strategy.matrix.shard).toEqual(['1/1']);
-    expect(runStep.run.match(/--poolOptions\.forks\.maxForks=3/g)).toHaveLength(
-      2,
+    expect(runStep.run).toMatch(
+      /^\s*npx cross-env .*QWEN_SANDBOX=docker vitest run .*--poolOptions\.forks\.maxForks=3/m,
+    );
+    expect(runStep.run).toMatch(
+      /^\s*QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- .*--poolOptions\.forks\.maxForks=3/m,
     );
   });
 


### PR DESCRIPTION
## What this PR does

This follow-up to #11306 isolates each Vitest fork's CLI integration-test directory with the worker process ID. Same-name cases still reuse and reset their directory when they run sequentially in one worker, while cases in concurrent fork workers no longer delete each other's live files.

It also pins the three-fork flag to the actual Docker and sandbox:none command lines and updates the two job comments that still described the retired multi-shard layout.

## Why it's needed

#11306 replaces three Linux shard jobs with one job running up to three Vitest forks. The global setup publishes one shared `INTEGRATION_TEST_FILE_DIR`, and two different specs call `TestRig.setup('should be able to write a file')`. Before this fix, both workers derived the same directory and each setup recursively removed it, so one worker could delete the other worker's cwd, settings, files, and telemetry log.

A deterministic two-file harness reproduced the collision on the base commit: two fork PIDs inherited the same run root, derived the same test directory, and the second setup deleted the first worker's sentinel. With this change, the workers derived PID-suffixed directories and the sentinel survived.

## Reviewer Test Plan

### How to verify

Confirm that two concurrent Vitest fork workers using the same test name derive different directories, while two sequential same-name setups in one worker still reset the reused directory. Confirm that removing the fork flag from either Linux command fails the workflow structure test.

### Evidence (Before & After)

N/A — this changes CI test isolation and has no user-interface impact.

Before: concurrent workers derived the same `should-be-able-to-write-a-file` directory; worker B's setup removed worker A's live sentinel.

After: workers derived `should-be-able-to-write-a-file-<pid>` directories; worker A's sentinel remained after worker B's setup.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run build` and `npm run typecheck` passed. The focused helper tests passed 7/7, the workflow structure tests passed 30/30, and ESLint, Prettier, and actionlint passed. The deterministic two-fork reproduction passed before and after the fix with the expected state transition. The credentialed Linux E2E workflow was not run locally.

## Risk & Scope

- Main risk or tradeoff: retained E2E artifacts now include a process ID in the case directory name.
- Not validated / out of scope: full Linux sandbox:none and Docker E2E runs with live model credentials; retry-budget tuning remains outside this review fix.
- Breaking changes / migration notes: none.

## Linked Issues

Follows up on the blocking review from #11306, which merged before this fix was prepared.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

这是 #11306 合并后的 follow-up 修复：在每个 Vitest fork 使用的 CLI 集成测试目录中加入 worker 进程 ID。同一 worker 内顺序执行的同名用例仍会复用并重置目录，而并发 fork worker 中的用例不再互相删除正在使用的文件。

同时，workflow 测试现在分别把三 fork 参数钉在 Docker 与 sandbox:none 的实际命令行上，并更新了 job 内仍在描述旧多分片形态的两处注释。

## 为什么需要

#11306 将三个 Linux shard job 改为一个最多运行三个 Vitest fork 的 job。全局 setup 会发布一个共享的 `INTEGRATION_TEST_FILE_DIR`，而两个不同的 spec 都调用了 `TestRig.setup('should be able to write a file')`。修复前，两个 worker 会派生出同一个目录，并且每次 setup 都会递归删除该目录，因此一个 worker 可能删除另一个 worker 正在使用的 cwd、settings、文件与 telemetry log。

一个确定性的双文件 harness 在 base commit 上复现了该冲突：两个 fork PID 继承同一个 run root、派生出同一个测试目录，第二个 setup 删除了第一个 worker 的哨兵文件。应用本改动后，两个 worker 派生出带 PID 后缀的不同目录，哨兵文件保持存在。

## Reviewer 测试计划

### 如何验证

确认两个并发 Vitest fork worker 使用同一个测试名时会派生出不同目录，同时同一 worker 内两次顺序执行的同名 setup 仍会重置复用目录。确认从任一 Linux 命令中删除 fork 参数都会让 workflow 结构测试失败。

### 证据（修改前后）

不适用——这是 CI 测试隔离改动，没有用户界面影响。

修改前：并发 worker 派生出同一个 `should-be-able-to-write-a-file` 目录；worker B 的 setup 删除了 worker A 正在使用的哨兵文件。

修改后：worker 派生出 `should-be-able-to-write-a-file-<pid>` 目录；worker B 执行 setup 后，worker A 的哨兵文件仍然存在。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`npm run build` 与 `npm run typecheck` 通过。定向 helper 测试 7/7 通过，workflow 结构测试 30/30 通过，ESLint、Prettier 与 actionlint 通过。确定性的双 fork 复现用例在修复前后都得到预期状态变化。未在本地运行需要真实模型凭据的 Linux E2E workflow。

## 风险与范围

- 主要风险或取舍：保留的 E2E 产物中，用例目录名现在会包含进程 ID。
- 未验证 / 范围外：带真实模型凭据的 Linux sandbox:none 与 Docker 完整 E2E；retry budget 调整仍不在本次 review 修复范围内。
- 破坏性变更 / 迁移说明：无。

## 关联事项

跟进 #11306 的阻塞性 review；该 PR 在本修复准备完成前已经合并。

</details>