### PR TITLE
fix(serve): fail fast on unsupported target mutations in the CDP tunnel

### DIFF
--- a/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.test.ts
@@ -180,6 +180,58 @@ describe('CdpBrowserEmulator (Plan C #5626)', () => {
     });
   });
 
+  it('errors on Target.createTarget instead of faking a targetId', async () => {
+    const { emu, replies, log } = setup();
+    await emu.handleFromClient({
+      id: 60,
+      method: 'Target.createTarget',
+      params: { url: 'about:blank' },
+    });
+    expect(replies[0].result).toBeUndefined();
+    expect(replies[0]).toMatchObject({ id: 60, error: { code: -32000 } });
+    expect((replies[0].error as { message: string }).message).toContain(
+      'Target.createTarget',
+    );
+    // An explicit case must not be reported as an unsupported-method gap.
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('errors on target/browser-context mutations the tunnel cannot perform', async () => {
+    const { emu, replies } = setup();
+    const methods = [
+      'Target.closeTarget',
+      'Target.createBrowserContext',
+      'Target.disposeBrowserContext',
+    ];
+    for (const [index, method] of methods.entries()) {
+      await emu.handleFromClient({ id: 70 + index, method, params: {} });
+    }
+    expect(replies).toHaveLength(methods.length);
+    for (const [index, method] of methods.entries()) {
+      expect(replies[index].result).toBeUndefined();
+      expect(replies[index]).toMatchObject({
+        id: 70 + index,
+        error: { code: -32000 },
+      });
+      expect((replies[index].error as { message: string }).message).toContain(
+        method,
+      );
+    }
+  });
+
+  it('still acks unknown browser-level commands so optional ones cannot hang', async () => {
+    const { emu, replies, log } = setup();
+    await emu.handleFromClient({
+      id: 80,
+      method: 'Browser.setDownloadBehavior',
+      params: {},
+    });
+    expect(replies[0]).toEqual({ id: 80, result: {} });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('unsupported browser-level CDP method'),
+    );
+  });
+
   it('reports that the selected page has no DevTools target', async () => {
     const { emu, replies, log } = setup();
     await emu.handleFromClient({

--- a/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.ts
@@ -174,6 +174,23 @@ export class CdpBrowserEmulator {
           // Handled explicitly (not via `default:`) so the empty ack is not
           // logged as an unsupported-method coverage gap.
           return this.cb.reply({ id, result: {} });
+        // Target mutations the tunnel cannot perform: behind it is ONE tab the
+        // user already has open, so there is nothing to create, close, or
+        // isolate. These must not fall through to the empty ack below — a CDP
+        // client reads `targetId` out of the createTarget result and then waits
+        // for a target that never appears, so a fake success turns "open a new
+        // page" into a protocol timeout instead of an immediate refusal.
+        case 'Target.createTarget':
+        case 'Target.closeTarget':
+        case 'Target.createBrowserContext':
+        case 'Target.disposeBrowserContext':
+          return this.cb.reply({
+            id,
+            error: {
+              code: SERVER_ERROR,
+              message: `${method} is not supported by the CDP tunnel: it drives a single existing tab`,
+            },
+          });
         case 'Target.attachToTarget': {
           const targetId = params?.['targetId'];
           if (targetId !== PAGE_TARGET_ID) {


### PR DESCRIPTION
## What this PR does

The daemon's CDP tunnel (the `/cdp` WebSocket that lets a browser-automation MCP adapter drive a real tab through the Chrome extension) answers every browser-level protocol command it does not recognize with an empty success result. That silently "succeeds" four target-mutation commands — create target, close target, create/dispose browser context — even though the tunnel only ever drives one tab the user already has open. This change makes those four commands fail immediately with an explicit protocol error (`-32000`) whose message names the single-existing-tab limitation. All other unhandled browser-level commands keep the empty-ack behavior, because optional handshake commands must not hang waiting for a reply; that invariant is pinned by a new regression test.

## Why it's needed

A CDP client reads `targetId` out of the `createTarget` result and then waits for a target that never appears. With the pinned chrome-devtools-mcp adapter this turns the `new_page` and `close_page` tools into a ~30s protocol timeout with a generic error, instead of an immediate refusal that tells the caller the tunnel drives a single existing tab. The fake success also makes the tunnel's coverage look broader than it is, which is exactly the failure mode the emulator's existing TODO warns about. This resolves part of that TODO without touching the connect/handshake path. Verified against the adapter's bundled source: the create-target result is destructured for `targetId`, and close-target is what `page.close()` sends.

## Reviewer Test Plan

### How to verify

- Unit: `cd packages/cli && npx vitest run src/serve/cdp-tunnel/` — 66 tests across 5 files pass, including the three new ones: explicit errors for the four target-mutation commands, and a guard that an unknown browser-level command still receives the empty ack.
- Behavior to confirm: a `Target.createTarget` frame over `/cdp` now returns `{ error: { code: -32000, message: "Target.createTarget is not supported by the CDP tunnel: it drives a single existing tab" } }` instead of `{}`; connect, auto-attach, attach/detach, and page-session forwarding are untouched.
- Standards: `npm run typecheck` clean; eslint/prettier clean on the touched files.
- Nothing else in the repo sends these four commands (grep-verified), and the adapter only sends them from `new_page` / `close_page` / `isolatedContext`, all of which were already broken (hang then timeout) before this change.

### Evidence (Before & After)

N/A — non-UI protocol behavior. Before: `{ id, result: {} }`, client waits for a nonexistent target until the protocol timeout. After: immediate `{ id, error: { code: -32000, ... } }`. Both pinned by unit tests in this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A (CI)  |
|  🐧 Linux  |  N/A (CI)  |

### Environment (optional)

Unit tests via vitest. Real-Chrome acceptance (`npm -w packages/chrome-extension run test:e2e:chrome`) not run — it needs a local Chrome with the unpacked extension, and this change does not touch the connect/handshake path that suite exercises.

## Risk & Scope

- Main risk or tradeoff: a client that depended on the fake-success `{}` now sees an error. Acceptable: the only known senders (adapter `new_page` / `close_page`) were already failing via timeout, and failing fast with an actionable message is strictly better.
- Not validated / out of scope: real-Chrome end-to-end run (see Environment); multi-tab support itself (Phase 3) is out of scope — these commands keep refusing until it lands.
- Breaking changes / migration notes: none for any working flow.

## Linked Issues

References #5626 (does not close — partial resolution of the emulator coverage TODO).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

daemon 的 CDP 隧道（`/cdp` WebSocket，让浏览器自动化 MCP 适配器经 Chrome 扩展驱动真实标签页）对所有不认识的 browser 级协议命令一律返回空成功结果。这使得四条 target 变更命令——create target、close target、create/dispose browser context——被静默"成功"，尽管隧道永远只驱动用户已经打开的那一个标签页。本改动让这四条命令立刻以显式协议错误（`-32000`）失败，错误消息说明单标签页限制。其余未处理的 browser 级命令保持空 ack 行为，因为握手期的可选命令不能挂起等待回复；这一不变量由新增的回归测试钉住。

## 为什么需要

CDP 客户端会从 `createTarget` 的结果里读取 `targetId`，然后等待一个永远不会出现的 target。对固定的 chrome-devtools-mcp 适配器来说，这会让 `new_page` 和 `close_page` 工具挂约 30 秒协议超时并报一个泛化错误，而不是立刻告诉调用方隧道只驱动一个已存在的标签页。假成功还让隧道的覆盖范围看起来比实际更广——这正是模拟层里既有 TODO 所警告的失败模式。本 PR 在不触碰连接/握手路径的前提下解决了该 TODO 的一部分。已对适配器内置源码核实：create-target 的返回值会被解构取 `targetId`，close-target 正是 `page.close()` 发送的命令。

## Reviewer 验证计划

### 如何验证

- 单元测试：`cd packages/cli && npx vitest run src/serve/cdp-tunnel/`——5 个文件 66 个用例全过，含三个新用例：四条 target 变更命令显式报错，以及一条守护未知 browser 级命令仍收到空 ack 的回归测试。
- 待确认行为：经 `/cdp` 发送 `Target.createTarget` 帧现在返回 `{ error: { code: -32000, message: "Target.createTarget is not supported by the CDP tunnel: it drives a single existing tab" } }` 而不是 `{}`；connect、auto-attach、attach/detach 与 page session 转发均未改动。
- 规范：`npm run typecheck` 干净；改动文件 eslint/prettier 干净。
- 仓库内没有其他地方发送这四条命令（已 grep 核实），适配器也只从 `new_page` / `close_page` / `isolatedContext` 路径发送它们——这些路径在本改动之前就是坏的（挂起然后超时）。

### 证据（前后对比）

N/A——非 UI 协议行为。改前：`{ id, result: {} }`，客户端等待一个不存在的 target 直到协议超时。改后：立即返回 `{ id, error: { code: -32000, ... } }`。两者均由本 PR 的单元测试钉住。

### 测试环境

macOS ✅；Windows / Linux 走 CI。

### 环境（可选）

vitest 单元测试。真机 Chrome 验收（`npm -w packages/chrome-extension run test:e2e:chrome`）未运行——需要本地 Chrome 加载未打包扩展，且本改动不涉及该套件覆盖的连接/握手路径。

## 风险与范围

- 主要风险或取舍：依赖假成功 `{}` 的客户端现在会看到错误。可接受：唯一已知的发送方（适配器 `new_page` / `close_page`）此前本来就是以超时方式失败的，快速失败并给出可操作的消息严格更优。
- 未验证 / 范围外：真机端到端运行（见环境一节）；多 tab 支持本身（Phase 3）不在本 PR 范围内——在其落地前这些命令会继续拒绝。
- 破坏性变更 / 迁移说明：对任何可用流程均无。

## 关联 Issue

引用 #5626（不关闭——仅部分解决模拟层覆盖范围的 TODO）。

</details>
