### PR TITLE
fix(web-shell): prefer clipboard text over image attachments

### DIFF
--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -905,6 +905,41 @@ describe('useComposerCore history and drafts', () => {
 });
 
 describe('useComposerCore paste', () => {
+  it('pastes editable text when PPT clipboard also includes an image', async () => {
+    const { onSubmit } = await mount();
+    const text = '第一季度收入增长 20%\n请改写这段文字。';
+    const image = new File(['png'], 'ppt-text.png', { type: 'image/png' });
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', {
+      value: {
+        files: [image],
+        items: [
+          { kind: 'file', type: 'image/png', getAsFile: () => image },
+          { kind: 'string', type: 'text/plain', getAsFile: () => null },
+        ],
+        types: ['Files', 'text/plain'],
+        getData: (type: string) => (type === 'text/plain' ? text : ''),
+      },
+    });
+
+    act(() => {
+      container!.querySelector('.cm-content')!.dispatchEvent(event);
+    });
+    await waitForImageIngestion();
+
+    expect.soft(latest!.getText()).toBe(text);
+    expect.soft(latest!.pastedImages).toEqual([]);
+
+    act(() => latest!.submitText());
+    expect(onSubmit).toHaveBeenCalledWith(
+      text,
+      undefined,
+      undefined,
+      expect.any(Function),
+      undefined,
+    );
+  });
+
   it('lets long plain text paste directly into the editor', async () => {
     await mount();
     const event = new Event('paste', { bubbles: true, cancelable: true });

--- a/packages/web-shell/client/hooks/useComposerCore.mobile.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.mobile.dom.test.tsx
@@ -371,7 +371,7 @@ describe('useComposerCore mobile textarea backend', () => {
     expect(document.activeElement).toBe(content);
   });
 
-  it('collects pasted images and lets plain text paste natively', async () => {
+  it('collects image-only paste and lets mixed text/image paste natively', async () => {
     mockTouchDevice();
     await mount();
     const preventDefault = vi.fn();
@@ -388,7 +388,12 @@ describe('useComposerCore mobile textarea backend', () => {
       cancelable: true,
     });
     Object.defineProperty(imageEvent, 'clipboardData', {
-      value: { files: [], items: [imageItem], types: ['Files'] },
+      value: {
+        files: [],
+        items: [imageItem],
+        types: ['Files'],
+        getData: () => '',
+      },
     });
     await act(async () => {
       imageEvent.preventDefault = preventDefault;
@@ -407,8 +412,12 @@ describe('useComposerCore mobile textarea backend', () => {
     Object.defineProperty(textEvent, 'clipboardData', {
       value: {
         files: [],
-        items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }],
-        types: ['text/plain'],
+        items: [
+          imageItem,
+          { kind: 'string', type: 'text/plain', getAsFile: () => null },
+        ],
+        types: ['Files', 'text/plain'],
+        getData: (type: string) => (type === 'text/plain' ? 'PPT 文字' : ''),
       },
     });
     act(() => {
@@ -416,6 +425,8 @@ describe('useComposerCore mobile textarea backend', () => {
       container!.querySelector('textarea')!.dispatchEvent(textEvent);
     });
     expect(textPreventDefault).not.toHaveBeenCalled();
+    expect(latest!.pastedImages).toHaveLength(1);
+    expect(latest!.pendingImageBatchCount).toBe(0);
   });
 
   it('saves the draft immediately on blur before the debounce timer fires', async () => {

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -1906,6 +1906,7 @@ export function useComposerCore(
   const imageTransferHandlers = useMemo<ComposerImageTransferHandlers>(
     () => ({
       onPasteCapture: (event) => {
+        if (event.clipboardData.getData('text/plain')) return;
         if (enqueueImageTransfer(event.clipboardData, 'paste')) {
           event.preventDefault();
           event.stopPropagation();


### PR DESCRIPTION
## What this PR does

Makes Web Shell prefer nonempty plain text when a pasted clipboard payload also contains an image or file. The existing editor handles text insertion and submission on desktop, and the native textarea handles insertion on mobile. Image-only paste, file uploads, and drag-and-drop keep their existing behavior.

## Why it's needed

A user reported that text copied from PowerPoint appeared as an image in Data Agent, while the same content pasted as editable text in qoderwork and Codex. Rich clipboard content can expose both plain text and an image representation of the same selection.

Web Shell previously claimed any clipboard image/file during the capture phase, then prevented the default paste and stopped event propagation. When both representations were present, that blocked the editor from receiving the available text and queued the image as an attachment instead. The agent consequently received an image rather than the text the user intended to quote or rewrite.

The fix lets paste continue to the editor whenever nonempty `text/plain` is available. It preserves the original text and avoids creating a redundant attachment, using the shared paste entry point for both desktop and mobile.

## Reviewer Test Plan

### How to verify

1. Copy a multiline text selection from PowerPoint and paste it into the Web Shell conversation input. When the clipboard exposes plain text alongside an image, confirm that the text is editable, line breaks are preserved, and no image attachment appears. Send it and confirm it is submitted as text.
2. Paste a screenshot with no plain text. Confirm that it still becomes an image attachment.
3. Confirm that ordinary text paste and file upload/drop still work. On a touch device, mixed text/image paste should use native textarea insertion.

### Evidence (Before & After)

A DOM integration regression sends a synthetic clipboard containing multiline Chinese `text/plain` and an `image/png` file through the real React capture handler and mounted CodeMirror editor.

- Before: the editor remained empty and one image attachment appeared; the regression failed.
- After: the exact multiline text is present and submitted without image/file payloads; the regression passes. Mobile coverage verifies that mixed text/image paste is not intercepted and image-only paste still adds an attachment.
- All 145 focused tests pass. Full build, bundle, repository typecheck, and ESLint/Prettier checks for changed files pass.

### Tested on

| OS | Status |
| :-- | :-- |
| 🍏 macOS | ✅ DOM regression tests and build checks |
| 🪟 Windows | ⚠️ Not tested |
| 🐧 Linux | ⚠️ Not tested |

### Environment (optional)

Node.js 22.14.0; local source tested with Vitest/jsdom. The worktree's development daemon and Vite UI were also started successfully, then stopped. Native PowerPoint-to-browser paste was not independently verified.

## Risk & Scope

- Main risk or tradeoff: mixed clipboard payloads now prefer any nonempty plain text over their image/file representation; users intending to paste an image should use an image-only clipboard or the attachment flow.
- Not validated / out of scope: actual PowerPoint clipboard formats on the reporting device, native mobile paste, and HTML-only clipboard conversion.
- Breaking changes / migration notes: no API or configuration changes; no migration required.

## Linked Issues

User-reported issue; no linked GitHub issue.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

当粘贴的剪贴板同时包含图片或文件和非空纯文本时，Web Shell 优先使用纯文本。桌面端沿用现有编辑器完成文字插入和提交，移动端由原生 textarea 完成插入。纯图片粘贴、文件上传和拖放保持现有行为。

## 为什么需要

用户反馈：从 PowerPoint 复制的文字粘贴到 Data Agent 后变成了图片，而相同内容粘贴到 qoderwork 和 Codex 时是可编辑文字。富内容剪贴板可以同时提供同一选区的纯文本和图片表示。

此前，Web Shell 在事件捕获阶段只要发现剪贴板图片或文件，就接管粘贴、阻止默认行为并停止事件传播。当两种表示同时存在时，编辑器无法收到已经存在的文字，图片反而进入附件队列。因此，Agent 收到的是图片，而不是用户打算引用或改写的文字。

修复后，只要存在非空 `text/plain`，粘贴事件就继续交给编辑器处理。通过桌面端和移动端共用的粘贴入口保留原始文字，避免生成多余附件。

## 审阅者测试计划

### 如何验证

1. 从 PowerPoint 复制一段多行文字，粘贴到 Web Shell 对话输入框。如果剪贴板同时提供纯文本和图片，应看到可编辑文字，换行保留，没有图片附件。发送后确认内容以文字提交。
2. 粘贴不含纯文本的截图，确认仍生成图片附件。
3. 确认普通文字粘贴、文件上传和拖放正常。触屏设备上，文字和图片混合的粘贴应交给原生 textarea 插入。

### 修复前后证据

DOM 集成回归测试构造同时包含多行中文 `text/plain` 和 `image/png` 文件的剪贴板，通过真实 React 捕获处理器和挂载的 CodeMirror 编辑器触发粘贴。

- 修复前：编辑器为空，出现一个图片附件，回归测试失败。
- 修复后：完整多行文字进入输入框，并以不含图片或文件载荷的形式提交，回归测试通过。移动端覆盖验证混合文字/图片粘贴不被拦截，纯图片粘贴仍生成附件。
- 145 项相关测试全部通过。全量构建、打包、仓库类型检查，以及改动文件的 ESLint/Prettier 检查均通过。

### 测试平台

| 操作系统 | 状态 |
| :-- | :-- |
| 🍏 macOS | ✅ DOM 回归测试和构建检查 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境

Node.js 22.14.0；使用 Vitest/jsdom 验证本地源码。此 worktree 的开发 daemon 和 Vite 界面也已成功启动并随后停止。尚未独立验证 PowerPoint 到浏览器的原生粘贴。

## 风险与范围

- 主要风险或取舍：混合剪贴板现在优先使用任何非空纯文本，而非其中的图片或文件表示；如果希望粘贴图片，应使用纯图片剪贴板或附件功能。
- 尚未验证或不在范围内：用户设备上的实际 PowerPoint 剪贴板格式、移动端原生粘贴，以及仅含 HTML 的剪贴板转换。
- 破坏性变更或迁移：没有 API 或配置变更，无需迁移。

## 关联 Issue

来自用户反馈，没有关联的 GitHub issue。

</details>
