### PR TITLE
fix(web-shell): cancel pending locate scroll timers on unmount

### DIFF
--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -571,6 +571,87 @@ const simpleTurns = (count: number): Message[] =>
     return [userMsg(`u${turn}`), asstMsg(`a${turn}`)] as Message[];
   }).flat();
 
+describe('MessageList — locate scroll timer lifecycle', () => {
+  it('does not schedule scroll work after unmounting before locate settles', () => {
+    vi.useFakeTimers();
+    const ref = createRef<MessageListHandle>();
+    const container = mount(simpleTurns(2), ref);
+    act(() => vi.advanceTimersByTime(32));
+
+    act(() => {
+      expect(ref.current?.scrollToMessage('u1')).toBe(true);
+    });
+    act(() => vi.advanceTimersByTime(149));
+
+    const index = mounted.findIndex((entry) => entry.container === container);
+    const [{ root }] = mounted.splice(index, 1);
+    act(() => root.unmount());
+    container.remove();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('keeps normal and repeated locate scrolling and highlighting working', () => {
+    vi.useFakeTimers();
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
+    const ref = createRef<MessageListHandle>();
+    const container = mount(simpleTurns(2), ref);
+    act(() => vi.advanceTimersByTime(32));
+
+    act(() => {
+      expect(ref.current?.scrollToMessage('u1')).toBe(true);
+    });
+    act(() => vi.advanceTimersByTime(32));
+    expect(
+      container
+        .querySelector('[data-testid="msg-u1"]')
+        ?.getAttribute('data-locate-flashing'),
+    ).toBe('true');
+
+    act(() => {
+      expect(ref.current?.scrollToMessage('u2')).toBe(true);
+    });
+    act(() => vi.advanceTimersByTime(32));
+    expect(
+      container
+        .querySelector('[data-testid="msg-u2"]')
+        ?.getAttribute('data-locate-flashing'),
+    ).toBe('true');
+    expect(
+      container
+        .querySelector('[data-testid="msg-u1"]')
+        ?.getAttribute('data-locate-flashing'),
+    ).toBeNull();
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: 'center' });
+    act(() => vi.advanceTimersByTime(150));
+  });
+
+  it('clears every pending locate timer after repeated navigation and unmount', () => {
+    vi.useFakeTimers();
+    const ref = createRef<MessageListHandle>();
+    const container = mount(simpleTurns(2), ref);
+    act(() => vi.advanceTimersByTime(32));
+
+    for (const id of ['u1', 'u2']) {
+      act(() => {
+        expect(ref.current?.scrollToMessage(id)).toBe(true);
+      });
+      act(() => vi.advanceTimersByTime(32));
+    }
+
+    const index = mounted.findIndex((entry) => entry.container === container);
+    const [{ root }] = mounted.splice(index, 1);
+    act(() => root.unmount());
+    container.remove();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
 describe('MessageList — failed prompt retry', () => {
   it('marks only the matching user message and forwards retry', () => {
     const onRetry = vi.fn();

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -3408,6 +3408,9 @@ export const MessageList = memo(
     const olderHistoryLoadGeneration = useRef(0);
     const scrollCooldown = useRef(false);
     const scrollCooldownCount = useRef(0);
+    const locateScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
     const pendingBottomFollowAfterCooldown = useRef(false);
     const sessionTimelineFrame = useRef<number | null>(null);
     const lastReportedCanScrollToBottom = useRef<boolean | null>(null);
@@ -4487,6 +4490,10 @@ export const MessageList = memo(
 
     useEffect(
       () => () => {
+        if (locateScrollTimer.current !== null) {
+          clearTimeout(locateScrollTimer.current);
+          locateScrollTimer.current = null;
+        }
         if (sessionTimelineFrame.current !== null) {
           cancelAnimationFrame(sessionTimelineFrame.current);
           sessionTimelineFrame.current = null;
@@ -4550,7 +4557,11 @@ export const MessageList = memo(
         }
         // Release once the scroll has settled (the virtualizer may re-scroll
         // a frame or two later after measuring the target row).
-        setTimeout(() => {
+        if (locateScrollTimer.current !== null) {
+          clearTimeout(locateScrollTimer.current);
+        }
+        locateScrollTimer.current = setTimeout(() => {
+          locateScrollTimer.current = null;
           if (scrollCooldownCount.current === gen) {
             scrollCooldown.current = false;
             scheduleSessionTimelineRangeUpdate();


### PR DESCRIPTION
## What this PR does

Cancel the pending 150 ms locate-scroll timer when another locate starts or the message list unmounts. Preserve the existing scroll cooldown guard and normal scrolling and target highlighting. Add three regression tests covering unmount, repeated navigation, and normal behavior.

## Why it's needed

Locating a message and unmounting the list before the timer settles previously left a callback that scheduled animation frames after unmount. During test teardown, that work can run after browser globals are removed and cause an intermittent `requestAnimationFrame is not defined` failure. This fixes the timer lifecycle left after #11208.

## Reviewer Test Plan

### How to verify

Locate a message, unmount the list before the 150 ms cooldown ends, and confirm that advancing time schedules no animation frames. Locate two messages in quick succession and unmount; no timers should remain. With the list mounted, both locate calls should scroll to the correct message and transfer the highlight to the second target.

The affected DOM test files passed together: 179/179 tests, including all three new lifecycle cases. Full repository build, typecheck, and bundle passed, as did ESLint and Prettier checks for the changed files and `git diff --check`.

### Evidence (Before & After)

Before: the deterministic DOM regression unmounted 149 ms after locating a message and observed two subsequent animation-frame requests; the normal-navigation control passed. After: the same regression observed no animation-frame requests, repeated navigation followed by unmount left zero pending timers, and normal scrolling and highlighting passed. There is no visual design change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js v22.22.3, package-local Vitest DOM tests. An isolated Chromium observation against global Qwen Code 0.23.0 did not reproduce the CI teardown environment; the reproduction and post-fix verification use deterministic DOM tests.

## Risk & Scope

- Main risk or tradeoff: cancelling a superseded locate timer must preserve the latest locate's cooldown release; repeated-navigation and normal-highlight tests cover that behavior.
- Not validated / out of scope: the original Ubuntu CI exception was not reproduced directly. The tests reproduce and verify removal of its underlying post-unmount animation scheduling. The combined run emitted React `act(...)` warnings without failing tests; cleanup of those warnings and other navigation follow-ups are outside this fix.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #11208. No issue is closed by this PR.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

在再次定位或消息列表卸载时，取消待执行的 150 ms 定位滚动定时器。保留现有滚动冷却代次检查，以及正常滚动和目标高亮行为。新增三项回归测试，覆盖卸载、连续定位和正常交互。

## 为什么需要

定位消息后，如果列表在定时器结束前卸载，原来的回调仍会在卸载后请求动画帧。测试环境销毁时，这段逻辑可能在浏览器全局对象移除后执行，导致偶发的 `requestAnimationFrame is not defined` 错误。本次修复 #11208 遗留的定时器生命周期问题。

## 审阅者测试计划

### 如何验证

定位一条消息，在 150 ms 冷却结束前卸载列表，确认推进时间后不会请求动画帧。快速连续定位两条消息后卸载，确认没有残留定时器。列表保持挂载时，两次定位都应滚动到正确消息，并将高亮切换到第二个目标。

相关两个 DOM 测试文件合跑通过 179/179 项测试，包含全部三项新增生命周期用例。全仓构建、类型检查和打包均通过，改动文件的 ESLint、Prettier 检查及 `git diff --check` 也均通过。

### 证据（修复前后）

修复前：确定性 DOM 回归测试在定位后第 149 ms 卸载，观察到随后仍有两次动画帧请求；正常定位对照测试通过。修复后：同一回归测试没有动画帧请求，连续定位后卸载的残留定时器数量为零，正常滚动和高亮测试通过。本次没有视觉设计变更。

### 测试平台

| 操作系统 | 状态 |
| :------: | :--: |
| macOS | ✅ 已测试 |
| Windows | ⚠️ 未测试 |
| Linux | ⚠️ 未测试 |

### 环境（可选）

macOS、Node.js v22.22.3、包内 Vitest DOM 测试。曾使用独立 Chromium 对全局 Qwen Code 0.23.0 进行观察，但浏览器无法复现 CI 环境销毁条件；问题复现和修复后验证均使用确定性 DOM 测试。

## 风险与范围

- 主要风险或取舍：取消被新定位替代的旧定时器时，必须保留最新一次定位的冷却释放；连续定位和正常高亮测试覆盖了这一行为。
- 未验证或不在范围内：未直接复现原始 Ubuntu CI 异常。测试复现并验证消除了其底层的卸载后动画帧调度。合跑时出现 React `act(...)` 警告，但未导致测试失败；这些警告的清理及其他导航后续事项不属于本次修复范围。
- 破坏性变更或迁移说明：无。

## 关联问题

#11208 的后续修复。本 PR 不关闭任何 issue。

</details>
