### PR TITLE
fix(rewind): close the review findings left open when #10959 merged

### DIFF
--- a/packages/cli/src/ui/opentui/session-rewind-model.ts
+++ b/packages/cli/src/ui/opentui/session-rewind-model.ts
@@ -45,6 +45,16 @@ export function rewindableTurns(turns: readonly RewindTurn[]): RewindTurn[] {
  * decorations (attachment suffixes, compression) cannot break the match.
  * Returns -1 when the history holds fewer real user prompts than
  * requested (e.g. the turn was absorbed by chat compression).
+ *
+ * Near-twin of core's `findApiRewindCutPoint`, with a deliberately different
+ * degenerate contract: this walk is 1-based and returns -1 for
+ * `occurrence <= 0`, where the core walk is 0-based and returns the end of
+ * the startup context for `turnIndex <= 0`. The two agree on the first turn
+ * only because nothing sits between the startup prelude and the first user
+ * prompt today. Any change to the walk semantics — `includeCompressed`, a
+ * new structural entry kind to skip, the -1 convention — must be made in
+ * both, or OpenTUI rewind computes a different boundary than ACP for the
+ * same history.
  */
 export function rewindApiCutPoint(
   apiHistory: Content[],

--- a/packages/cli/src/ui/utils/historyMapping.ts
+++ b/packages/cli/src/ui/utils/historyMapping.ts
@@ -15,10 +15,13 @@ import {
 import { isSlashCommand } from './commandUtils.js';
 
 /**
- * TUI rewind's binding of the shared user-prompt classifier. Exported so the
- * OpenTUI parity path counts prompts under the exact same rule.
+ * TUI rewind's binding of the shared user-prompt classifier. Deliberately
+ * module-private: `isUserTextContent` below is the only door to this rule, and
+ * the OpenTUI parity path reaches it by importing that function. Exporting the
+ * options would let a caller compose `isApiUserPrompt(x, …)` directly and
+ * re-create the per-surface twin this consolidation removes.
  */
-export const TUI_API_USER_PROMPT_OPTIONS: ApiUserPromptOptions = {
+const TUI_API_USER_PROMPT_OPTIONS: ApiUserPromptOptions = {
   excludeClearedMediaPlaceholders: true,
 };
 
@@ -53,9 +56,9 @@ export function isRealUserTurn(
  * a visible user turn, so counting it would desynchronize the API prompt
  * count from the UI turn count and truncate one turn early. See
  * `ApiUserPromptOptions` in core for why that exclusion is an option rather
- * than part of the shared rule (ACP must keep those entries counted), and for
- * the exact-match collision this leaves behind — which is what prompt
- * identity resolves.
+ * than part of the shared rule — ACP must keep those entries counted — and
+ * for the exact-match collision it leaves behind, which remains an open
+ * limitation pinned by the tests in this file's suite.
  */
 export function isUserTextContent(content: Content): boolean {
   return isApiUserPrompt(content, TUI_API_USER_PROMPT_OPTIONS);

--- a/packages/core/src/services/api-user-prompt.test.ts
+++ b/packages/core/src/services/api-user-prompt.test.ts
@@ -33,6 +33,23 @@ const toolResult = (): Content => ({
   parts: [{ functionResponse: { name: 'x', response: { output: 'ok' } } }],
 });
 
+/**
+ * A summarizing-compressed session's prefix, matching
+ * `detectCompressedPrefixLength`'s exact sentinels: the reminder prelude, a
+ * user entry whose text contains 'Resume the prior task', and a model ack
+ * whose first part is exactly 'Got it. Thanks for the additional context!'.
+ * Both walks skip it via `includeCompressed: true`; without that flag the
+ * synthetic summary entry counts as a real prompt and every ordinal shifts.
+ */
+const compressedPrefix = (): Content[] => [
+  reminder('startup'),
+  user('<summary>…</summary>\nResume the prior task from where it left off.'),
+  {
+    role: 'model',
+    parts: [{ text: 'Got it. Thanks for the additional context!' }],
+  },
+];
+
 const CLEARED_MEDIA = '[Old inline media cleared: image/png]';
 const TODO_GUARD = '[Todo Stop Guard] continue';
 const isTodoGuard = (text: string) => text.startsWith('[Todo Stop Guard] ');
@@ -151,6 +168,15 @@ describe('findApiRewindCutPoint', () => {
     expect(findApiRewindCutPoint(withTools, 1)).toBe(4);
   });
 
+  it('skips a summarizing-compressed prefix', () => {
+    // The compressed prefix ends at index 3, so the only real prompt is the
+    // one after it. Dropping `includeCompressed: true` counts the synthetic
+    // summary entry too and returns 1 here instead of 3.
+    const history: Content[] = [...compressedPrefix(), user('real prompt')];
+    expect(findApiRewindCutPoint(history, 0)).toBe(3);
+    expect(findApiRewindCutPoint(history, 1)).toBe(-1);
+  });
+
   it('shifts the boundary when the two bindings disagree', () => {
     // The same history yields different cut points under the TUI and ACP
     // bindings — which is why the divergence is an explicit option instead
@@ -183,6 +209,14 @@ describe('countApiUserPrompts', () => {
     ];
     expect(countApiUserPrompts(history)).toBe(2);
     expect(countApiUserPrompts([])).toBe(0);
+  });
+
+  it('does not count a summarizing-compressed prefix as a prompt', () => {
+    // Same guard on the counting side: without `includeCompressed: true` the
+    // synthetic summary entry counts and this returns 2.
+    expect(
+      countApiUserPrompts([...compressedPrefix(), user('real prompt')]),
+    ).toBe(1);
   });
 
   it('honours the binding options', () => {

--- a/packages/core/src/services/api-user-prompt.ts
+++ b/packages/core/src/services/api-user-prompt.ts
@@ -43,8 +43,10 @@ export interface ApiUserPromptOptions {
    * Matching is on the FULL generated placeholder shape, so a genuine prompt
    * that merely begins with the prefix keeps counting. A prompt whose entire
    * text equals a generated placeholder is indistinguishable from a cleared
-   * entry once serialized; resolving that collision is what prompt identity
-   * (`findApiHistoryPromptIndex`) is for.
+   * entry once serialized, and this classifier drops it — a known, still-open
+   * limitation, pinned as a loud rewind block by `historyMapping.test.ts`.
+   * Disambiguating it durably needs a structural sentinel on cleared parts;
+   * the prompt-identity anchoring tracked in #9437 is the intended fix.
    */
   excludeClearedMediaPlaceholders?: boolean;
 
@@ -112,6 +114,20 @@ export function isApiUserPrompt(
  * first turn keeps only the prelude. Returns -1 when the history holds fewer
  * user prompts than requested, e.g. the target turn was absorbed by chat
  * compression.
+ *
+ * Two CLI-side walks are not yet delegated here and are near-twins of this
+ * one, so a change to the walk semantics below — `includeCompressed`, a new
+ * structural entry kind to skip, the -1 convention — has to be re-applied to
+ * both or ink/OpenTUI rewind computes a different boundary than ACP for the
+ * same history:
+ *
+ * - `computeApiTruncationIndex` (`ui/utils/historyMapping.ts`) walks UI items
+ *   alongside the API history, so it cannot call this directly.
+ * - `rewindApiCutPoint` (`ui/opentui/session-rewind-model.ts`) is 1-based and
+ *   returns -1 for `occurrence <= 0`, where this function is 0-based and
+ *   returns `startIndex` for `turnIndex <= 0`. They agree on the first turn
+ *   only because nothing sits between the startup prelude and the first user
+ *   prompt today.
  */
 export function findApiRewindCutPoint(
   apiHistory: Content[],


### PR DESCRIPTION
## What this PR does

Closes the four Suggestion-level review findings that were still open when #10959
merged. All four are confirmed live on `main` at the time of writing.

| # | finding | fix |
| --- | --- | --- |
| 1 | `TUI_API_USER_PROMPT_OPTIONS` exported with zero importers | made module-private, comment corrected |
| 2 | comments cite `findApiHistoryPromptIndex`, which does not exist on `main` | reworded to describe the real, still-open limitation |
| 3 | three hand-maintained positional walks, differing degenerate contracts | cross-references on both sides naming the difference and the drift risk |
| 4 | `includeCompressed: true` pinned by no test | compressed-prefix fixture, mutation-verified |

## Why it's needed

**1 — the dead export is a second door to the rule.** Nothing outside
`historyMapping.ts` imports `TUI_API_USER_PROMPT_OPTIONS`; OpenTUI reaches the same
rule by importing the bound `isUserTextContent`. So the comment's justification
("exported so the OpenTUI parity path counts prompts under the exact same rule") names
a consumer that does not read it, which misdirects impact analysis — and the export is
exactly what a future OpenTUI change would compose directly to re-create the
per-surface twin #10959 set out to remove.

**2 — the pointer dead-ends.** `findApiHistoryPromptIndex` belongs to the identity
work in #9466; on `main` a repo-wide sweep matches it once, in the comment itself. The
comment #10959 *deleted* had documented the placeholder collision as a known
unresolved limitation; the replacement implies it is resolved. A maintainer debugging
the documented failure mode — a genuine prompt whose entire text equals a generated
`[Old inline media cleared: …]` placeholder, which the TUI binding miscounts, aborting
rewinds with "Cannot rewind to a turn that was compressed" — greps for the named
resolver and finds nothing.

**3 — the classifier is unified, the walks are not.** `rewindApiCutPoint` (OpenTUI)
and the counting loop in `computeApiTruncationIndex` (ink) remain near-twins of core's
`findApiRewindCutPoint`, with divergent conventions: `rewindApiCutPoint` is 1-based and
returns -1 for `occurrence <= 0`; `findApiRewindCutPoint` is 0-based and returns
`startIndex` for `turnIndex <= 0`. They agree on the first turn today only because
nothing sits between the startup prelude and the first user prompt.

This PR does **not** delegate them, deliberately. Delegating `rewindApiCutPoint` would
change `rewindApiCutPoint([], 1)` from -1 to 0 — a behavior change on a function with
no production caller, in a follow-up whose job is to close doc/test gaps. And
`computeApiTruncationIndex` cannot delegate at all: it walks UI items alongside the API
history. Both sides now carry the warning instead, so a future change to walk semantics
(`includeCompressed`, a new structural entry kind, the -1 convention) cannot be made in
one place without seeing the other two. If the walks should be fully collapsed, the
right move is to change `rewindApiCutPoint`'s degenerate contract deliberately, in its
own PR.

**4 — the `includeCompressed` wiring was untested.** Every summarizing-compressed
session carries the prefix shape, and if a later edit drops or flips the flag in either
function, the synthetic summary user entry counts as a real prompt: every rewind
ordinal shifts by one, so `rewindToTurn` truncates one turn early and silently drops a
turn the client expected to keep. Credit to the reviewer for running the mutant that
proved the gap.

## Reviewer Test Plan

### How to verify

1. `vitest run packages/core/src/services/api-user-prompt.test.ts` — 17 pass.
2. Mutate: flip `includeCompressed: true` → `false` in **both** functions in
   `api-user-prompt.ts`. Exactly the two new tests must go red; the other 15 stay
   green. Revert.
3. `grep -rn TUI_API_USER_PROMPT_OPTIONS packages/` — 2 matches, both in
   `historyMapping.ts`, 0 imports.
4. `grep -rn findApiHistoryPromptIndex packages/` — 0 matches.

The fixture must match `detectCompressedPrefixLength`'s exact sentinels
(`environmentContext.ts`): a user entry whose text contains `Resume the prior task`,
followed by a model entry whose first part is exactly
`Got it. Thanks for the additional context!`. Anything else and the prefix is not
detected and the fixture pins nothing.

### Evidence

```
intact:  Test Files 1 passed | Tests 17 passed (17)
mutant:  Tests 2 failed | 15 passed (17)
         × findApiRewindCutPoint > skips a summarizing-compressed prefix
         × countApiUserPrompts > does not count a summarizing-compressed prefix as a prompt
```

Run on named files only; typecheck and build were not run locally and are CI's to
confirm. Prettier and ESLint clean on all four touched files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🐧 Linux  |   ✅   |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: three of the four changes are comments and one narrowed
  visibility; the only executable change is two added tests. Lowest-risk shape
  available for closing these.
- Not validated / out of scope: the walk consolidation itself (finding 3) is documented
  rather than performed, for the contract reason above.
- Breaking changes / migration notes: none. `TUI_API_USER_PROMPT_OPTIONS` loses its
  `export`, which no code imported.

## Linked Issues

Refs #9437, #10959

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

关闭 #10959 合入时仍未处理的 4 条建议级评审发现，4 条在当前 `main` 上都仍然存在。

1. **`TUI_API_USER_PROMPT_OPTIONS` 是无人导入的导出。** OpenTUI 是通过绑定函数 `isUserTextContent` 复用该规则的，注释里"为了让 OpenTUI 按同一规则计数才导出"的理由指向了一个并不读取它的消费者，会误导影响面分析；而这个导出正是未来 OpenTUI 改动可能直接组合、从而重新制造出 #10959 要消除的按入口分叉双胞胎的那扇"第二扇门"。改为模块私有，注释改写。
2. **注释引用了 `findApiHistoryPromptIndex`，但该符号在 `main` 上不存在**（属于 #9466 的身份工作），全仓库只命中注释自身。#10959 删掉的旧注释原本把占位符碰撞记录为"已知未解决限制"，替换后的措辞却暗示已解决——维护者按图索骥会查无此符号。改为陈述真实情况：仍是已知限制、由测试钉成响亮的 rewind 阻断、durable 修复需要在被清空的 part 上加结构化哨兵、#9437 是既定方向。
3. **分类器统一了，位置遍历没有。** OpenTUI 的 `rewindApiCutPoint` 与 ink 的 `computeApiTruncationIndex` 计数循环仍是 core `findApiRewindCutPoint` 的手工孪生，且退化契约不同（1-based/`occurrence <= 0` 返回 -1，vs 0-based/`turnIndex <= 0` 返回 `startIndex`）。本 PR **有意不做**委托：委托会把 `rewindApiCutPoint([], 1)` 从 -1 变成 0，是在一个只负责补文档与测试的跟进 PR 里改行为；而 `computeApiTruncationIndex` 因为要与 UI 条目并行遍历，根本无法委托。改为两侧都加交叉引用，写明约定差异与漂移风险。
4. **`includeCompressed: true` 没有任何测试钉住。** 评审跑的变异证明：去掉它，15 个既有测试仍全绿，但压缩会话中合成 summary 条目会被当作真实提示词，每个 rewind 序号偏移一位，`rewindToTurn` 会提前一轮截断、静默丢掉客户端预期保留的轮次。已补上匹配 `detectCompressedPrefixLength` 精确哨兵的 fixture。

## 验证

变异验证：完整 17/17 通过；翻转 `includeCompressed` 后恰好新增的 2 条变红（2 failed | 15 passed）。本地只跑了具名测试文件；typecheck 与 build 未在本地执行，交由 CI。Prettier 与 ESLint 干净。

## 风险与范围

- 4 项中 3 项是注释、1 项是收窄可见性，唯一的可执行改动是新增两条测试——关闭这些发现的最低风险形态。
- 范围外：发现 3 的遍历合并是"记录"而非"执行"，理由见上。
- 破坏性变更：无。`TUI_API_USER_PROMPT_OPTIONS` 去掉了 `export`，没有任何代码导入它。

</details>

https://claude.ai/code/session_01NcCCaJ7heyd7kSupskeTC3
