### PR TITLE
ci: fail Lint & Static when the base moved the lint gate

### DIFF
--- a/.github/scripts/check-lint-gate-freshness.mjs
+++ b/.github/scripts/check-lint-gate-freshness.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Fail a PR's Lint & Static lane when the base branch changed the lint gate
+ * after this branch last incorporated it.
+ *
+ * The lane checks out refs/pull/N/head — the branch alone, a deliberate
+ * trade-off recorded above the Checkout step in ci.yml (GitHub rebuilds the
+ * merge ref asynchronously and can serve it stale for minutes). A green run
+ * therefore proves "the branch passes the gate AS THE BRANCH DEFINES IT",
+ * not as the base defines it. When the base changes the gate between branch
+ * point and merge, the branch keeps validating with the old gate: #11117
+ * flipped the Prettier lane from --write to --check on main while #11216's
+ * branch still ran --write; its green was real, the merged tree was red,
+ * and every later full-profile PR failed lint for a reason outside its own
+ * diff (#11378 cleaned up). Nothing else catches this: main's ruleset
+ * requires reviews, not status checks, and the merge queue has been off
+ * since 2026-07-02.
+ *
+ * Gate-defining files only, deliberately NOT package.json /
+ * package-lock.json: at 50-100 merges a day a dependency bump lands almost
+ * daily, and forcing every in-flight PR to rebase behind one recreates the
+ * "require up-to-date branch" treadmill. A prettier/eslint version bump
+ * cannot sneak changed semantics past a branch either — both run repo-wide
+ * (`--check .`, `eslint .`), so the bumping PR must bring the whole tree
+ * under the new semantics in its own run. What can sneak is a change to
+ * how the gate RUNS (the lane definitions in lint.js, the configs they
+ * read, this check), which is exactly the list below. Rare enough — lint.js
+ * saw five commits in the months before this check — that an occasional
+ * "rebase, the gate moved" is cheap.
+ *
+ * Fail-open on API errors: with no required status checks this step is
+ * advisory by convention (red means do not merge), and a GitHub API
+ * brownout must not hold every PR hostage. The warning stays in the log.
+ *
+ * Cost: two API calls per gate file (latest base-side commit, then a
+ * containment compare). The per-file `commits?path=` lookup is exact where
+ * the alternative — scanning one swapped compare's file list — caps at 300
+ * files, and a branch a few days behind a repo merging 50-100 PRs a day
+ * blows past that, silently dropping gate files from the scan.
+ */
+import { execFile } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const GATE_FILES = [
+  'scripts/lint.js',
+  'eslint.config.js',
+  'eslint.legacy-filenames.mjs',
+  '.prettierrc.json',
+  '.prettierignore',
+  '.github/workflows/ci.yml',
+  // This check is itself part of the gate: a base-side change to it must
+  // not be validated by the branch's older copy.
+  '.github/scripts/check-lint-gate-freshness.mjs',
+];
+
+/**
+ * curl honours HTTPS_PROXY/NO_PROXY on the ECS runners' squid egress;
+ * node's global fetch does not (undici needs a ProxyAgent that builtins
+ * alone cannot construct). `-f` turns HTTP errors into a non-zero exit,
+ * which execFile rejects — the caller's fail-open catches both shapes.
+ */
+async function curlJson(path, token) {
+  try {
+    const { stdout } = await execFileAsync(
+      'curl',
+      [
+        '-sS',
+        '-fL',
+        '--max-time',
+        '30',
+        '-H',
+        `Authorization: Bearer ${token}`,
+        '-H',
+        'Accept: application/vnd.github+json',
+        '-H',
+        'X-GitHub-Api-Version: 2022-11-28',
+        `https://api.github.com${path}`,
+      ],
+      { maxBuffer: 16 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout);
+  } catch (error) {
+    // execFile's message embeds the full argv — including the bearer token.
+    // Actions masks the exact secret in logs, but a local run would print
+    // it, so rebuild the error from the exit code and curl's own stderr.
+    const stderr = String(error.stderr ?? '')
+      .trim()
+      .split('\n')
+      .pop();
+    throw new Error(
+      `GET ${path} failed (curl exit ${error.code ?? '?'})${stderr ? `: ${stderr}` : ''}`,
+    );
+  }
+}
+
+function firstLine(message) {
+  return message.split('\n', 1)[0];
+}
+
+/**
+ * Return the gate files whose latest base-side change this branch does not
+ * contain. `fetchJson(path)` is injected so tests never touch the network.
+ *
+ * Containment uses the swapped three-dot compare `S...head`: its status is
+ * "ahead"/"identical" exactly when S is an ancestor of (or equal to) head;
+ * "diverged"/"behind" mean the base's gate change never reached the branch.
+ */
+export async function findStaleGateFiles({
+  fetchJson,
+  repo,
+  baseRef,
+  headSha,
+  gateFiles = GATE_FILES,
+}) {
+  const latest = await Promise.all(
+    gateFiles.map(async (file) => {
+      const commits = await fetchJson(
+        `/repos/${repo}/commits?path=${encodeURIComponent(file)}` +
+          `&sha=${encodeURIComponent(baseRef)}&per_page=1`,
+      );
+      const commit = commits[0];
+      // Never existed on the base: nothing to be stale against.
+      if (!commit) return null;
+      return {
+        file,
+        sha: commit.sha,
+        message: firstLine(commit.commit.message),
+        date: commit.commit.committer.date,
+        url: commit.html_url,
+      };
+    }),
+  );
+  const candidates = latest.filter((entry) => entry !== null);
+  const verdicts = await Promise.all(
+    candidates.map(async (candidate) => {
+      const comparison = await fetchJson(
+        `/repos/${repo}/compare/${candidate.sha}...${headSha}`,
+      );
+      return {
+        ...candidate,
+        contained:
+          comparison.status === 'ahead' || comparison.status === 'identical',
+      };
+    }),
+  );
+  return verdicts.filter((verdict) => !verdict.contained);
+}
+
+export function renderReport(stale, baseRef) {
+  const lines = stale.map(
+    (entry) =>
+      `  - ${entry.file}: ${entry.sha.slice(0, 12)} ${entry.message} ` +
+      `(${entry.date.slice(0, 10)})\n    ${entry.url}`,
+  );
+  return [
+    `The lint gate changed on '${baseRef}' after this branch last incorporated it:`,
+    '',
+    ...lines,
+    '',
+    'This lane checks out the branch head alone, so its green proves the branch',
+    'passes the gate AS THE BRANCH DEFINES IT — with the files above, that gate',
+    `is stale. Merge or rebase '${baseRef}' into this branch and push to`,
+    're-validate under the current gate.',
+  ].join('\n');
+}
+
+async function main() {
+  const { GITHUB_TOKEN, BASE_REF, HEAD_SHA, GITHUB_REPOSITORY } = process.env;
+  if (!GITHUB_TOKEN || !BASE_REF || !HEAD_SHA || !GITHUB_REPOSITORY) {
+    console.log(
+      '::warning::lint gate freshness: BASE_REF, HEAD_SHA, ' +
+        'GITHUB_REPOSITORY or GITHUB_TOKEN missing; skipping the check',
+    );
+    return;
+  }
+  try {
+    const fetchJson = (path) => curlJson(path, GITHUB_TOKEN);
+    const stale = await findStaleGateFiles({
+      fetchJson,
+      repo: GITHUB_REPOSITORY,
+      baseRef: BASE_REF,
+      headSha: HEAD_SHA,
+    });
+    if (stale.length === 0) {
+      console.log(
+        `Lint gate freshness OK: this branch contains every '${BASE_REF}' ` +
+          `change to the ${GATE_FILES.length} gate files.`,
+      );
+      return;
+    }
+    console.error(renderReport(stale, BASE_REF));
+    process.exitCode = 1;
+  } catch (error) {
+    console.log(
+      `::warning::lint gate freshness check could not run ` +
+        `(${error.message}); treating the branch as fresh`,
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/.github/scripts/check-lint-gate-freshness.test.mjs
+++ b/.github/scripts/check-lint-gate-freshness.test.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  GATE_FILES,
+  findStaleGateFiles,
+  renderReport,
+} from './check-lint-gate-freshness.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function fakeFetch(handlers, calls = []) {
+  return async (path) => {
+    calls.push(path);
+    for (const [pattern, response] of handlers) {
+      if (path.startsWith(pattern)) return response;
+    }
+    throw new Error(`unexpected path: ${path}`);
+  };
+}
+
+function commitsResponse(sha) {
+  return [
+    {
+      sha,
+      commit: {
+        message: `ci: change the gate (#1)\n\nbody`,
+        committer: { date: '2026-09-07T00:44:18Z' },
+      },
+      html_url: `https://github.com/QwenLM/qwen-code/commit/${sha}`,
+    },
+  ];
+}
+
+const BASE_OPTS = {
+  repo: 'QwenLM/qwen-code',
+  baseRef: 'main',
+  headSha: 'f'.repeat(40),
+  gateFiles: ['scripts/lint.js'],
+};
+
+test('pins the gate file list', () => {
+  // Mutation witness: dropping a gate file from the list — lint.js being
+  // the file whose --write → --check flip caused #11378 — must redden this
+  // assertion, or the check silently stops watching that gate.
+  assert.deepEqual(GATE_FILES, [
+    'scripts/lint.js',
+    'eslint.config.js',
+    'eslint.legacy-filenames.mjs',
+    '.prettierrc.json',
+    '.prettierignore',
+    '.github/workflows/ci.yml',
+    '.github/scripts/check-lint-gate-freshness.mjs',
+  ]);
+});
+
+test('passes when the branch contains the base-side gate change', async () => {
+  const calls = [];
+  const fetchJson = fakeFetch(
+    [
+      ['/repos/QwenLM/qwen-code/commits?', commitsResponse('a'.repeat(40))],
+      [
+        `/repos/QwenLM/qwen-code/compare/${'a'.repeat(40)}...`,
+        { status: 'ahead' },
+      ],
+    ],
+    calls,
+  );
+  assert.deepEqual(await findStaleGateFiles({ ...BASE_OPTS, fetchJson }), []);
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0].includes('path=scripts%2Flint.js'));
+  assert.ok(calls[0].includes('sha=main'));
+  assert.ok(calls[1].endsWith(`...${'f'.repeat(40)}`));
+});
+
+test('treats an identical head as contained', async () => {
+  const fetchJson = fakeFetch([
+    ['/repos/QwenLM/qwen-code/commits?', commitsResponse('a'.repeat(40))],
+    [
+      `/repos/QwenLM/qwen-code/compare/${'a'.repeat(40)}...`,
+      { status: 'identical' },
+    ],
+  ]);
+  assert.deepEqual(await findStaleGateFiles({ ...BASE_OPTS, fetchJson }), []);
+});
+
+test('flags a diverged compare as stale', async () => {
+  const fetchJson = fakeFetch([
+    ['/repos/QwenLM/qwen-code/commits?', commitsResponse('a'.repeat(40))],
+    [
+      `/repos/QwenLM/qwen-code/compare/${'a'.repeat(40)}...`,
+      { status: 'diverged' },
+    ],
+  ]);
+  const stale = await findStaleGateFiles({ ...BASE_OPTS, fetchJson });
+  assert.equal(stale.length, 1);
+  assert.equal(stale[0].file, 'scripts/lint.js');
+  assert.equal(stale[0].message, 'ci: change the gate (#1)');
+  assert.equal(stale[0].date, '2026-09-07T00:44:18Z');
+});
+
+test('flags "behind" as stale: the head is an ancestor of the gate commit', async () => {
+  const fetchJson = fakeFetch([
+    ['/repos/QwenLM/qwen-code/commits?', commitsResponse('a'.repeat(40))],
+    [
+      `/repos/QwenLM/qwen-code/compare/${'a'.repeat(40)}...`,
+      { status: 'behind' },
+    ],
+  ]);
+  const stale = await findStaleGateFiles({ ...BASE_OPTS, fetchJson });
+  assert.equal(stale.length, 1);
+});
+
+test('skips a gate file that never existed on the base', async () => {
+  const calls = [];
+  const fetchJson = fakeFetch(
+    [['/repos/QwenLM/qwen-code/commits?', []]],
+    calls,
+  );
+  assert.deepEqual(await findStaleGateFiles({ ...BASE_OPTS, fetchJson }), []);
+  // No containment compare without a base-side commit.
+  assert.equal(calls.length, 1);
+});
+
+test('propagates API errors so the caller can fail open', async () => {
+  const fetchJson = async () => {
+    throw new Error('403 rate limit');
+  };
+  await assert.rejects(findStaleGateFiles({ ...BASE_OPTS, fetchJson }), /403/);
+});
+
+test('report names the file, the commit, and the remedy', () => {
+  const report = renderReport(
+    [
+      {
+        file: 'scripts/lint.js',
+        sha: 'a'.repeat(40),
+        message: 'ci: change the gate (#1)',
+        date: '2026-09-07T00:44:18Z',
+        url: 'https://github.com/QwenLM/qwen-code/commit/' + 'a'.repeat(40),
+      },
+    ],
+    'main',
+  );
+  assert.match(report, /scripts\/lint\.js/);
+  assert.match(report, /aaaaaaaaaaaa/);
+  assert.match(report, /2026-09-07/);
+  assert.match(report, /rebase 'main' into this branch/);
+});
+
+test('ci.yml wires the check into lint_and_static before the lint lanes', () => {
+  const ci = readFileSync(join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+  // Slice out the lint_and_static job: from its key to the next job key.
+  const jobStart = ci.indexOf('\n  lint_and_static:');
+  const jobEnd = ci.indexOf('\n  test_macos:', jobStart);
+  assert.ok(jobStart > 0 && jobEnd > jobStart, 'lint_and_static job not found');
+  const job = ci.slice(jobStart, jobEnd);
+
+  const step = job.indexOf("- name: 'Check lint gate freshness'");
+  assert.ok(step > 0, 'freshness step missing');
+  // PRs only: merge_group validates the prospective merged tree (fresh by
+  // construction) and push validates the base itself.
+  const stepBlock = job.slice(step, job.indexOf('\n      - name:', step + 1));
+  assert.ok(
+    stepBlock.includes("github.event_name == 'pull_request'"),
+    'step must be gated to pull_request',
+  );
+  assert.ok(
+    stepBlock.includes("skip_ci != 'true'"),
+    'step must stay running alongside the other no-op-pass lanes on skip_ci',
+  );
+  assert.ok(
+    stepBlock.includes('node .github/scripts/check-lint-gate-freshness.mjs'),
+    'step must run the freshness script',
+  );
+  assert.ok(
+    stepBlock.includes('github.event.pull_request.base.ref') &&
+      stepBlock.includes('github.event.pull_request.head.sha'),
+    'step must pass the PR base ref and head sha',
+  );
+  // Fail fast: the check costs seconds and must run before the expensive
+  // install/lint steps it can make pointless.
+  assert.ok(
+    step < job.indexOf("- name: 'Run ESLint'"),
+    'freshness step must precede Run ESLint',
+  );
+  assert.ok(
+    step < job.indexOf("- name: 'Install dependencies'"),
+    'freshness step must precede Install dependencies',
+  );
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ env:
   # re-runs every suite after `npm ci`, and a push to main always classifies
   # `full` (classify_pr computes a profile only for pull_request), so what
   # the fast lane skips is still re-checked post-merge.
-  HELPER_TESTS_DEP_FREE: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/classify-platform-sensitivity.test.mjs .github/scripts/ci/classify-pr-profile.test.mjs .github/scripts/upsert-bot-comment.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/dsw-swe-verified/make-terminal-bench-manifest.test.mjs .github/scripts/update-ecs-runner-qwen-workflow.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/serve-ab-drive.test.mjs .github/scripts/autofix-status-heartbeat.test.mjs .github/scripts/check-disk-floor.test.mjs'
-  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/classify-platform-sensitivity.test.mjs .github/scripts/ci/classify-pr-profile.test.mjs .github/scripts/upsert-bot-comment.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/dsw-swe-verified/make-terminal-bench-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/update-ecs-runner-qwen-workflow.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/serve-ab-drive.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/assign-issue-owner.test.mjs .github/scripts/auto-minimize-spam.test.mjs .github/scripts/ci-runner-routing.test.mjs .github/scripts/autofix-status-heartbeat.test.mjs .github/scripts/assign-pr-owner.test.mjs .github/scripts/check-disk-floor.test.mjs .github/scripts/ci-disk-pressure.test.mjs .github/scripts/e2e-build.test.mjs integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.test.mjs'
+  HELPER_TESTS_DEP_FREE: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/classify-platform-sensitivity.test.mjs .github/scripts/ci/classify-pr-profile.test.mjs .github/scripts/upsert-bot-comment.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/dsw-swe-verified/make-terminal-bench-manifest.test.mjs .github/scripts/update-ecs-runner-qwen-workflow.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/serve-ab-drive.test.mjs .github/scripts/autofix-status-heartbeat.test.mjs .github/scripts/check-disk-floor.test.mjs .github/scripts/check-lint-gate-freshness.test.mjs'
+  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/classify-platform-sensitivity.test.mjs .github/scripts/ci/classify-pr-profile.test.mjs .github/scripts/upsert-bot-comment.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/dsw-swe-verified/make-terminal-bench-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/update-ecs-runner-qwen-workflow.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/serve-ab-drive.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/assign-issue-owner.test.mjs .github/scripts/auto-minimize-spam.test.mjs .github/scripts/ci-runner-routing.test.mjs .github/scripts/autofix-status-heartbeat.test.mjs .github/scripts/assign-pr-owner.test.mjs .github/scripts/check-disk-floor.test.mjs .github/scripts/check-lint-gate-freshness.test.mjs .github/scripts/ci-disk-pressure.test.mjs .github/scripts/e2e-build.test.mjs integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.test.mjs'
   # The growth ratchet and its vitest mirror compare each workflow against
   # the PR's base commit to tell "this PR grew the file" apart from "the
   # baseline went stale on main" (#9904). Wired once here so every lane
@@ -1046,6 +1046,25 @@ jobs:
       - name: 'Check workflow file size'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
         run: '.github/scripts/check-workflow-size.sh'
+
+      # A green lane proves the branch passes the gate AS THE BRANCH defines
+      # it — the checkout above is refs/pull/N/head by deliberate trade-off —
+      # not as the base defines it. #11117 flipped Prettier --write →
+      # --check on main while #11216's branch still ran --write; it merged
+      # green and reddened every later full-profile PR (#11378 cleaned up).
+      # Fail a branch whose base has since changed a gate-defining file.
+      # PRs only: merge_group validates the prospective merged tree and push
+      # validates the base itself. docs_only runs no lint lane, so there is
+      # no stale green to catch; github_ci_only runs lint.js lanes in the
+      # helper step below, so it is covered. Seconds of API calls before the
+      # expensive steps; details in the script's header.
+      - name: 'Check lint gate freshness'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && github.event_name == 'pull_request' && steps.ci_profile.outputs.ci_profile != 'docs_only' }}"
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          BASE_REF: '${{ github.event.pull_request.base.ref }}'
+          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: 'node .github/scripts/check-lint-gate-freshness.mjs'
 
       # Avoid setup-node downloads on ECS, where nodejs.org may be unreachable
       # through the egress proxy; reuse the machine's Node instead.


### PR DESCRIPTION
## What this PR does

Adds a "Check lint gate freshness" step to the Lint & Static job, ahead of the install and lint steps. For each gate-defining file — the lint script, the ESLint and Prettier configs, the CI workflow itself, and the new check — the step asks the GitHub API two questions: what is the newest commit on the PR's base branch that touched the file, and does this branch contain it. A branch that lacks a base-side gate change fails in seconds with the offending commits, dates and links listed, plus a rebase instruction. API failures warn and pass: an advisory gate must not hold every PR hostage during an API brownout. `package.json` and the lockfile are deliberately excluded — at 50–100 merges a day that would force every in-flight PR to rebase behind every dependency bump, and a Prettier/ESLint version bump cannot sneak changed semantics past a branch anyway, because both tools run repo-wide and the bumping PR must bring the whole tree under the new semantics in its own run.

## Why it's needed

The lane checks out the PR head alone — a deliberate trade-off recorded at the checkout step, because GitHub rebuilds the merge ref asynchronously and can serve it stale. A green run therefore proves the branch passes the gate as the branch defines it, not as the base defines it. #11117 flipped the Prettier lane from `--write` to `--check` on main while #11216's branch still ran `--write`; #11216 merged green, main went red, and every later full-profile PR failed lint for a reason outside its own diff until #11378 reformatted the file. Nothing else catches this class today: the branch ruleset requires reviews, not status checks, and the merge queue has been disabled since 2026-07-02. Gate-file changes are rare (the lint script saw five commits in the months before this check), so an occasional forced rebase is cheap insurance.

## Reviewer Test Plan

### How to verify

The decision logic is covered by a nine-case node:test suite (every compare status, empty base-side history, error propagation, the workflow wiring, and a mutation witness on the gate-file list): `node --test .github/scripts/check-lint-gate-freshness.test.mjs`. For a live check against the real API, run the script with a token and two heads: a fresh head (the base tip) prints the OK line and exits 0; a stale head (the parent of the last base commit touching the CI workflow) exits 1 naming that commit, its date and URL, and the rebase remedy. Missing or invalid tokens exit 0 with a `::warning::` — the fail-open path.

Expected on this PR's own run: the step passes, because the branch contains every base-side gate change as of its branch point.

### Evidence (Before & After)

N/A — no UI or TUI surface. Before: a branch stale against a base-side gate change merges green and reddens main. After (simulated against the live API with a stale head):

```
The lint gate changed on 'main' after this branch last incorporated it:

  - .github/workflows/ci.yml: 32f51a330bdc chore: restore regression coverage after WebUI retirement (#11101) (2026-09-08)
    https://github.com/QwenLM/qwen-code/commit/32f51a330bdc2fccb6b17a2683bfbe7ca7300a33

This lane checks out the branch head alone, so its green proves the branch
passes the gate AS THE BRANCH DEFINES IT — with the files above, that gate
is stale. Merge or rebase 'main' into this branch and push to
re-validate under the current gate.
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS: the nine-case suite, the wiring assertions, Prettier/ESLint/yamllint/actionlint on the touched files, the workflow size ratchet (within the allowance), and the full scripts test suite — its only failures sit in unrelated, environment-dependent files and reproduce identically with this change stashed. Live-API runs covered pass, fail and both fail-open shapes. The HTTP layer shells out to curl precisely so the ECS runners' squid proxy variables are honored; node builtins only, so the step can run before any dependency install.

## Risk & Scope

- Main risk or tradeoff: a false positive costs one rebase; a false negative keeps today's hole. The containment semantics were verified against the live compare API in both directions, and the error path was rebuilt so it cannot echo the token into logs.
- Not validated / out of scope: general semantic conflicts between two green PRs (same-code changes) — that class needs the merge queue or required status checks, a separate project. Fork-PR containment relies on PR head commits being present in the base repository's object network (standard GitHub behavior); a miss there fails open like any other API error.
- Breaking changes / migration notes: none. In-flight branches older than this merge will be asked to update once — the check watches its own introduction — which is the intended one-time wave.

## Linked Issues

None filed; the incident analysis is on #11378 and the #11117 → #11216 timeline.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 Lint & Static job 里、安装与 lint 各步骤之前，新增一个 "Check lint gate freshness" 步骤。对每个闸门定义文件——lint 脚本、ESLint 与 Prettier 配置、CI 工作流本身、以及这个新检查——该步骤向 GitHub API 问两个问题：PR 的 base 分支上最近一次改动该文件的是哪个提交，以及当前分支是否包含它。缺少 base 侧闸门改动的分支会在几秒内失败，输出列出相关提交、日期与链接，并给出 rebase 指引。API 失败时告警并放行：一个劝告性闸门不能在 API 故障时劫持所有 PR。`package.json` 与 lockfile 被刻意排除——在每天 50–100 个合入的频率下，纳入它们会迫使每个在途 PR 跟在每次依赖升级后面 rebase；而且 Prettier/ESLint 版本升级也无法把变更后的语义偷运过分支，因为这两个工具都是全仓运行，发起升级的 PR 必须在自己的运行里让整棵树满足新语义。

## 为什么需要

这条 lane checkout 的是 PR head 本身——这是 checkout 步骤处记录的刻意取舍，因为 GitHub 异步重建 merge ref，可能提供陈旧内容。因此绿色运行证明的是「分支通过了分支所定义的闸门」，而不是「base 所定义的闸门」。#11117 在 main 上把 Prettier lane 从 `--write` 切成 `--check`，而 #11216 的分支仍在跑 `--write`；#11216 绿着合入，main 变红，之后每个 full-profile PR 都因与自身 diff 无关的原因 lint 失败，直到 #11378 重新格式化该文件。今天没有任何其他机制兜住这一类问题：分支 ruleset 要求的是 review 而不是 status check，merge queue 自 2026-07-02 起停用。闸门文件的变更很稀少（lint 脚本在本次检查之前的几个月里只有五次提交），所以偶尔强制 rebase 一次是廉价的保险。

## 审阅测试计划

### 如何验证

判定逻辑由九个 node:test 用例覆盖（每种 compare 状态、base 侧无历史、错误传播、工作流接线，以及闸门文件清单的 mutation witness）：`node --test .github/scripts/check-lint-gate-freshness.test.mjs`。要用真实 API 做活体验证，带 token 跑两次脚本：新鲜 head（base 最新提交）打印 OK 行并以 0 退出；陈旧 head（base 上最后一次触碰 CI 工作流的提交的父提交）以 1 退出，并指名该提交、日期、URL 与 rebase 指引。缺失或无效 token 时以 0 退出并打印 `::warning::`——即 fail-open 路径。

本 PR 自己的运行预期：该步骤通过，因为分支包含了截至分叉点的全部 base 侧闸门改动。

### 前后对比证据

N/A——不涉及 UI 或 TUI 界面。改动前：落后于 base 侧闸门变更的分支绿着合入并使 main 变红。改动后（用陈旧 head 对真实 API 模拟）：

```
The lint gate changed on 'main' after this branch last incorporated it:

  - .github/workflows/ci.yml: 32f51a330bdc chore: restore regression coverage after WebUI retirement (#11101) (2026-09-08)
    https://github.com/QwenLM/qwen-code/commit/32f51a330bdc2fccb6b17a2683bfbe7ca7300a33

This lane checks out the branch head alone, so its green proves the branch
passes the gate AS THE BRANCH DEFINES IT — with the files above, that gate
is stale. Merge or rebase 'main' into this branch and push to
re-validate under the current gate.
```

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地 macOS：九用例套件、接线断言、对改动文件跑 Prettier/ESLint/yamllint/actionlint、workflow 体积棘轮（在余量内）、以及完整 scripts 测试套件——其仅有的失败都在与本改动无关的环境依赖型文件里，且把本改动 stash 后照样复现。真实 API 运行覆盖了通过、失败与两种 fail-open 形态。HTTP 层刻意改用 curl，就是为了遵守 ECS runner 的 squid 代理环境变量；脚本只用 node 内置模块，因此可以在任何依赖安装之前运行。

## 风险与范围

- 主要风险或取舍：误报的代价是一次 rebase；漏报则是维持今天的漏洞。包含关系语义已针对真实 compare API 双向验证；错误路径已重写，不会把 token 打进日志。
- 未验证 / 不在范围内：两个各自绿色的 PR 之间的一般性语义冲突（改同一段代码）——那一类需要 merge queue 或 required status checks，是另一个项目。fork PR 的包含关系判定依赖 PR head 提交存在于 base 仓库的对象网络中（GitHub 的标准行为）；万一缺失，与任何 API 错误一样 fail-open。
- 破坏性变更 / 迁移说明：无。比本次合入更老的在途分支会被要求更新一次——这个检查监听着它自身的引入——这正是预期的一次性波及。

## 关联 Issue

未单独建 issue；事故分析见 #11378 以及 #11117 → #11216 的时间线。

</details>
