### PR TITLE
chore(core): format the one file the prettier check lane still rejects

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -3394,17 +3394,15 @@ describe('AnthropicContentGenerator', () => {
         const client = new ActualAnthropic({
           apiKey: 'test-key',
           maxRetries: 0,
-          fetch: vi
-            .fn()
-            .mockResolvedValue(
-              new Response(
-                `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type, message } })}\n\n`,
-                {
-                  status: 200,
-                  headers: { 'content-type': 'text/event-stream' },
-                },
-              ),
+          fetch: vi.fn().mockResolvedValue(
+            new Response(
+              `event: error\ndata: ${JSON.stringify({ type: 'error', error: { type, message } })}\n\n`,
+              {
+                status: 200,
+                headers: { 'content-type': 'text/event-stream' },
+              },
             ),
+          ),
         });
         const stream = await client.messages.create({
           model: 'test-model',


### PR DESCRIPTION
## What this PR does

Runs the formatter over the single file in the repository that the Prettier check still rejects. Eight lines added, ten removed, all of it one member chain reflowed — no expression changes.

## Why it's needed

The Prettier lane ran `--write` for most of its life. As the comment above it in the lint script records, `--write` exits 0 whether or not anything changed and no caller inspected the tree afterwards, so the lane reported a pass on unformatted code and CI discarded the rewrites when the job ended. It now runs `--check`, which surfaces whatever merged under the old behaviour.

This file is the only remaining violation repo-wide. The offending construct is a `fetch: vi.fn().mockResolvedValue(new Response(...))` chain in the Anthropic SSE error test, added by #11216, whose own `Lint & Static` job passed because the lane was still writing rather than checking at that point. Blame puts every one of those lines on that commit, and the file is byte-identical between it and current main, so this is pre-existing formatting debt rather than anything a later change introduced.

The practical effect today is that any PR running the full CI profile against a tree containing this file fails `Lint & Static` for a reason that has nothing to do with its own diff.

## Reviewer Test Plan

### How to verify

Run the same command the CI lane runs, from the repository root:

```
node scripts/lint.js --prettier
```

Before this change it exits 1 naming `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts`; after, it reports `All matched files use Prettier code style!` and exits 0. Confirming the change is formatting-only needs no test run, but the reformatted file's own suite was run anyway and is green.

### Evidence (Before & After)

N/A — no UI or TUI surface.

Before:

```
[warn] packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
[warn] Code style issues found in 1 file. Run Prettier with --write to fix.
exit 1
```

After:

```
All matched files use Prettier code style!
exit 0
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local, on macOS: the CI lint command repo-wide before and after, ESLint on the changed file, and that file's own vitest suite (172 tests). Prettier 3.6.1, matching the lockfile, so the local verdict and CI's agree.

## Risk & Scope

- Main risk or tradeoff: none. Prettier preserves semantics, the diff is one call chain, and the file's tests pass unchanged.
- Not validated / out of scope: nothing. A repo-wide check confirms this was the only violation, so the lane should stay green after this lands.
- Breaking changes / migration notes: none.

## Linked Issues

None. Found while diagnosing a `Lint & Static` failure on #11291 that turned out to be inherited from main rather than caused by it.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对仓库里唯一一个仍被 Prettier 检查拒绝的文件跑一遍格式化。新增 8 行、删除 10 行，全部是一条成员链的重排——没有任何表达式改动。

## 为什么需要

Prettier 这条 lane 在其生命周期的大部分时间里跑的是 `--write`。正如 lint 脚本里它上方那段注释所记录的：`--write` 无论是否真的改动都退出 0，且没有任何调用方在事后检查工作树，于是这条 lane 会在未格式化的代码上报告通过，而 CI 在 job 结束时把重写结果丢弃。它现在跑的是 `--check`，这就把旧行为下混进来的东西暴露了出来。

这个文件是全仓唯一残留的违规处。出问题的构造是 Anthropic SSE 错误测试里的 `fetch: vi.fn().mockResolvedValue(new Response(...))` 链，由 #11216 引入；那个 PR 自己的 `Lint & Static` job 是通过的，因为当时这条 lane 仍在写而不是在检查。blame 把每一行都归到该提交，且该文件在它与当前 main 之间逐字节相同，所以这是既有的格式欠账，而不是后续某次改动引入的。

它今天的实际影响是：任何针对包含此文件的代码树运行完整 CI profile 的 PR，都会因为与自身 diff 毫无关系的原因而让 `Lint & Static` 变红。

## 审阅测试计划

### 如何验证

在仓库根目录运行 CI lane 所用的同一条命令：

```
node scripts/lint.js --prettier
```

改动前它以 1 退出并指名 `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts`；改动后报告 `All matched files use Prettier code style!` 并以 0 退出。确认改动纯属格式化并不需要跑测试，但仍然跑了被格式化文件自己的套件，结果全绿。

### 前后对比证据

N/A——不涉及 UI 或 TUI 界面。

改动前：

```
[warn] packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
[warn] Code style issues found in 1 file. Run Prettier with --write to fix.
exit 1
```

改动后：

```
All matched files use Prettier code style!
exit 0
```

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地 macOS：改动前后各跑一次全仓 CI lint 命令、对改动文件跑 ESLint、并跑该文件自己的 vitest 套件（172 条）。Prettier 为 3.6.1，与 lockfile 一致，因此本地结论与 CI 一致。

## 风险与范围

- 主要风险或取舍：无。Prettier 保持语义不变，diff 只有一条调用链，且该文件的测试照常通过。
- 未验证 / 不在范围内：无。全仓检查确认这是唯一违规处，因此这条 lane 在本 PR 合入后应保持绿色。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。是在排查 #11291 上那个 `Lint & Static` 失败时发现的，最终查明它是从 main 继承来的，而非该 PR 自身造成。

</details>
