### PR TITLE
fix(web-shell): stop surfacing SSE backpressure warning in transcript

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -190,13 +190,17 @@ export function normalizeDaemonEvent(
         },
       ];
     case 'slow_client_warning':
-      return [
-        {
-          ...base,
-          type: 'status',
-          text: 'SSE stream is lagging',
-        },
-      ];
+      // The daemon reports this SSE subscriber's queue backing up — a
+      // transport diagnostic, not a user-facing failure. Surfacing it as a
+      // transcript status reads as a broken connection mid-turn, so log the
+      // queue watermarks to the console instead; `client_evicted` remains the
+      // real disconnect signal and flows through its own error path. Fires at
+      // most once per overflow episode (daemon-side hysteresis).
+      if (typeof console !== 'undefined') {
+        // eslint-disable-next-line no-console -- intentional diagnostic for subscriber backpressure
+        console.warn?.('[daemon-ui] SSE stream is lagging', event.data);
+      }
+      return [];
     case 'stream_error': {
       const errorKind = asDaemonErrorKind(getString(event.data, 'errorKind'));
       return [

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -2436,14 +2436,23 @@ describe('daemon UI normalizer and transcript reducer', () => {
         data: { reason: 'slow' },
       }),
     ).toMatchObject([{ type: 'error', recoverable: true, text: 'slow' }]);
-    expect(
-      normalizeDaemonEvent({
-        id: 54,
-        v: 1,
-        type: 'slow_client_warning',
-        data: {},
-      }),
-    ).toMatchObject([{ type: 'status', text: 'SSE stream is lagging' }]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      expect(
+        normalizeDaemonEvent({
+          id: 54,
+          v: 1,
+          type: 'slow_client_warning',
+          data: { queueSize: 200, maxQueued: 256 },
+        }),
+      ).toEqual([]);
+      expect(warn).toHaveBeenCalledWith('[daemon-ui] SSE stream is lagging', {
+        queueSize: 200,
+        maxQueued: 256,
+      });
+    } finally {
+      warn.mockRestore();
+    }
     expect(
       normalizeDaemonEvent({
         id: 55,


### PR DESCRIPTION
## What this PR does

The Web Shell used to render a "SSE stream is lagging" status line into the chat whenever the daemon reported that this SSE subscriber's event queue was backing up. That frame is a transport-level diagnostic about the subscriber's own consumption speed — not a user-visible failure. This PR stops injecting it into the transcript and instead logs it to the browser console with the queue watermarks, so a conversation keeps a clean transcript while the agent is working.

## Why it's needed

During long tool calls the daemon can briefly produce events faster than the browser drains them, which queues events and trips the daemon's per-subscriber backpressure warning (75% of the queue cap, re-armed only after a 37.5% drain). Users read the resulting chat line as a broken connection mid-turn and refreshed or abandoned sessions while the agent was actually running normally. The real disconnect signal (`client_evicted`) keeps its own error path with the existing auto-reconnect and resync, and daemon-side counters plus telemetry are untouched, so no diagnostic capability is lost by removing the chat line.

## Reviewer Test Plan

### How to verify

Unit: from `packages/sdk-typescript`, run `env -u QWEN_SERVE_MCP_BUDGET_MODE -u QWEN_SERVE_MCP_CLIENT_BUDGET npx vitest run test/unit/daemonUi.test.ts`. The updated case asserts the normalizer returns no block for `slow_client_warning` and emits one `console.warn` carrying the queue watermarks.

Manual: make an SSE client consume slowly (network throttle or a paused main thread) until the daemon emits `slow_client_warning`. Expected: the chat transcript shows nothing (no "SSE stream is lagging"); the DevTools console shows at most one `[daemon-ui] SSE stream is lagging` warning per overflow episode, with `queueSize`/`maxQueued` in the payload. Reconnect behavior after a real eviction is unchanged.

### Evidence (Before & After)

Before: the transcript displayed a status line "SSE stream is lagging" mid-turn. After: no transcript entry appears; the event is logged to the console with its queue watermarks. This change was verified at the unit level in this environment (assertions above); no end-to-end run against a live daemon was performed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only: fresh `npm ci` in a dedicated worktree, vitest, repo-wide `npm run typecheck`, prettier and eslint clean on the touched files.

## Risk & Scope

- Main risk or tradeoff: removing the only in-UI heads-up that eviction may follow. Accepted because end users cannot act on it, eviction still auto-recovers through the existing reconnect + cursor resync path, and the diagnostic remains available in the console, in daemon logs, and in the SDK view-state counters.
- Not validated / out of scope: no end-to-end run against a real daemon; tuning why a subscriber's queue backs up (event bursts, transport throughput) is a separate concern.
- Breaking changes / migration notes: none. The daemon frame is still recognized and counted; only the transcript rendering is removed.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

此前 Web Shell 只要收到 daemon 关于「当前 SSE 订阅者的事件队列积压」的帧，就会在对话里渲染一条 "SSE stream is lagging" 状态行。该帧本质是传输层针对订阅者自身消费速度的诊断，并非用户可见的故障。本 PR 不再把它注入对话流，改为在浏览器控制台打印一条带队列水位的警告，使 Agent 正常工作时对话保持干净。

## 为什么需要

长工具调用期间，daemon 可能短暂地比浏览器消费得更快，事件排队后会触发 daemon 的订阅者级背压告警（达到队列上限的 75%，须排空到 37.5% 才会重新触发）。用户把对话里出现的这行文字读成「连接中途断了」，在 Agent 实际正常运行时刷新甚至放弃会话。真正的断连信号（client_evicted）仍走它自己的错误路径与既有的自动重连、续传机制；daemon 侧计数与遥测均未改动，移除对话行不损失任何诊断能力。

## Reviewer 验证计划

### 如何验证

单元：在 `packages/sdk-typescript` 下执行 `env -u QWEN_SERVE_MCP_BUDGET_MODE -u QWEN_SERVE_MCP_CLIENT_BUDGET npx vitest run test/unit/daemonUi.test.ts`。更新后的用例断言：normalizer 对 `slow_client_warning` 返回空（不产出块），并恰好打印一条携带队列水位的 `console.warn`。

手工：让 SSE 客户端慢速消费（网络限速或暂停主线程），直到 daemon 发出 `slow_client_warning`。预期：对话流中不出现任何内容（无 "SSE stream is lagging"）；DevTools 控制台在每个积压期内至多出现一条 `[daemon-ui] SSE stream is lagging` 警告，载荷含 `queueSize`/`maxQueued`。真正被踢后的重连行为不变。

### 验证证据（Before & After）

Before：对话中途显示状态行 "SSE stream is lagging"。After：对话流不再出现该条目；事件改为携带水位写入控制台。本环境内以单元层验证为准（见上方断言），未对真实 daemon 做端到端运行。

### 测试平台

macOS 已测；Windows / Linux 未测。

### 运行环境

仅单元测试：独立 worktree 内全新 `npm ci`、vitest、全仓 `npm run typecheck`，改动文件 prettier 与 eslint 干净。

## 风险与范围

- 主要风险/取舍：移除了 UI 上唯一的「即将被踢」预告。可接受：端用户无法据此处置；被踢后仍走既有重连 + 游标续传自动恢复；诊断仍保留在控制台、daemon 日志与 SDK 视图状态计数中。
- 未验证/不在范围：未对真实 daemon 做端到端验证；「订阅者队列为何积压」（事件突发、传输吞吐）属另一议题。
- 破坏性变更/迁移：无。daemon 帧仍被识别与计数，仅移除对话渲染。

## 关联项

N/A

</details>
