### PR TITLE
fix(live-host): keep packaging in the standalone npm workspace

### DIFF
--- a/packages/live-host/package.json
+++ b/packages/live-host/package.json
@@ -4,6 +4,7 @@
   "description": "Native macOS audio and global-shortcut host for Qwen Code Live Voice",
   "main": "dist/main.cjs",
   "private": true,
+  "workspaces": [],
   "type": "module",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## What this PR does

Keeps Live Host packaging inside its standalone npm workspace instead of inheriting the parent repository's pnpm package-manager selection. This is a one-line workspace boundary declaration; no dependency or workflow changes.

## Why it's needed

#10449 introduced the root pnpm declaration while explicitly excluding Live Host from that workspace. electron-builder 26.15.3 nevertheless walks up to the parent's workspace declaration and selects pnpm. The Live Host CI installs with npm and has no pnpm executable, so packaging fails with `spawn pnpm ENOENT`.

An empty child workspace declaration stops that upward lookup and preserves the existing npm lockfile and dependency layout. Declaring only a child npm package-manager version does not stop the later parent lookup.

## Reviewer Test Plan

### How to verify

Run the Live Host packaging lane against the pnpm-enabled main branch. Dependency collection should select npm with Live Host as the workspace root, retain its production dependency, and complete unsigned macOS packaging without invoking pnpm.

### Evidence (Before & After)

Before: [Live Host CI on #11314](https://github.com/QwenLM/qwen-code/actions/runs/34189887395/job/101945605629) selected the parent pnpm configuration and failed with `spawn pnpm ENOENT`.

After: the real electron-builder detection and production collector were exercised with a parent pnpm workspace and a child npm lockfile. They selected the child npm workspace and collected `ws`. Detection was also verified against this PR's latest-main worktree. Live Host code is unchanged from the locally tested revision: installation, build, typecheck, and all 68 tests passed. Full local packaging selected npm but stopped on an Electron download connection timeout; CI must validate the complete package.

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ✅ targeted checks; full packaging blocked by download |
| 🪟 Windows | ⚠️ |
| 🐧 Linux | ⚠️ |

## Risk & Scope

- Main risk or tradeoff: relies on electron-builder recognizing the explicit child workspace boundary; verified with the locked 26.15.3 version.
- Not validated / out of scope: complete signed/release packaging, API profile behavior, and Web Shell E2E failures.
- Breaking changes / migration notes: none; Live Host remains an independent npm project.

## Linked Issues

Follow-up to #10449. Observed in #11314; kept separate from that feature PR.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Live Host 打包保持在自身独立的 npm 工作区内，不再继承父仓库的 pnpm 选择。仅增加一行工作区边界声明，不改依赖或工作流。

## 为什么需要

#10449 在根目录引入 pnpm 声明，同时明确将 Live Host 排除在该工作区之外。但 electron-builder 26.15.3 仍向上找到父工作区并选择 pnpm。Live Host CI 使用 npm 安装，环境中没有 pnpm，导致打包报错 `spawn pnpm ENOENT`。

空的子工作区声明阻止继续向上查找，保留现有 npm 锁文件及依赖布局。仅声明子项目的 npm 版本不能阻止后续的父目录查找。

## Reviewer 测试计划

### 如何验证

在已启用 pnpm 的 main 基线上运行 Live Host 打包任务。依赖收集应选择 npm，以 Live Host 为工作区根目录，保留生产依赖，并在不调用 pnpm 的情况下完成 macOS 未签名打包。

### Before & After 证据

修复前：[#11314 的 Live Host CI](https://github.com/QwenLM/qwen-code/actions/runs/34189887395/job/101945605629) 选择父目录 pnpm 配置，报错 `spawn pnpm ENOENT`。

修复后：使用父 pnpm 工作区和子 npm 锁文件，执行真实 electron-builder 检测及生产依赖收集，正确选择子 npm 工作区并收集到 `ws`。也在本 PR 基于最新 main 的 worktree 中验证了检测结果。Live Host 代码与本地已测试版本一致：依赖安装、构建、类型检查及 68 个测试通过。完整本地打包正确选择 npm，但因 Electron 下载连接超时中断；完整产物仍需 CI 验证。

### 测试环境

| OS | 状态 |
| :--: | :--: |
| 🍏 macOS | ✅ 定向验证；完整打包被下载阻断 |
| 🪟 Windows | ⚠️ |
| 🐧 Linux | ⚠️ |

## 风险与范围

- 主要风险或取舍：依赖 electron-builder 识别显式子工作区边界，已使用锁定的 26.15.3 版本验证。
- 未验证 / 超出范围：完整签名及发布打包、API profile 行为、Web Shell E2E 失败。
- 破坏性变更 / 迁移说明：无；Live Host 保持独立 npm 项目。

## 关联 Issue

#10449 的后续修复。在 #11314 中观察到，独立于该功能 PR 提交。

</details>
