### PR TITLE
perf(web-shell): avoid an unnecessary initial turn-index page request

### DIFF
--- a/packages/web-shell/client/components/GlobalTurnNavigation.test.tsx
+++ b/packages/web-shell/client/components/GlobalTurnNavigation.test.tsx
@@ -19,15 +19,41 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-async function setup() {
+function tailPages(count: number) {
+  const start = Math.max(0, count - 200);
+  return new Map(
+    count
+      ? [
+          [
+            start,
+            {
+              start,
+              end: count,
+              snapshot: 'tail-snapshot',
+              retainedBytes: 100,
+              turns: Array.from({ length: count - start }, (_, index) => ({
+                ordinal: start + index,
+                turnId: `turn-${start + index}`,
+                kind: 'prompt' as const,
+                label: `Turn ${start + index + 1}`,
+              })),
+            },
+          ],
+        ]
+      : [],
+  );
+}
+
+async function setup(count = 5000, cachedTail = true) {
   vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   const store = createDaemonTurnNavigationStore();
   const state = {
     ...store.getSnapshot(),
     sessionId: 'session',
     mode: 'ready' as const,
-    totalTurns: 5000,
-    effectiveTurnCount: 5000,
+    totalTurns: count,
+    effectiveTurnCount: count,
+    indexPages: tailPages(cachedTail ? count : 0),
   };
   const load = vi.spyOn(store, 'loadOrdinal').mockResolvedValue();
   const select = vi.fn();
@@ -107,15 +133,82 @@ it('represents all turns while bounding DOM rows and loading only visible metada
   );
   expect(container.querySelector('[aria-setsize="5000"]')).not.toBeNull();
   expect(container.querySelector('[data-turn-ordinal="4999"]')).not.toBeNull();
-  // The initial render and the jump to the tail can each request one metadata page.
-  expect(load.mock.calls.length).toBeLessThanOrEqual(2);
-  expect(
-    load.mock.calls.every(([ordinal]) => ordinal < 200 || ordinal >= 4800),
-  ).toBe(true);
+  expect(load).not.toHaveBeenCalled();
+});
+
+it('initializes an empty session at its cached tail when the count arrives', async () => {
+  const { state, store, select, load } = await setup(0);
+  expect(load).not.toHaveBeenCalled();
+  await act(async () =>
+    root.render(
+      <GlobalTurnNavigation
+        state={{
+          ...state,
+          totalTurns: 5000,
+          effectiveTurnCount: 5000,
+          indexPages: tailPages(5000),
+        }}
+        store={store}
+        onSelect={select}
+      />,
+    ),
+  );
+  expect(container.querySelector('[data-turn-ordinal="4999"]')).not.toBeNull();
+  expect(load).not.toHaveBeenCalled();
+});
+
+it.each([5000, 10000])(
+  'initializes a different %i-turn session at its tail without loading the prior viewport',
+  async (count) => {
+    const { state, store, select, load } = await setup();
+    const scroll = container.querySelector<HTMLElement>('nav > div')!;
+    await act(async () => {
+      scroll.scrollTop = 0;
+      scroll.dispatchEvent(new Event('scroll'));
+    });
+    load.mockClear();
+    await act(async () =>
+      root.render(
+        <GlobalTurnNavigation
+          state={{
+            ...state,
+            sessionId: 'next-session',
+            totalTurns: count,
+            effectiveTurnCount: count,
+            indexPages: tailPages(count),
+          }}
+          store={store}
+          onSelect={select}
+        />,
+      ),
+    );
+    expect(
+      container.querySelector(`[data-turn-ordinal="${count - 1}"]`),
+    ).not.toBeNull();
+    expect(load).not.toHaveBeenCalled();
+  },
+);
+
+it('loads the displayed tail metadata when it is missing', async () => {
+  const { load } = await setup(5000, false);
+  expect(container.querySelector('[data-turn-ordinal="4999"]')).not.toBeNull();
+  expect(load).toHaveBeenCalledExactlyOnceWith(4800);
+});
+
+it('loads the first page on demand when the reader scrolls there', async () => {
+  const { load } = await setup();
+  load.mockClear();
+  const scroll = container.querySelector<HTMLElement>('nav > div')!;
+  await act(async () => {
+    scroll.scrollTop = 0;
+    scroll.dispatchEvent(new Event('scroll'));
+  });
+  expect(load).toHaveBeenCalledExactlyOnceWith(0);
 });
 
 it('moves keyboard focus to unloaded first and last turns and selects on click', async () => {
   const { select, load } = await setup();
+  load.mockClear();
   const last = container.querySelector<HTMLButtonElement>(
     '[data-turn-ordinal="4999"]',
   )!;
@@ -130,7 +223,7 @@ it('moves keyboard focus to unloaded first and last turns and selects on click',
   expect(document.activeElement).toBe(first);
   await act(async () => first.click());
   expect(select).toHaveBeenLastCalledWith(0);
-  expect(load.mock.calls.some(([ordinal]) => ordinal < 200)).toBe(true);
+  expect(load).toHaveBeenCalledExactlyOnceWith(0);
   await act(async () =>
     first.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'End', bubbles: true }),

--- a/packages/web-shell/client/components/GlobalTurnNavigation.tsx
+++ b/packages/web-shell/client/components/GlobalTurnNavigation.tsx
@@ -66,20 +66,21 @@ export function GlobalTurnNavigation({
     return () => observer.disconnect();
   }, []);
 
-  const initialized = useRef<string | undefined>(undefined);
+  const [initializedSession, setInitializedSession] = useState<string>();
   useLayoutEffect(() => {
-    if (!count || initialized.current === state.sessionId) return;
-    initialized.current = state.sessionId;
+    if (!count || initializedSession === state.sessionId) return;
     const element = viewport.current;
     if (!element) return;
     element.scrollTop = Math.max(0, count * ROW_HEIGHT - height);
     setTop(element.scrollTop);
     setFocus(count - 1);
-  }, [count, state.sessionId, height]);
+    setInitializedSession(state.sessionId);
+  }, [count, state.sessionId, height, initializedSession]);
 
   const missing = new Set<number>();
   for (
     let ordinal = start;
+    initializedSession === state.sessionId &&
     ordinal < Math.min(end, state.totalTurns);
     ordinal++
   ) {


### PR DESCRIPTION
## What this PR does

Wait for the navigation's initial tail position to commit before requesting missing turn metadata. Apply the same initialization rule when sessions change, while preserving on-demand loading for scrolling and keyboard navigation.

## Why it's needed

Opening a long session starts the navigation at the latest turns, but its first render calculates missing metadata at scroll position zero. The initial effect can therefore fetch the oldest index page before the tail position takes effect, even when the latest page is already cached. Avoiding that request saves an unnecessary transfer of up to 200 index entries without changing the navigation interaction.

## Reviewer Test Plan

### How to verify

Open a long session at its latest turn and confirm there is no explicit `start=0` index request. Scroll to the oldest turns or press Home; the first page should load on demand, and clicking a turn should locate the correct transcript. Press End to return to the latest turns without another index request when the tail is cached. Check previews, continued historical scrolling, session switches with equal or different turn counts, and history arriving after an initially empty session. Missing tail metadata must still load.

All 100 related tests across five component/store test files passed, including 11 navigation cases. Two Chromium scenarios against production assets passed. Full repository build, typecheck, bundle, changed-file ESLint/Prettier, and `git diff --check` passed.

### Evidence (Before & After)

Before: a deterministic component test with all 200 tail entries cached still requested ordinal zero on mount. The development-browser reproduction also observed first-page requests before any user navigation. After: the same component makes no extra request, and a 5000-turn production-browser fixture records zero first-page requests on opening, one after Home, and no further request after End. Mouse scrolling, previews, selection, and continued transcript loading pass. There is no visual design change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js v22.22.3, Vitest DOM tests, and Chromium loading the actual production assets with HTTP/SSE fixture data. The current bundle was also launched locally and passed its health check before the preview was stopped.

## Risk & Scope

- Main risk or tradeoff: initialization must not suppress necessary metadata requests; cached/missing tail, delayed count, session-switch, mouse and keyboard tests cover those paths.
- Not validated / out of scope: browser history was mocked; no real-history performance benchmark or local Windows/Linux validation was performed. The fixture still makes two startup head refreshes; this change targets only the unnecessary first-page request. React act warnings occurred in the passing combined test run.
- Breaking changes / migration notes: none. Pagination, endpoints, transcript behavior, and visual design remain unchanged.

## Linked Issues

Follow-up to #11208. No issue is closed by this PR.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

等待导航初始尾部位置提交后，再请求缺失的轮次元数据。切换会话时采用同样的初始化规则，同时保留滚动和键盘导航的按需加载。

## 为什么需要

打开长会话时，导航显示最新轮次，但首次渲染按滚动位置零计算缺失元数据。因此，即使最新一页已缓存，初始副作用也可能在尾部位置生效前请求最早一页索引。消除该请求可以省去最多 200 条索引的无用传输，同时保持导航交互不变。

## 审阅者测试计划

### 如何验证

打开长会话并停在最新轮次，确认没有显式 `start=0` 的索引请求。滚动到最早轮次或按 Home，第一页应按需加载，点击轮次应定位到正确正文。按 End 返回最新轮次，尾页已缓存时不应增加索引请求。检查内容预览、历史继续滚动、相同或不同轮次数的会话切换，以及初始为空后才收到历史的场景。缺失的尾页元数据仍须正常加载。

相关五个组件和状态存储测试文件的 100 项测试全部通过，其中包含 11 项导航用例。两项使用生产资源的 Chromium 场景通过。全仓构建、类型检查、打包、改动文件 ESLint/Prettier 及 `git diff --check` 均通过。

### 证据（修复前后）

修复前：确定性组件测试已缓存尾页全部 200 条索引，挂载时仍请求第零轮。开发模式浏览器复现也观察到用户操作前发出的第一页请求。修复后：同一组件不再额外请求，5000 轮生产页面测试场景在打开时记录到零次第一页请求，按 Home 后为一次，按 End 后不再增加请求。鼠标滚动、预览、选择和历史正文继续加载均通过。本次没有视觉设计变更。

### 测试平台

| 操作系统 | 状态 |
| :------: | :--: |
| macOS | ✅ 已测试 |
| Windows | ⚠️ 未测试 |
| Linux | ⚠️ 未测试 |

### 环境（可选）

macOS、Node.js v22.22.3、Vitest DOM 测试，以及加载真实生产资源并使用 HTTP/SSE 测试数据的 Chromium。当前打包产物也已在本地启动并通过健康检查，随后停止了预览。

## 风险与范围

- 主要风险或取舍：初始化不能阻止必要的元数据请求；尾页已缓存或缺失、计数延迟到达、会话切换、鼠标和键盘测试覆盖这些路径。
- 未验证或不在范围内：浏览器历史使用模拟数据；未进行真实历史性能基准测试，也未在本地验证 Windows/Linux。测试场景仍有两次启动时的头部刷新，本次仅消除无用的第一页请求。合跑测试通过，但出现 React act 警告。
- 破坏性变更或迁移说明：无。分页、接口、正文行为和视觉设计保持不变。

## 关联问题

#11208 的后续优化。本 PR 不关闭任何 issue。

</details>
