### PR TITLE
fix(web-shell): preserve running subagent timer across replay

### DIFF
--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -185,6 +185,7 @@ function toolBlock(
     details: overrides.details,
     parentToolCallId: overrides.parentToolCallId,
     subagentType: overrides.subagentType,
+    serverTimestamp: overrides.serverTimestamp,
     clientReceivedAt: createdAt,
     createdAt,
     updatedAt: overrides.updatedAt ?? createdAt,
@@ -4933,3 +4934,85 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(agentB!.subContent).toBeUndefined();
   });
 });
+
+describe('running subagent replay start time', () => {
+  function firstTool(blocks: DaemonTranscriptBlock[]) {
+    return transcriptBlocksToDaemonMessages(blocks).find(
+      (message) => message.role === 'tool_group',
+    )?.tools[0];
+  }
+
+  it.each([10_000, 20_000])(
+    'keeps the server start when reopened at %s',
+    (receivedAt) => {
+      const tool = firstTool([
+        toolBlock('agent', 'agent-1', 'in_progress', receivedAt, {
+          toolName: 'Agent',
+          serverTimestamp: 1_000,
+        }),
+      ]);
+      expect(tool?.startTime).toBe(1_000);
+    },
+  );
+
+  it.each([
+    ['Agent', 'completed', 1_000],
+    ['Agent', 'failed', 1_000],
+    ['Read', 'in_progress', 1_000],
+    ['Agent', 'in_progress', undefined],
+  ])(
+    'preserves existing timing for %s/%s/%s',
+    (toolName, status, serverTimestamp) => {
+      const tool = firstTool([
+        toolBlock('tool', 'tool-1', status, 10_000, {
+          toolName,
+          serverTimestamp,
+        }),
+      ]);
+      expect(tool?.startTime).toBe(10_000);
+    },
+  );
+});
+
+it.each(['selected:allow', 'selected:cancel'])(
+  'keeps permission merging compatible with the running clock (%s)',
+  (resolved) => {
+    const permission: DaemonTranscriptBlock = {
+      id: 'permission',
+      kind: 'permission',
+      requestId: 'req',
+      sessionId: 'session',
+      title: 'Agent',
+      options: [],
+      preview: { kind: 'generic' },
+      resolved,
+      toolCall: {
+        toolCallId: 'agent-1',
+        rawInput: { subagent_type: 'general-purpose' },
+      },
+      serverTimestamp: 1_000,
+      clientReceivedAt: 10_000,
+      createdAt: 10_000,
+      updatedAt: 11_000,
+    };
+    const real = toolBlock('real', 'agent-1', 'in_progress', 12_000, {
+      toolName: 'Agent',
+      serverTimestamp: 2_000,
+    });
+    for (const blocks of [
+      [permission],
+      [permission, real],
+      [real, permission],
+    ]) {
+      const tool = transcriptBlocksToDaemonMessages(blocks).find(
+        (message) => message.role === 'tool_group',
+      )?.tools[0];
+      if (tool?.endTime !== undefined) {
+        expect(tool.endTime).toBe(11_000);
+        expect(tool.startTime).toBe(blocks[0].createdAt);
+      } else {
+        expect(tool?.startTime).toBe(blocks.includes(real) ? 2_000 : 1_000);
+      }
+    }
+  },
+);

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -24,6 +24,7 @@ import type {
   DaemonUserMessage,
 } from './messageTypes.js';
 import {
+  isActiveToolStatus,
   isSubAgentToolCall,
   projectTerminalBackgroundAgentTool,
 } from './toolClassification.js';
@@ -393,6 +394,7 @@ export function transcriptBlocksToDaemonMessages(
   // Subagent-owned assistant/thought/tool blocks are expected to carry
   // parentToolCallId; unparented blocks are rendered as top-level transcript.
   const toolsByCallId = new Map<string, DaemonMessageToolCall>();
+  const serverStartTimes = new Map<string, number>();
   const permissionToolInfoByCallId = new Map<string, PermissionToolInfo>();
   const backgroundAgentTaskUpdates = collectBackgroundAgentTaskUpdates(blocks);
   let currentAssistantIdx: number | null = null;
@@ -708,6 +710,9 @@ export function transcriptBlocksToDaemonMessages(
           backgroundAgentUpdate?.endTime,
           safeToolProjection,
         );
+        if (toolBlock.serverTimestamp !== undefined) {
+          serverStartTimes.set(toolCall.callId, toolBlock.serverTimestamp);
+        }
         const permissionInfo = permissionToolInfoByCallId.get(toolCall.callId);
         if (permissionInfo?.title) {
           toolCall.title = permissionInfo.title;
@@ -829,6 +834,15 @@ export function transcriptBlocksToDaemonMessages(
           safeToolProjection,
         );
         if (!permissionToolCall) break;
+        if (
+          permBlock.serverTimestamp !== undefined &&
+          !serverStartTimes.has(permissionToolCall.callId)
+        ) {
+          serverStartTimes.set(
+            permissionToolCall.callId,
+            permBlock.serverTimestamp,
+          );
+        }
         const isSubAgentPermission = isSubAgentToolCall(permissionToolCall);
         // Pending permissions are rendered by the dedicated permission UI.
         if (!permBlock.resolved) {
@@ -1019,6 +1033,16 @@ export function transcriptBlocksToDaemonMessages(
 
       default:
         break;
+    }
+  }
+
+  for (const tool of toolsByCallId.values()) {
+    if (
+      isSubAgentToolCall(tool) &&
+      isActiveToolStatus(tool.status) &&
+      tool.endTime === undefined
+    ) {
+      tool.startTime = serverStartTimes.get(tool.callId) ?? tool.startTime;
     }
   }
 


### PR DESCRIPTION
## What this PR does

Keeps the Message-area timer for a running subagent anchored to its recorded server start when its transcript is replayed or reopened. A real tool timestamp takes precedence over a permission placeholder timestamp, and the start is applied after status merging.

## Why it's needed

Replay assigns new client receipt times. Using those as execution start times makes an already-running subagent appear to restart its timer each time the message view is reopened.

## Reviewer Test Plan

### How to verify

Open a running subagent in the Message area, wait, then reopen its transcript. Confirm that the elapsed time continues from the original start. Also confirm that approved permission placeholders use the available server timestamp, real tool events take precedence, and rejected or completed cards retain their existing timing behavior.

### Evidence (Before & After)

Code-only reproduction with a fixed server start of 1,000 ms and client receipt time of 10,000 ms: at 14,000 ms, the old projection displays 4s; the corrected projection displays 13s. Replaying at a later receipt time retains the same start and displays 23s at 24,000 ms. No browser E2E or screenshots were captured.

After rebasing onto main: 332 related adapter/component tests passed; Web Shell build and typecheck passed. Commit hooks passed formatting and ESLint. Full repository build, bundle, and typecheck also passed before the rebase.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | ✅ Code-only reproduction, unit tests, build and typecheck |
| Windows | ⚠️ Not tested |
| Linux | ⚠️ Not tested |

### Environment (optional)

Local worktree; Vitest adapter/component tests and code-only reproduction.

## Risk & Scope

- Main risk or tradeoff: elapsed time uses an existing server timestamp and the current client clock, as other live timer displays do.
- Not validated / out of scope: real browser E2E, historical completed-task duration recovery, and thinking timers. Ordinary tools and completed timing retain their existing behavior. Records without a server timestamp retain their existing fallback.
- Breaking changes / migration notes: none; only two frontend files change, with 24 production lines and 83 test lines added.

## Linked Issues

None; reported during local Web Shell use.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

Message 区域中运行中的 subagent，在回放或重新打开记录时继续使用已记录的服务端起点计时。真实工具事件的时间优先于权限占位事件，起点在状态合并完成后应用。

## 为什么需要

回放会产生新的客户端接收时间。把接收时间当作任务起点，会导致已经运行的 subagent 在每次重新打开消息视图时看起来重新计时。

## Reviewer Test Plan

### 如何验证

在 Message 区域打开一个运行中的 subagent，等待一段时间后重新打开其记录，确认耗时从原始起点继续。还需确认已批准的权限占位卡使用可用的服务端时间，真实工具事件优先，以及被拒绝或已完成卡片保留原有计时行为。

### 前后对比证据

仅代码复现：固定服务端起点为 1,000 ms、客户端接收时间为 10,000 ms，在 14,000 ms 时旧逻辑显示 4s，修复后显示 13s。稍后以新的接收时间回放，仍保留同一起点，在 24,000 ms 时显示 23s。未进行真实浏览器 E2E，也未截取截图。

同步 main 后，332 项相关适配器和组件测试通过，Web Shell 构建和类型检查通过。提交钩子的格式化及 ESLint 通过。同步前还通过了全仓构建、打包和类型检查。

### 测试平台

| 系统 | 状态 |
| :-- | :-- |
| macOS | ✅ 代码复现、单元测试、构建和类型检查 |
| Windows | ⚠️ 未测试 |
| Linux | ⚠️ 未测试 |

### 环境

本地 worktree；Vitest 适配器和组件测试，以及仅代码复现。

## 风险和范围

- 主要风险或取舍：与其他实时计时展示一样，耗时使用已有的服务端时间戳和当前客户端时钟。
- 未验证或范围外：真实浏览器 E2E、历史已完成任务的精确耗时恢复，以及正在思考的计时。普通工具和已完成任务的计时保持原样。缺少服务端时间戳的记录保留原来的回退行为。
- 破坏性变更或迁移：无；只修改两个前端文件，新增 24 行生产代码和 83 行测试。

## 关联 Issue

无；问题来自本地 Web Shell 使用反馈。

</details>
