### PR TITLE
fix(web-shell): gate todo progress interaction

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -9901,6 +9901,7 @@ describe('App plan todos', () => {
   });
 
   it('refreshes dependencies when only blockedBy changes', async () => {
+    testState.settings = [sessionWorkflowSetting()];
     testState.messages = [
       {
         id: 'plan',
@@ -10072,11 +10073,21 @@ describe('App plan todos', () => {
     const { container, rerender } = renderApp();
     await flush();
 
-    expect(testState.latestTodoPanelOnOpen).not.toBeNull();
+    expect(testState.latestTodoPanelTodos.map((todo) => todo.id)).toEqual([
+      'prepare',
+      'work',
+    ]);
+    expect(testState.latestTodoPanelOnOpen).toBeNull();
 
     testState.settings = [sessionWorkflowSetting()];
     rerender();
     await flush();
+
+    expect(testState.latestTodoPanelTodos.map((todo) => todo.id)).toEqual([
+      'prepare',
+      'work',
+    ]);
+    expect(testState.latestTodoPanelOnOpen).not.toBeNull();
 
     await act(async () => {
       testState.latestTodoPanelOnOpen?.();
@@ -10757,7 +10768,7 @@ describe('App session workflow', () => {
     ).not.toBeNull();
   });
 
-  it('keeps the tasks dialog plain when Session Workflow is off', async () => {
+  it('keeps Todo progress non-interactive when Session Workflow is off', async () => {
     testState.messages = [
       {
         id: 'plan',
@@ -10780,18 +10791,11 @@ describe('App session workflow', () => {
     const { container } = renderApp();
     await flush();
 
-    await act(async () => {
-      testState.latestTodoPanelOnOpen?.();
-      await Promise.resolve();
-    });
-
-    expect(testState.latestTasksStatusProps?.planTodos).toEqual([]);
-    expect(testState.latestTasksStatusProps?.agentTools).toEqual([]);
-    expect(
-      container
-        .querySelector('[data-testid="dialog-shell"]')
-        ?.getAttribute('data-dialog-title'),
-    ).toBe('Background tasks');
+    expect(testState.latestTodoPanelTodos.map((todo) => todo.id)).toEqual([
+      'work',
+    ]);
+    expect(testState.latestTodoPanelOnOpen).toBeNull();
+    expect(container.querySelector('[data-testid="dialog-shell"]')).toBeNull();
   });
 
   it('keeps workflow agent tools mounted behind the tasks dialog', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -17998,7 +17998,7 @@ export function App({
                               sessionActiveWorkState === 'active'
                             }
                             onOpen={
-                              showFloatingTodos
+                              sessionWorkflowEnabled && showFloatingTodos
                                 ? floatingTodosUseSessionWorkflow
                                   ? openWorkflowInspector
                                   : openTasksPanel


### PR DESCRIPTION
## What this PR does

Keeps the floating Todo progress indicator visible but non-interactive while the experimental Session Workflow setting is disabled. When the setting is enabled, Workflow-backed Todos still open the Workflow inspector and ordinary Todos still open task details.

## Why it's needed

The progress indicator currently opens an empty Background tasks dialog even though the experiment that owns this workflow surface is disabled. It should continue showing progress without opening a detail surface until the experiment is enabled.

## Reviewer Test Plan

### How to verify

1. Leave Session Workflow disabled and start a task that produces an in-progress Todo list. Confirm the floating progress indicator remains visible and clicking it opens no dialog.
2. Enable Session Workflow and confirm a Workflow-backed Todo opens the Workflow inspector.
3. With Session Workflow enabled, confirm an ordinary Todo still opens Plan & tasks.

### Evidence (Before & After)

- Before: clicking Todo progress with Session Workflow disabled opens an empty Background tasks dialog.
- After: the progress indicator remains visible but has no click action while the setting is disabled; enabled routes are unchanged.
- Automated verification: Web Shell App tests passed 790/790; focused behavior tests passed 4/4; browser verification passed 3/3; repository build, typecheck, and changed-file lint and formatting checks passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Web Shell unit-test and production-build environment.

## Risk & Scope

- Main risk or tradeoff: users can no longer use the floating Todo progress indicator as a shortcut to Background tasks while Session Workflow is disabled; its progress display and the dedicated Background tasks entry remain unchanged.
- Not validated / out of scope: browser-level visual verification on Windows and Linux.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当实验性的 Session Workflow 设置关闭时，悬浮 Todo 进度指示器继续显示，但不可交互。设置开启后，Workflow 类型的 Todo 仍会打开 Workflow 检查器，普通 Todo 仍会打开任务详情。

## 为什么需要

当前即使负责该工作流界面的实验功能已经关闭，点击进度指示器仍会打开一个空的“后台任务”弹框。实验功能开启前，指示器应继续展示进度，但不应打开详情界面。

## Reviewer 测试计划

### 验证方式

1. 保持 Session Workflow 关闭，启动一个会生成进行中 Todo 列表的任务。确认悬浮进度指示器仍然显示，但点击不会打开弹框。
2. 开启 Session Workflow，确认 Workflow 类型的 Todo 会打开 Workflow 检查器。
3. 在 Session Workflow 开启时，确认普通 Todo 仍会打开“计划与任务”。

### 证据（修改前后）

- 修改前：Session Workflow 关闭时，点击 Todo 进度会打开一个空的“后台任务”弹框。
- 修改后：设置关闭时进度指示器仍然显示，但没有点击行为；开启后的路由行为保持不变。
- 自动化验证：Web Shell App 测试 790/790 通过；聚焦行为测试 4/4 通过；浏览器验证 3/3 通过；仓库构建、类型检查，以及改动文件的 lint 和格式检查均通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 Web Shell 单元测试和生产构建环境。

## 风险与范围

- 主要风险或权衡：Session Workflow 关闭时，用户不能再通过悬浮 Todo 进度指示器跳转到“后台任务”；进度展示和专门的“后台任务”入口不受影响。
- 未验证 / 范围外：Windows 和 Linux 上的浏览器级视觉验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
