### PR TITLE
fix(ci): reap release integration containers

### DIFF
--- a/.github/scripts/run-release-docker-integration.sh
+++ b/.github/scripts/run-release-docker-integration.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cleanup_release_containers() {
+  container_ids="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${RELEASE_CONTAINER_OWNER}" 2>/dev/null)" || container_ids=''
+  if [ -n "$container_ids" ]; then
+    printf '%s\n' "$container_ids" | xargs -r timeout 60 docker rm -f > /dev/null 2>&1 || echo "::warning::failed to remove release containers for ${RELEASE_CONTAINER_OWNER}"
+  fi
+}
+
+if [ "${1:-}" = 'cleanup' ]; then
+  cleanup_release_containers
+  remaining="$(timeout 30 docker ps -aq --filter "label=org.qwen-code.ci.owner=${RELEASE_CONTAINER_OWNER}")"
+  if [ -n "$remaining" ]; then
+    echo "::error::release containers remain for ${RELEASE_CONTAINER_OWNER}: ${remaining//$'\n'/,}"
+    exit 1
+  fi
+  exit 0
+fi
+
+trap cleanup_release_containers EXIT
+trap 'exit 1' INT TERM
+
 sandbox_revision="$(git rev-parse HEAD)"
 sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-release-${sandbox_revision}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,8 +546,16 @@ jobs:
         env:
           QWEN_SANDBOX: 'docker'
           BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
+          RELEASE_CONTAINER_OWNER: '${{ github.run_id }}-${{ github.run_attempt }}-release'
+          SANDBOX_FLAGS: '--label org.qwen-code.ci.owner=${RELEASE_CONTAINER_OWNER}'
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: '.release-workflow/.github/scripts/run-release-docker-integration.sh'
+
+      - name: 'Remove job-owned release containers'
+        if: "${{ always() && runner.environment == 'self-hosted' }}"
+        env:
+          RELEASE_CONTAINER_OWNER: '${{ github.run_id }}-${{ github.run_attempt }}-release'
+        run: '.release-workflow/.github/scripts/run-release-docker-integration.sh cleanup'
 
   audio_capture_prebuilds:
     name: 'Audio Capture Prebuilds'

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -2077,6 +2077,37 @@ describe('release workflow', () => {
     );
   });
 
+  it('reaps only the Docker integration containers owned by its job', () => {
+    const owner = '${{ github.run_id }}-${{ github.run_attempt }}-release';
+    const steps = releaseYaml.jobs.integration_docker.steps;
+    const testStep = steps.find(
+      (step) => step.name === 'Run Docker Integration Tests',
+    );
+    const cleanupStep = steps.find(
+      (step) => step.name === 'Remove job-owned release containers',
+    );
+
+    expect(testStep.env.RELEASE_CONTAINER_OWNER).toBe(owner);
+    expect(testStep.env.SANDBOX_FLAGS).toContain(
+      'org.qwen-code.ci.owner=${RELEASE_CONTAINER_OWNER}',
+    );
+    expect(dockerIntegrationScript).toContain(
+      'trap cleanup_release_containers EXIT',
+    );
+    expect(dockerIntegrationScript).toContain("trap 'exit 1' INT TERM");
+    expect(dockerIntegrationScript).toContain(
+      '--filter "label=org.qwen-code.ci.owner=${RELEASE_CONTAINER_OWNER}"',
+    );
+    expect(cleanupStep.if).toContain('always()');
+    expect(cleanupStep.env.RELEASE_CONTAINER_OWNER).toBe(owner);
+    expect(cleanupStep.run).toBe(
+      '.release-workflow/.github/scripts/run-release-docker-integration.sh cleanup',
+    );
+    expect(dockerIntegrationScript).toContain('docker rm -f > /dev/null');
+    expect(dockerIntegrationScript.match(/docker ps -aq/g)).toHaveLength(2);
+    expect(dockerIntegrationScript).toContain('release containers remain');
+  });
+
   it('digest-pins every sandbox base image', () => {
     // integration_docker builds on the shared pool, whose docker daemon
     // store persists across jobs: a co-resident job can retag a mutable
@@ -2530,11 +2561,15 @@ describe('release lane runner routing', () => {
     ]) {
       const job = releaseYaml.jobs[name];
       expect(job.env.RUNNER_ENVIRONMENT, name).toBeUndefined();
-      const testSteps = job.steps.filter((step) =>
-        /(?:vitest|test:integration|run-release-docker-integration)/.test(
-          String(step.run ?? ''),
-        ),
-      );
+      const testSteps = job.steps.filter((step) => {
+        const command = String(step.run ?? '');
+        return (
+          !command.endsWith(' cleanup') &&
+          /(?:vitest|test:integration|run-release-docker-integration)/.test(
+            command,
+          )
+        );
+      });
       expect(testSteps, name).toHaveLength(expectedSteps);
       for (const step of testSteps) {
         expect(step.env.RUNNER_ENVIRONMENT, `${name}: ${step.name}`).toBe(


### PR DESCRIPTION
## What this PR does

Labels every container started by the Docker release-validation job with a run-scoped owner and removes only those containers when the test command or job finishes. The final cleanup checks for residue and fails the job if owned containers remain.

## Why it's needed

The scheduled release run [34162336173](https://github.com/QwenLM/qwen-code/actions/runs/34162336173) completed successfully but left eight `qwen-code-integration-test-*` containers running on `ecs-qwen-hk4-10`. Those containers had only the shared sandbox-image label, so the E2E cleanup added in #11264 could not identify or remove them.

## Reviewer Test Plan

### How to verify

1. Dispatch the Release workflow from this branch with `dry_run=true` and `force_skip_tests=false`.
2. Confirm `Integration Tests (Docker)` completes and `Remove job-owned release containers` succeeds on the self-hosted runner.
3. On that runner, confirm no container remains with `org.qwen-code.ci.owner=<run-id>-<attempt>-release`.

### Evidence (Before & After)

Before: release run 34162336173 left eight running containers after its Docker integration job completed.

After: dry-run 34194126628 completed successfully. Its Docker integration cleanup step succeeded on `ecs-qwen-hk4-25`, and a post-job SSH check found zero containers carrying `org.qwen-code.ci.owner=34194126628-1-release` and zero remaining containers created during the job window.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ workflow test (49 passed, 1 skipped) |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ release dry-run and ECS residue check |

### Environment (optional)

Local workflow parsing and structural regression test with Node.js 22.

## Risk & Scope

- Main risk or tradeoff: cleanup relies on Docker label filtering and affects only containers owned by the current release run.
- Not validated / out of scope: historical unlabeled containers and runner disk migration are intentionally separate.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #11264.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Docker 发布验证任务启动的每个容器增加按运行隔离的 owner 标签，并在测试命令或任务结束时只删除这些容器。最终清理步骤会检查是否仍有残留，若存在则让任务失败。

## 为什么需要

定时发布运行 [34162336173](https://github.com/QwenLM/qwen-code/actions/runs/34162336173) 虽然成功结束，但在 `ecs-qwen-hk4-10` 上留下了八个仍在运行的 `qwen-code-integration-test-*` 容器。这些容器只有共享的 sandbox 镜像标签，因此 #11264 增加的 E2E 清理无法识别和删除它们。

## Reviewer 测试计划

### 如何验证

1. 从当前分支手动触发 Release workflow，设置 `dry_run=true`、`force_skip_tests=false`。
2. 确认 `Integration Tests (Docker)` 完成，并且 self-hosted runner 上的 `Remove job-owned release containers` 成功。
3. 在对应 Runner 上确认不存在 `org.qwen-code.ci.owner=<run-id>-<attempt>-release` 标签的容器。

### 前后证据

修复前：Release run 34162336173 的 Docker 集成任务结束后留下了八个运行中的容器。

修复后：dry-run 34194126628 全部成功。Docker 集成清理步骤在 `ecs-qwen-hk4-25` 上成功，任务结束后的 SSH 检查确认 `org.qwen-code.ci.owner=34194126628-1-release` 标签容器为零，并且任务运行期间创建的容器没有残留。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ workflow 测试（49 passed，1 skipped） |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ Release dry-run 和 ECS 残留检查 |

本地使用 Node.js 22 完成 workflow 解析和结构回归测试。

## 风险和范围

- 主要风险或取舍：清理依赖 Docker 标签过滤，并且只处理当前 Release run 拥有的容器。
- 未验证或范围外：历史无标签容器和 Runner 磁盘迁移保持独立处理。
- 破坏性变更或迁移说明：无。

## 关联事项

#11264 的后续修复。

</details>
