### PR TITLE
feat(web-shell): add opt-in browser task notifications

### DIFF
--- a/docs/design/web-shell/web-shell-browser-turn-notifications.md
+++ b/docs/design/web-shell/web-shell-browser-turn-notifications.md
@@ -1,0 +1,176 @@
+# Web Shell 浏览器任务通知：独立实现设计
+
+状态：独立浏览器通知已实现，构建和自动化验证通过。调研及实现日期：2026-09-08。
+
+## 决策与范围
+
+基于当前 main 独立实现，不依赖 #11251。首版只修改 Web Shell client，复用已有 `turn_complete` / `turn_error`，增加通知专用的内部事件适配和一个用户开关。先浏览器通知，再支持 Channel。
+
+产品名称为“浏览器任务通知”，但事件语义是一次 assistant 回合结束，不代表整个项目、多轮目标或所有后台 agent 都完成。首版覆盖页面仍在运行且当前聊天或 Split View 仍被观察的情形，包括浏览器切到后台、窗口失焦。切换到别的聊天后未挂载会话的即时提醒、关闭网页、浏览器冻结或系统休眠不在首版保证内。
+
+## 当前代码依据
+
+源码基线：`1a73f5bff6201473f237c5106367e944ba2d092b`。设计依据为该基线；后续实现及验证记录见文末。
+
+| 当前实现                                                             | 可复用部分与限制                                                                                              |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `packages/acp-bridge/src/bridge.ts`                                  | 发布权威 turn_complete / turn_error，包含 session、prompt 标识。兼容类型允许缺少 promptId，通知不能猜测标识。 |
+| `packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx` | 已有 live 事件、历史恢复、重连及终态前 transcript flush；是通知观察接入点。                                   |
+| `packages/web-shell/client/daemon/session/actions.ts`                | 普通及队列提交已有 onPromptAdmitted，确认移除已有 onPromptRemoved，可复用作恢复时的跟踪证据。                 |
+| `packages/web-shell/client/main.tsx`                                 | StandaloneApp 已管理浏览器本地 theme/language；根节点覆盖主聊天和 Split View。                                |
+| `packages/web-shell/client/components/messages/SettingsMessage.tsx`  | 已有本地 chatWidth 项及共享 Switch、SettingsRow。                                                             |
+| `packages/cli/src/serve/routes/workspace-settings.ts`                | general.terminalBell、general.notificationMode 被归为 TUI-only，不能复用为浏览器开关。                        |
+| `packages/sdk-typescript/src/daemon/DaemonSessionClient.ts`          | 有 lastEventId/epoch 恢复能力；SSE 结束也会拒绝 pending promise，不能据任意 reject 发任务失败通知。           |
+
+App 的旧 onSessionChange(turn_complete) 和侧边栏 completedUnread 来自 UI/摘要变化，不作为新通知输入。旧原型位于独立的 `codex/browser-turn-notifications` 分支；只参考其权限、文案及设置逻辑，不整体引入已关闭 #10398 的历史。#11251 的宿主回调、最终 assistant 消息提取不属于本功能范围。
+
+## 用户开关
+
+入口：**Settings → UI → 浏览器任务通知**。默认关闭，立即生效，无需刷新或重启 daemon。
+
+```text
+浏览器任务通知                                  [关闭 / 开启]
+页面在后台或窗口失焦时，提醒当前聊天和分屏聊天的回合结束或失败。
+仅保存在此浏览器站点；关闭网页后不再提醒。
+
+状态：未开启 / 已开启 / 等待授权 / 浏览器已阻止 / 当前环境不可用
+```
+
+复用已有 Switch 与 SettingsRow；增加 local 类型设置项，明确标注“此浏览器站点”。Settings 的 workspace/user scope 切换不改变该值，也不向 daemon settings API 写入。
+
+| 配置项           | 决定                                                                           |
+| ---------------- | ------------------------------------------------------------------------------ |
+| 内部名称         | browserNotificationsEnabled: boolean                                           |
+| localStorage key | qwen-code-web-shell-browser-notifications                                      |
+| 持久化值         | 字符串 true/false；不存在或非法时为 false                                      |
+| 范围             | 当前 browser profile + origin；不随 workspace 变化，不同步到其他设备           |
+| 默认与启停       | 默认 false，即使权限已授予也不自动开启；关闭停止新通知，开启不补发已处理的回合 |
+| 标签页同步       | 监听 storage 事件；写入页面直接更新本地状态                                    |
+| 存储失败         | 本页面内继续可用，提示“设置仅在当前页面有效”                                   |
+
+不写入 `.qwen/settings.json`：浏览器权限是设备/站点状态，daemon 配置不能代替用户授权；同一个 workspace 可以同时被权限不同的浏览器打开。
+
+### 权限与设置状态
+
+开关表示用户偏好，状态文字表示当前是否可用。发送需同时满足偏好开启、权限 granted、环境支持及后台条件。
+
+| 操作或状态                           | 行为                                                                                                            |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| 关闭→开启，permission=granted        | 保存 true，立即生效。                                                                                           |
+| 关闭→开启，permission=default        | 在点击的同步调用链中 requestPermission；等待期间禁用重复提交，允许后才保存 true。拒绝或关闭对话框则保持 false。 |
+| 关闭→开启，permission=denied         | 保持 false，提示去浏览器站点设置允许通知，不重复请求。                                                          |
+| 开启→关闭                            | 保存 false，不撤销浏览器权限，不补发。                                                                          |
+| 已保存 true，权限后来被撤回          | 保留偏好，显示“浏览器已阻止，当前不会通知”；可关闭开关。发送前重新检查权限。                                    |
+| 已保存 true，permission 回到 default | 显示“等待授权”和“允许通知”操作；页面加载不自动申请。                                                            |
+| 非安全上下文、API 缺失               | 显示不可用原因并禁止开启，不自动改写持久偏好。                                                                  |
+
+设置页打开、窗口重新聚焦和实际发送前重新读取权限，不依赖持续权限订阅。迟到的授权结果不得覆盖其他标签页在等待期间作出的关闭操作，使用请求代次和最新偏好检查丢弃失效结果。
+
+首版面向桌面浏览器；Notification 对象存在不代表手机支持构造器。构造失败或 error 事件更新本地可用状态，不能影响聊天或重复弹错误。用户手势、安全上下文和跨源 iframe 限制参见 [MDN Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API)。
+
+## 触发与文案
+
+| 输入                                   | 行为                                                              |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| turn_complete，stopReason=end_turn     | 通知“本轮已完成”。                                                |
+| turn_error                             | 通知“本轮执行失败，请返回查看”，不显示错误正文。                  |
+| turn_complete，stopReason=cancelled    | 不通知，静默消费终态。                                            |
+| 其他合法 turn_complete stopReason      | “本轮已结束，请返回查看”，不把 token 上限等停止原因说成任务成功。 |
+| prompt_cancelled                       | 只是取消请求，不抢先消费最终终态。                                |
+| 排队 prompt 确认 removed               | 清理对应跟踪记录并静默处理，不改变其他回合。                      |
+| SSE 断开、重试、HTTP/权限错误、UI idle | 不作为任务失败证据。                                              |
+| 缺失或冲突的 sessionId/promptId        | 不通知，不用当前会话替代事件来源。                                |
+
+展示条件为 `document.visibilityState !== 'visible' || !document.hasFocus()`。前台聚焦时消费终态但不展示，后来失焦不补弹。首版不增加时长阈值、声音选择或自定义正文。
+
+标题固定 Qwen Code，正文仅上述通用文案，不含 prompt、答复、错误、会话标题、路径或 workspace 名。点击尝试 window.focus() 并关闭通知，不自动切换会话；操作系统可能拒绝聚焦，不能保证成功。展示失败不改变回合结果。
+
+## 内部架构
+
+```mermaid
+flowchart TD
+    A[现有 daemon SSE 与恢复快照] --> B[DaemonSessionProvider]
+    P[已有 admission / removal 回调] --> B
+    B --> C[内部通知观察接口]
+    C --> D[Standalone 根部通知协调器]
+    S[本地开关与浏览器权限] --> D
+    D --> E[去重与后台判断]
+    E --> N[Notification API]
+```
+
+在 `client/daemon/session/` 增加包内通知观察 Context，默认 undefined，仅传纯数据，不访问 Notification 或 localStorage。实现由 standalone 根协调器提供，主聊天和 Split View 共用。非 standalone 宿主无此祖先时不跟踪、不显示设置、不申请权限；standalone 页面被 iframe 加载时也不挂载通知协调器。
+
+接口最小数据：来源范围、sessionId、promptId、事件类别、stopReason、live/restore 来源，以及 admission/removal 信号。不传正文，不导出公共 SDK API，不修改既有宿主回调。下层 session 只依赖内部类型，上层浏览器模块消费它，避免循环依赖。
+
+来源范围由规范化 daemon base URL、产品 session context 和已解析 workspace 身份组成，取自捕获的 session owner。异步发送不能再读取已经切换的全局 connection。token、URL 查询参数和 fragment 不得进入通知标识或共享记录。
+
+### 终态与恢复顺序
+
+1. 在现有 live 终态完成 normalize、flush 和 assistant.done 投影后发布通知数据；先校验 owner，避免在 active/observer 两个分支重复发布。
+2. 复用 onPromptAdmitted，只读 owner/promptId，保留已有 turn navigation 行为。普通及队列提交都登记；确认 removal 后移除。带明确 promptId 的 live 启动证据也可登记，历史用户消息不能建立新 admission。
+3. live 流（包括 cursor 增量恢复）的真实终态可以直接进入统一去重。终态先于本地 admission 回调抵达时先处理，晚到 admission 不能重新登记为未结束。
+4. 初始历史、历史分页和跳转加载保持静默。恢复快照的终态只有匹配本页面此前跟踪的未结束 prompt 才可补发，且在快照提交后发布。
+5. 同会话重连、epoch 重置和 ring eviction 重载保留待跟踪身份；不能只存在可能被清理的 activePromptsRef 中。根协调器保存最小集合。
+6. 页面刷新不持久化待跟踪列表；新页面不补发刷新前已完成历史，之后 live 到达的新终态仍可通知。恢复数据不含目标终态时，不依据 hasActivePrompt=false 推测成功。
+7. 明确切换会话或关闭 pane 后，不另保留连接；最后一个对应观察者退出时清理其跟踪。连接重试及 React StrictMode 的同身份重建不算用户离开，不能误清理。
+
+当前观察范围的终态在开关关闭/前台时仍被消费，以防重复事件在后来开启时补弹。上述集合属于通知模块，不能反向改变 transcript、输入或 daemon 生命周期。
+
+## 去重保证
+
+键包含来源范围 + sessionId + promptId。通知 tag 和共享记录使用稳定指纹，源数据只留在内存，不存正文/token。已处理记录采用有界近期缓存，候选上限 1024 条，不增加用户配置；历史终态始终先经过跟踪门槛，因此缓存淘汰不应重放历史通知。
+
+- 同页面先认领终态，再判断取消、开关、权限及前后台。主聊天和分屏重复事件只触发一次通知尝试；取消/前台/关闭也算已处理。
+- 同源多标签页在 Web Locks 与共享存储可用时，用短锁保护已认领指纹的检查及写入，锁内重新检查开关和权限。只有满足本地展示条件的页面参与跨页发送认领；未开启的页面不能吞掉有效页面的资格。
+- 同一键使用稳定 tag，支持时 renotify=false。无锁或无共享存储时退回同页面去重及同 tag 替换，不保证跨标签页严格只提醒一次。
+- 跨页记录表示已认领一次尝试，不表示用户收到或看到。写入后崩溃或系统通知失败可能漏提醒；首版不增加持久投递队列与重试，不宣称 exactly-once delivery。
+- 可见性以发送页面为准：一个标签页前台、另一个后台时，后者仍可能提醒。首版不增加跨页阅读状态协调。
+
+Web Locks 提供同源互斥，tag 是通知替换而非事务幂等。参见 [MDN Web Locks](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) 和 [MDN renotify](https://developer.mozilla.org/en-US/docs/Web/API/Notification/renotify)。
+
+## 实际改动
+
+实现涉及以下位置及对应测试。
+
+| 位置（packages/web-shell）                         | 责任                                                                        |
+| -------------------------------------------------- | --------------------------------------------------------------------------- |
+| client/daemon/session/turn-notification-context.ts | 包内观察接口及类型，不导出公共 barrel。                                     |
+| client/daemon/session/DaemonSessionProvider.tsx    | admission/removal、live 终态及恢复快照提交点。                              |
+| client/browser-turn-notifications.tsx              | 根协调器、本地设置 context、权限/展示及有限去重状态；避免提前建设通用框架。 |
+| client/main.tsx                                    | 仅顶层 standalone 挂载协调器，传入当前语言。                                |
+| client/components/messages/SettingsMessage.tsx     | UI 本地开关、权限状态及授权操作。                                           |
+| client/i18n.tsx、README、对应测试                  | 文案、产品边界和回归验证。                                                  |
+
+不新增 SSE 连接或额外 transcript provider，不改 daemon route、settings schema、CLI 通知服务、Channel worker 或 SDK 公共合同。#11251 若后来合并，可评估复用入口，但不是交付条件。
+
+## 验证与交付
+
+实施前按仓库要求使用全局 qwen 做基线 dry-run；设计阶段不运行。实施后运行 build、typecheck、相关单测与桌面浏览器 E2E。模拟 Notification 的单测不能代替 OS 通知接收证据。
+
+| 测试组     | 验收重点                                                                                        |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| 开关       | 默认关闭、granted 不自动启用、workspace/user scope 不影响、刷新持久化、storage 同步及失败降级。 |
+| 权限       | 点击才请求、三个权限状态、撤回、迟到授权、iframe/API/安全上下文、构造及 error 事件失败。        |
+| 终态       | 完成/失败/取消/其他 stopReason、冲突 ID、取消请求不抢占终态、断网不是任务失败。                 |
+| 身份与排序 | 投影先于通知、终态先于 admission、主聊天/分屏重复、workspace 切换和旧 owner 隔离。              |
+| 恢复       | 历史静默、跟踪回合的增量/快照补发、epoch/ring 重载、StrictMode、刷新不补旧历史。                |
+| 去重       | 前台/关闭消费后不补弹、缓存边界、多页锁竞争、无锁/存储降级、失败不改变聊天。                    |
+| 手工       | Chrome/Safari 桌面后台完成和失败、OS 权限、点击聚焦；其他浏览器未测需明确标注，手机不宣称支持。 |
+
+E2E 清单见 `.qwen/e2e-tests/web-shell-browser-turn-notifications-independent.md`。实现完成后审阅完整 diff，按仓库要求完成两轮干净自审和独立代码复核；提交 PR 另按用户指示执行。
+
+## 后续能力
+
+切换聊天后仍提醒旧聊天，可另加针对未结束 prompt 的轻量观察或评估 workspace 终态流，不能靠 running-to-idle 猜测，也不为全部历史会话建立连接。
+
+关闭网页后提醒优先由服务端 Channel 承担。已有 prompt delivery 投递正常 end_turn 的最终答复，不等同于状态通知或失败提醒；简短完成/失败提醒需另接服务端终态，并沿用明确授权目标和所属 workspace，不由浏览器收到事件后代发。
+
+网页关闭后的浏览器推送需要另外的 Push 投递链路，单独注册 Service Worker 不够，首版不包含。参见 [MDN Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)。
+
+## 实现与验证记录
+
+实现仅修改 Web Shell：根组件提供页面级通知状态和本地设置，DaemonSessionProvider 在 live / recovery 已完成 transcript 投影后观察权威终态，既有提交回调用于恢复跟踪。没有新增 daemon 路由、SSE 连接或公开 SDK 回调。页面验证同时发现并修正共享 Switch 的状态选择器：匹配 Radix 的 data-state 属性，以正确显示开关颜色和滑块位置。
+
+单元测试覆盖终态分类、权限与偏好、重复消费、历史静默、存储受限、通知失败隔离，以及实际 Provider 的终态投影顺序和 epoch reset 恢复。页面级验证使用真实 Web Shell、mockDaemon SSE、Chromium 和 Notification stub，覆盖设置入口、无 daemon 设置写入、前后台差异、双页开关同步与真实 Web Locks 竞争。操作系统最终展示、移动端及关闭页面后的推送不属于本次验证。详细命令和结果位于本地 `.qwen/e2e-tests/web-shell-browser-turn-notifications-independent.md`。
+
+最终源码通过全仓 `npm run build`、`npm run typecheck`、`npm run bundle`，6 个相关测试文件合计 365 项通过；修改文件 ESLint、Prettier 和 diff 检查通过。独立复核发现并修复迟到授权覆盖其他标签页关闭操作的竞态，修复后的复核无新增问题。

--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -13,6 +13,21 @@ Qwen Code Web Shell 是面向浏览器的 daemon 会话终端 UI，可以作为 
 组件包会自动注入自身的 CSS（包括 Tailwind 编译产物），接入方不需要配置
 Tailwind 或额外引入全局 CSS。
 
+## 浏览器任务通知
+
+通过 `qwen serve` 打开的独立 Web Shell 可在 **Settings → UI → 浏览器任务通知**
+开启提醒。默认关闭，仅在用户点击后申请浏览器授权；偏好保存在当前浏览器站点，
+不写入 daemon 或 workspace 设置，同源标签页之间同步。
+
+页面在后台或窗口失焦时，当前聊天及 Split View 中仍挂载的聊天在回合结束或失败后
+可以发送系统通知。取消回合、初次加载历史和前台已处理的回合保持静默。通知只显示
+通用状态，不含聊天正文、错误详情或工作目录；点击通知尝试聚焦原窗口。
+
+需要支持 Notifications API 的桌面浏览器以及 HTTPS 或可信的 localhost 环境。
+支持 Web Locks 且存储可用时，同源标签页协调去重；否则退化为页面内去重及相同 tag
+的通知替换。关闭网页、页面冻结或离开未挂载的聊天后不保证提醒。嵌入式组件不自动
+启用此能力；Channel 推送不在首版范围内。
+
 ## Tailwind 与 shadcn/ui
 
 Web Shell 已配置 Tailwind CSS v4 和 shadcn/ui。shadcn 的 token 仅用于新增的

--- a/packages/web-shell/client/browser-turn-notifications.test.tsx
+++ b/packages/web-shell/client/browser-turn-notifications.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+
+import { webcrypto } from 'node:crypto';
+import { act, useContext, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BrowserTurnNotifications,
+  BROWSER_NOTIFICATIONS_STORAGE_KEY,
+  useBrowserNotificationSettings,
+} from './browser-turn-notifications';
+import {
+  TurnNotificationContext,
+  type TurnNotificationObserver,
+} from './daemon/session/turn-notification-context';
+
+type Settings = NonNullable<ReturnType<typeof useBrowserNotificationSettings>>;
+interface Capture {
+  settings?: Settings;
+  observer?: TurnNotificationObserver;
+}
+const notifications: FakeNotification[] = [];
+class FakeNotification {
+  static permission: NotificationPermission = 'granted';
+  static requestPermission = vi.fn(
+    async (): Promise<NotificationPermission> => {
+      FakeNotification.permission = 'granted';
+      return 'granted';
+    },
+  );
+  onclick?: () => void;
+  onerror?: () => void;
+  close = vi.fn();
+  constructor(
+    public title: string,
+    public options: NotificationOptions,
+  ) {
+    notifications.push(this);
+  }
+}
+const roots: Root[] = [];
+function Probe({ capture }: { capture: Capture }) {
+  capture.settings = useBrowserNotificationSettings();
+  capture.observer = useContext(TurnNotificationContext);
+  return null;
+}
+function render(capture: Capture, wrapper?: (node: ReactNode) => ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  act(() =>
+    root.render(
+      wrapper ? (
+        wrapper(<Probe capture={capture} />)
+      ) : (
+        <BrowserTurnNotifications language="en">
+          <Probe capture={capture} />
+        </BrowserTurnNotifications>
+      ),
+    ),
+  );
+  return root;
+}
+async function settle(capture: Capture, promptId = 'prompt') {
+  await act(async () => {
+    capture.observer!.observe('scope', 'session', {
+      type: 'turn_complete',
+      data: { sessionId: 'session', promptId, stopReason: 'end_turn' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+}
+function attach(capture: Capture) {
+  capture.observer!.retain('scope');
+}
+
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  notifications.length = 0;
+  const values = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    clear: () => values.clear(),
+  });
+  FakeNotification.permission = 'granted';
+  FakeNotification.requestPermission
+    .mockReset()
+    .mockImplementation(async () => {
+      FakeNotification.permission = 'granted';
+      return 'granted';
+    });
+  vi.stubGlobal('Notification', FakeNotification);
+  vi.stubGlobal('crypto', webcrypto);
+  vi.stubGlobal('isSecureContext', true);
+  vi.stubGlobal('navigator', { locks: undefined });
+  vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+});
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('browser task notifications', () => {
+  it('defaults off despite permission, consumes disabled terminals and persists an explicit choice', async () => {
+    const capture: Capture = {};
+    render(capture);
+    attach(capture);
+    expect(capture.settings!.enabled).toBe(false);
+    await settle(capture);
+    await act(() => capture.settings!.setEnabled(true));
+    expect(window.localStorage.getItem(BROWSER_NOTIFICATIONS_STORAGE_KEY)).toBe(
+      'true',
+    );
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+    await settle(capture);
+    expect(notifications).toHaveLength(0);
+    await settle(capture, 'new');
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.options.body).toBe('This turn has completed.');
+    expect(notifications[0]?.options.tag).not.toContain('scope');
+  });
+
+  it('requests permission only when the user enables and keeps a denied preference off', async () => {
+    FakeNotification.permission = 'default';
+    FakeNotification.requestPermission.mockImplementation(async () => {
+      FakeNotification.permission = 'denied';
+      return 'denied';
+    });
+    const capture: Capture = {};
+    render(capture);
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+    await act(() => capture.settings!.setEnabled(true));
+    expect(FakeNotification.requestPermission).toHaveBeenCalledOnce();
+    expect(capture.settings!.permission).toBe('denied');
+    expect(capture.settings!.enabled).toBe(false);
+    await act(() => capture.settings!.setEnabled(true));
+    expect(FakeNotification.requestPermission).toHaveBeenCalledOnce();
+  });
+
+  it('suppresses foreground and cancelled turns, and uses generic failure text', async () => {
+    window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'true');
+    const capture: Capture = {};
+    render(capture);
+    attach(capture);
+    vi.mocked(document.hasFocus).mockReturnValue(true);
+    await settle(capture);
+    vi.mocked(document.hasFocus).mockReturnValue(false);
+    await settle(capture);
+    await act(async () => {
+      capture.observer!.observe('scope', 'session', {
+        type: 'turn_complete',
+        data: {
+          sessionId: 'session',
+          promptId: 'cancel',
+          stopReason: 'cancelled',
+        },
+      });
+      capture.observer!.observe('scope', 'session', {
+        type: 'turn_error',
+        data: {
+          sessionId: 'session',
+          promptId: 'error',
+          message: 'secret /workspace/path',
+        },
+      });
+      await vi.waitFor(() => expect(notifications).toHaveLength(1));
+    });
+    expect(notifications[0]?.options.body).toBe(
+      'This turn failed. Return to view the details.',
+    );
+    expect(JSON.stringify(notifications)).not.toContain('secret');
+    const focus = vi.spyOn(window, 'focus').mockImplementation(() => {});
+    notifications[0]?.onclick?.();
+    expect(focus).toHaveBeenCalledOnce();
+    expect(notifications[0]?.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps preference but stops sending after permission is revoked', async () => {
+    window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'true');
+    const capture: Capture = {};
+    render(capture);
+    attach(capture);
+    FakeNotification.permission = 'denied';
+    act(() => window.dispatchEvent(new Event('focus')));
+    expect(capture.settings).toMatchObject({
+      enabled: true,
+      permission: 'denied',
+    });
+    await settle(capture);
+    expect(notifications).toHaveLength(0);
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('does not let late permission overwrite another tab disabling notifications', async () => {
+    window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'true');
+    FakeNotification.permission = 'default';
+    let resolve!: (permission: NotificationPermission) => void;
+    FakeNotification.requestPermission.mockImplementation(
+      () =>
+        new Promise((done) => {
+          resolve = done;
+        }),
+    );
+    const capture: Capture = {};
+    render(capture);
+    let enabling!: Promise<void>;
+    act(() => {
+      enabling = capture.settings!.setEnabled(true);
+    });
+    act(() => {
+      window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'false');
+    });
+    await act(async () => {
+      FakeNotification.permission = 'granted';
+      resolve('granted');
+      await enabling;
+    });
+    act(() =>
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: BROWSER_NOTIFICATIONS_STORAGE_KEY,
+          newValue: 'false',
+        }),
+      ),
+    );
+    expect(capture.settings!.enabled).toBe(false);
+    expect(window.localStorage.getItem(BROWSER_NOTIFICATIONS_STORAGE_KEY)).toBe(
+      'false',
+    );
+  });
+
+  it('coordinates two page instances with Web Locks and a shared claim', async () => {
+    let queue = Promise.resolve();
+    vi.stubGlobal('navigator', {
+      locks: {
+        request: (_name: string, action: () => void) => {
+          queue = queue.then(action);
+          return queue;
+        },
+      },
+    });
+    window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'true');
+    const a: Capture = {},
+      b: Capture = {};
+    render(a);
+    render(b);
+    attach(a);
+    attach(b);
+    await settle(a);
+    await settle(b);
+    expect(notifications).toHaveLength(1);
+  });
+
+  it('falls back to a page-local choice when storage is blocked', async () => {
+    vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const capture: Capture = {};
+    render(capture);
+    attach(capture);
+    await act(() => capture.settings!.setEnabled(true));
+    expect(capture.settings).toMatchObject({
+      enabled: true,
+      persistent: false,
+    });
+    await settle(capture);
+    expect(notifications).toHaveLength(1);
+  });
+
+  it('handles Notification construction and asynchronous display failures', async () => {
+    window.localStorage.setItem(BROWSER_NOTIFICATIONS_STORAGE_KEY, 'true');
+    const capture: Capture = {};
+    render(capture);
+    attach(capture);
+    await settle(capture);
+    act(() => notifications[0]?.onerror?.());
+    expect(capture.settings!.error).toBe(true);
+    class BrokenNotification extends FakeNotification {
+      constructor(title: string, opts: NotificationOptions) {
+        super(title, opts);
+        throw new Error('display blocked');
+      }
+    }
+    vi.stubGlobal('Notification', BrokenNotification);
+    await settle(capture, 'broken');
+    expect(capture.settings!.error).toBe(true);
+  });
+
+  it('exposes no controls to embedded hosts and does not request permission in an insecure context', async () => {
+    const embedded: Capture = {};
+    render(embedded, (node) => node);
+    expect(embedded.settings).toBeUndefined();
+    expect(embedded.observer).toBeUndefined();
+    vi.stubGlobal('isSecureContext', false);
+    const standalone: Capture = {};
+    render(standalone);
+    expect(standalone.settings!.permission).toBe('unavailable');
+    await act(() => standalone.settings!.setEnabled(true));
+    expect(standalone.settings!.enabled).toBe(false);
+    expect(FakeNotification.requestPermission).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-shell/client/browser-turn-notifications.tsx
+++ b/packages/web-shell/client/browser-turn-notifications.tsx
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getTranslator, type WebShellLanguage } from './i18n';
+import {
+  createTurnNotificationObserver,
+  TurnNotificationContext,
+  type TurnNotification,
+} from './daemon/session/turn-notification-context';
+
+export const BROWSER_NOTIFICATIONS_STORAGE_KEY =
+  'qwen-code-web-shell-browser-notifications';
+const CLAIMS_STORAGE_KEY = 'qwen-code-web-shell-notification-claims';
+const MAX_CLAIMS = 1024;
+
+type Permission = NotificationPermission | 'unavailable';
+
+interface BrowserNotificationSettings {
+  enabled: boolean;
+  permission: Permission;
+  pending: boolean;
+  persistent: boolean;
+  error: boolean;
+  setEnabled(enabled: boolean): Promise<void>;
+  refreshPermission(): void;
+}
+
+const BrowserNotificationSettingsContext = createContext<
+  BrowserNotificationSettings | undefined
+>(undefined);
+
+export function useBrowserNotificationSettings() {
+  return useContext(BrowserNotificationSettingsContext);
+}
+
+function permission(): Permission {
+  return window.isSecureContext && typeof window.Notification === 'function'
+    ? window.Notification.permission
+    : 'unavailable';
+}
+
+function readStoredPreference(): string | null | undefined {
+  try {
+    return window.localStorage.getItem(BROWSER_NOTIFICATIONS_STORAGE_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+function readPreference() {
+  const stored = readStoredPreference();
+  return { enabled: stored === 'true', persistent: stored !== undefined };
+}
+
+export function BrowserTurnNotifications({
+  children,
+  language,
+}: {
+  children: ReactNode;
+  language: WebShellLanguage;
+}) {
+  if (typeof window === 'undefined' || window.top !== window.self)
+    return <>{children}</>;
+  return (
+    <StandaloneNotifications language={language}>
+      {children}
+    </StandaloneNotifications>
+  );
+}
+
+function StandaloneNotifications({
+  children,
+  language,
+}: {
+  children: ReactNode;
+  language: WebShellLanguage;
+}) {
+  const [preference, setPreference] = useState(readPreference);
+  const [currentPermission, setPermission] = useState(permission);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState(false);
+  const enabledRef = useRef(preference.enabled);
+  const version = useRef(0);
+  const mounted = useRef(true);
+  const notifyRef = useRef<(turn: TurnNotification) => void>(() => {});
+  const [observer] = useState(() =>
+    createTurnNotificationObserver((turn) => notifyRef.current(turn)),
+  );
+  const refreshPermission = useCallback(() => setPermission(permission()), []);
+  const savePreference = useCallback((enabled: boolean) => {
+    enabledRef.current = enabled;
+    let persistent = true;
+    try {
+      window.localStorage.setItem(
+        BROWSER_NOTIFICATIONS_STORAGE_KEY,
+        String(enabled),
+      );
+    } catch {
+      persistent = false;
+    }
+    setPreference({ enabled, persistent });
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    const requestVersion = version;
+    const sync = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== BROWSER_NOTIFICATIONS_STORAGE_KEY)
+        return;
+      version.current++;
+      const next = readPreference();
+      enabledRef.current = next.enabled;
+      setPreference(next);
+      setPending(false);
+      refreshPermission();
+    };
+    window.addEventListener('storage', sync);
+    window.addEventListener('focus', refreshPermission);
+    return () => {
+      mounted.current = false;
+      requestVersion.current++;
+      window.removeEventListener('storage', sync);
+      window.removeEventListener('focus', refreshPermission);
+    };
+  }, [refreshPermission]);
+
+  const setEnabled = useCallback(
+    async (enabled: boolean) => {
+      const request = ++version.current;
+      setError(false);
+      if (!enabled) {
+        setPending(false);
+        savePreference(false);
+        return;
+      }
+      const storedBeforeRequest = readStoredPreference();
+      let nextPermission = permission();
+      if (nextPermission === 'default') {
+        setPending(true);
+        try {
+          nextPermission = await window.Notification.requestPermission();
+        } catch {
+          if (mounted.current && request === version.current) setError(true);
+        }
+      }
+      if (!mounted.current || request !== version.current) return;
+      setPending(false);
+      setPermission(permission());
+      if (readStoredPreference() !== storedBeforeRequest) {
+        const next = readPreference();
+        enabledRef.current = next.enabled;
+        setPreference(next);
+        return;
+      }
+      if (nextPermission === 'granted') savePreference(true);
+    },
+    [savePreference],
+  );
+
+  notifyRef.current = (turn) => {
+    const request = version.current;
+    const canShow = () =>
+      mounted.current &&
+      request === version.current &&
+      enabledRef.current &&
+      permission() === 'granted' &&
+      (document.visibilityState !== 'visible' || !document.hasFocus());
+    if (turn.outcome === 'cancelled' || !canShow()) return;
+    const show = async () => {
+      // Hash identities so notification tags and shared storage contain no paths.
+      const digest = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode(turn.key),
+      );
+      const tag = `qwen-code-turn:${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+      let attempted = false;
+      const deliver = (shared: boolean) => {
+        attempted = true;
+        if (!canShow()) return;
+        if (shared) {
+          try {
+            const raw: unknown = JSON.parse(
+              window.localStorage.getItem(CLAIMS_STORAGE_KEY) ?? '[]',
+            );
+            const claims = Array.isArray(raw)
+              ? raw
+                  .filter((key): key is string => typeof key === 'string')
+                  .slice(-MAX_CLAIMS)
+              : [];
+            if (claims.includes(tag)) return;
+            window.localStorage.setItem(
+              CLAIMS_STORAGE_KEY,
+              JSON.stringify([...claims.slice(-(MAX_CLAIMS - 1)), tag]),
+            );
+          } catch {
+            // Storage restrictions degrade to page-local deduplication and tag replacement.
+          }
+        }
+        const t = getTranslator(language);
+        const notification = new window.Notification('Qwen Code', {
+          body: t(`browserNotifications.${turn.outcome}`),
+          tag,
+          ...{ renotify: false },
+        });
+        notification.onclick = () => {
+          try {
+            window.focus();
+          } finally {
+            notification.close();
+          }
+        };
+        notification.onerror = () => {
+          if (mounted.current) setError(true);
+        };
+      };
+      if (navigator.locks) {
+        try {
+          await navigator.locks.request(CLAIMS_STORAGE_KEY, () =>
+            deliver(true),
+          );
+        } catch (failure) {
+          if (attempted) throw failure;
+          deliver(false);
+        }
+      } else deliver(false);
+    };
+    void show().catch(() => {
+      if (mounted.current) setError(true);
+    });
+  };
+
+  return (
+    <TurnNotificationContext.Provider value={observer}>
+      <BrowserNotificationSettingsContext.Provider
+        value={{
+          ...preference,
+          permission: currentPermission,
+          pending,
+          error,
+          setEnabled,
+          refreshPermission,
+        }}
+      >
+        {children}
+      </BrowserNotificationSettingsContext.Provider>
+    </TurnNotificationContext.Provider>
+  );
+}

--- a/packages/web-shell/client/components/messages/SettingsMessage.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.tsx
@@ -28,6 +28,7 @@ import {
   useI18n,
   type WebShellLanguage,
 } from '../../i18n';
+import { useBrowserNotificationSettings } from '../../browser-turn-notifications';
 import { LiveVoiceSettingsCard } from '../../live/LiveVoiceSettingsCard';
 import type { UseLiveVoiceSetupResult } from '../../live/useLiveVoiceSetup';
 import {
@@ -250,7 +251,7 @@ interface CategoryGroup {
 
 type SettingsPageItem =
   | { type: 'setting'; setting: DaemonSettingDescriptor }
-  | { type: 'local'; localKey: 'chatWidth' }
+  | { type: 'local'; localKey: 'chatWidth' | 'browserNotifications' }
   | { type: 'local-control' }
   | { type: 'live' };
 
@@ -394,7 +395,7 @@ function SettingInput({
 export type FlatRow =
   | { type: 'header'; category: string }
   | { type: 'setting'; setting: DaemonSettingDescriptor }
-  | { type: 'local'; localKey: 'chatWidth' };
+  | { type: 'local'; localKey: 'chatWidth' | 'browserNotifications' };
 
 /* Wraps around at both ends (matching the native CLI) while skipping
    category-header rows. Exported for tests. */
@@ -426,6 +427,11 @@ export function SettingsMessage({
 }: SettingsMessageProps) {
   const { language: selectedLanguage, t } = useI18n();
   const selectedTheme = useTheme();
+  const notifications = useBrowserNotificationSettings();
+  const refreshNotificationPermission = notifications?.refreshPermission;
+  useEffect(() => {
+    refreshNotificationPermission?.();
+  }, [refreshNotificationPermission]);
   const { status, settings, loading, error, reload, setValue, liveSetup } =
     settingsState;
   const [scope, setScope] = useState<Scope>('workspace');
@@ -434,6 +440,7 @@ export function SettingsMessage({
   const [message, setMessage] = useState<string | null>(null);
   const [restartPending, setRestartPending] = useState(false);
 
+  const hasNotifications = notifications !== undefined;
   const showInitialLoading = loading && !status;
   const categories = useMemo(() => {
     const visibleSettings = settings.filter(
@@ -474,6 +481,10 @@ export function SettingsMessage({
         items: [localItem],
       });
     }
+    if (hasNotifications) {
+      const group = groups.find((item) => item.items.includes(localItem));
+      group?.items.push({ type: 'local', localKey: 'browserNotifications' });
+    }
     if (liveSetup?.supported) {
       const experimental = groups.find((group) => group.id === 'Experimental');
       if (experimental) {
@@ -497,7 +508,7 @@ export function SettingsMessage({
       });
     }
     return groups;
-  }, [liveSetup, settings, t]);
+  }, [liveSetup, settings, t, hasNotifications]);
 
   useEffect(() => {
     if (categories.length === 0) return;
@@ -799,6 +810,73 @@ export function SettingsMessage({
                         const separator = index > 0 && (
                           <Separator className="mx-5 w-auto max-md:mx-4" />
                         );
+                        if (
+                          item.type === 'local' &&
+                          item.localKey === 'browserNotifications' &&
+                          notifications
+                        ) {
+                          const unavailable =
+                            notifications.permission === 'unavailable';
+                          const status = unavailable
+                            ? 'unavailable'
+                            : notifications.pending
+                              ? 'requesting'
+                              : notifications.permission === 'denied'
+                                ? 'denied'
+                                : notifications.error
+                                  ? 'error'
+                                  : notifications.enabled
+                                    ? notifications.permission === 'granted'
+                                      ? 'enabled'
+                                      : 'waiting'
+                                    : 'disabled';
+                          return (
+                            <div key={item.localKey}>
+                              {separator}
+                              <SettingsRow
+                                title={t('browserNotifications.label')}
+                                description={[
+                                  t('browserNotifications.description'),
+                                  t(`browserNotifications.${status}`),
+                                  ...(!notifications.persistent
+                                    ? [t('browserNotifications.temporary')]
+                                    : []),
+                                ].join(' ')}
+                                control={
+                                  <div className="flex items-center gap-2">
+                                    {notifications.enabled &&
+                                      notifications.permission ===
+                                        'default' && (
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          disabled={notifications.pending}
+                                          onClick={() =>
+                                            void notifications.setEnabled(true)
+                                          }
+                                        >
+                                          {t('browserNotifications.allow')}
+                                        </Button>
+                                      )}
+                                    <Switch
+                                      aria-label={t(
+                                        'browserNotifications.label',
+                                      )}
+                                      checked={notifications.enabled}
+                                      disabled={
+                                        notifications.pending ||
+                                        (unavailable && !notifications.enabled)
+                                      }
+                                      onCheckedChange={(enabled) =>
+                                        void notifications.setEnabled(enabled)
+                                      }
+                                    />
+                                  </div>
+                                }
+                              />
+                            </div>
+                          );
+                        }
                         if (item.type === 'local') {
                           return (
                             <div key={item.localKey}>

--- a/packages/web-shell/client/components/ui/switch.tsx
+++ b/packages/web-shell/client/components/ui/switch.tsx
@@ -17,14 +17,14 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50',
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-[state=checked]:translate-x-[calc(100%-2px)] dark:data-[state=checked]:bg-primary-foreground group-data-[size=default]/switch:data-[state=unchecked]:translate-x-0 group-data-[size=sm]/switch:data-[state=unchecked]:translate-x-0 dark:data-[state=unchecked]:bg-foreground"
       />
     </SwitchPrimitive.Root>
   );

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
@@ -58,6 +58,11 @@ import {
   clearSidechannelMidTurnInjected,
   getSidechannelMidTurnInjected,
 } from '../midTurnInjectedSidechannel.js';
+import {
+  createTurnNotificationObserver,
+  TurnNotificationContext,
+  type TurnNotificationObserver,
+} from './turn-notification-context.js';
 import { persistStableClientId } from './clientLifecycle.js';
 
 interface MockSession {
@@ -19443,9 +19448,150 @@ describe('DaemonSessionProvider', () => {
     );
   });
 
+  it('keeps initial history quiet and notifies once after a live terminal is projected', async () => {
+    const terminal: DaemonEvent = {
+      id: 2,
+      v: 1,
+      type: 'turn_complete',
+      data: {
+        sessionId: 'session-1',
+        promptId: 'live',
+        stopReason: 'end_turn',
+      },
+    };
+    const go = createDeferred<void>();
+    let store: DaemonTranscriptStore | undefined;
+    let snapshotAtNotification: unknown;
+    const notify = vi.fn(() => {
+      snapshotAtNotification = store?.getSnapshot();
+    });
+    const observer = createTurnNotificationObserver(notify);
+    sdkMocks.sessions.push(
+      createMockSession({
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              ...terminal,
+              data: { ...(terminal.data as object), promptId: 'history' },
+            },
+          ],
+          liveJournal: [],
+        },
+        async *events(opts) {
+          await go.promise;
+          yield {
+            id: 3,
+            v: 1,
+            type: 'session_update',
+            promptId: 'live',
+            data: {
+              sessionId: 'session-1',
+              promptId: 'live',
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'final answer' },
+              },
+            },
+          };
+          yield { ...terminal, id: 4 };
+          yield { ...terminal, id: 5 };
+          yield* createIdleEvents()(opts);
+        },
+      }),
+    );
+    function Harness() {
+      store = useDaemonTranscriptStore();
+      return null;
+    }
+    await renderWithProvider(<Harness />, { autoConnect: true }, observer);
+    expect(notify).not.toHaveBeenCalled();
+    await act(async () => {
+      go.resolve();
+      await flushPromises();
+    });
+    expect(notify).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'completed' }),
+    );
+    expect(JSON.stringify(snapshotAtNotification)).toContain('final answer');
+  });
+
+  it('retains a live admitted prompt across epoch reset and settles it from replay', async () => {
+    const reloaded = createDeferred<void>();
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    sdkMocks.sessions.push(
+      createMockSession({
+        hasActivePrompt: true,
+        async *events() {
+          yield {
+            id: 1,
+            v: 1,
+            type: 'pending_prompt_started',
+            data: {
+              sessionId: 'session-1',
+              promptId: 'known',
+              text: 'request',
+            },
+          };
+          yield {
+            id: 2,
+            v: 1,
+            type: 'state_resync_required',
+            data: { reason: 'epoch_reset' },
+          };
+        },
+      }),
+      createMockSession({
+        replaySnapshot: {
+          compactedReplay: [
+            {
+              id: 3,
+              v: 1,
+              type: 'turn_complete',
+              data: {
+                sessionId: 'session-1',
+                promptId: 'unknown',
+                stopReason: 'end_turn',
+              },
+            },
+            {
+              id: 4,
+              v: 1,
+              type: 'turn_complete',
+              data: {
+                sessionId: 'session-1',
+                promptId: 'known',
+                stopReason: 'end_turn',
+              },
+            },
+          ],
+          liveJournal: [],
+        },
+        events: createPendingEvents(reloaded),
+      }),
+    );
+    await renderWithProvider(
+      null,
+      { autoConnect: true, reconnectDelayMs: 1, maxReconnectDelayMs: 1 },
+      observer,
+    );
+    await act(async () => {
+      await reloaded.promise;
+      await flushPromises();
+    });
+    expect(notify).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'completed' }),
+    );
+    expect(notify.mock.calls[0]?.[0].key).toContain('known');
+    expect(notify.mock.calls[0]?.[0].key).not.toContain('unknown');
+  });
+
   async function renderWithProvider(
     children: ReactNode,
     props: Partial<DaemonSessionProviderProps> = {},
+    notifications?: TurnNotificationObserver,
   ) {
     const defaultSessionId =
       props.autoConnect === true &&
@@ -19458,16 +19604,25 @@ describe('DaemonSessionProvider', () => {
     document.body.appendChild(container);
     root = createRoot(container);
 
+    const provider = (
+      <DaemonSessionProvider
+        baseUrl="http://127.0.0.1:4170"
+        autoConnect={false}
+        {...(defaultSessionId ? { sessionId: defaultSessionId } : {})}
+        {...props}
+      >
+        {children}
+      </DaemonSessionProvider>
+    );
     act(() => {
       root?.render(
-        <DaemonSessionProvider
-          baseUrl="http://127.0.0.1:4170"
-          autoConnect={false}
-          {...(defaultSessionId ? { sessionId: defaultSessionId } : {})}
-          {...props}
-        >
-          {children}
-        </DaemonSessionProvider>,
+        notifications ? (
+          <TurnNotificationContext.Provider value={notifications}>
+            {provider}
+          </TurnNotificationContext.Provider>
+        ) : (
+          provider
+        ),
       );
     });
     await act(async () => {

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
@@ -138,6 +138,7 @@ import type {
   PendingSessionLoad,
   SettledPrompt,
 } from './types.js';
+import { useTurnNotificationBinding } from './turn-notification-context.js';
 import { SESSION_TURN_NAVIGATION_FEATURE } from '../../constants/sessions.js';
 import {
   createDaemonTurnNavigationStore,
@@ -1164,6 +1165,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       ? { error: sessionContextResolutionError }
       : {}),
   });
+  const turnNotifications = useTurnNotificationBinding(
+    resolvedBaseUrl,
+    connection,
+  );
   const connectionRef = useRef(connection);
   connectionRef.current = connection;
   const initialClientIdDependencyRef = useRef(clientId);
@@ -2306,6 +2311,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     kind: 'workspace' as const,
                     cwd: activeSession.workspaceCwd,
                   };
+          turnNotifications.remember(
+            activeSession,
+            activeProductSessionContext,
+          );
+          turnNotifications.activate(activeSession);
           const activeWorkspaceScoped =
             activeProductSessionContext.kind === 'workspace';
           runnerSession = activeSession;
@@ -2487,6 +2497,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             const markerIndex = replayTarget
               ? sourceEvents.indexOf(replayTarget.marker)
               : -1;
+            const notificationReplayEvents: DaemonEvent[] = [];
             const eventGroups: Array<{
               transcript: DaemonUiEvent[];
               sideEffects: DaemonUiEvent[];
@@ -2543,6 +2554,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     assistantDoneFromTurnEvent(replayEvent, 'error'),
                   );
                 }
+                notificationReplayEvents.push(replayEvent);
                 eventGroups.push({
                   transcript: groupEvents,
                   sideEffects:
@@ -2797,6 +2809,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 passiveAssistantDoneTimerRef,
                 { requireBoundPromptId: true },
               );
+            }
+            if (sessionRef.current === activeSession) {
+              for (const event of notificationReplayEvents) {
+                turnNotifications.observe(activeSession, event, true);
+              }
             }
             setConnection((c) => ({ ...c, catchingUp: undefined }));
             // Release the raw snapshot only after the injection above
@@ -3469,6 +3486,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   },
                 );
               }
+              if (sessionRef.current === activeSession) {
+                turnNotifications.observe(activeSession, event);
+              }
               const pendingRepair = liveJournalRepairRef.current;
               if (
                 pendingRepair?.sessionId === activeSession.sessionId &&
@@ -4088,6 +4108,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   }, [
     autoConnect,
     autoReconnect,
+    turnNotifications,
     resolvedBaseUrl,
     resolvedToken,
     sessionEffectContext,
@@ -4351,6 +4372,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             client,
             request,
             requestClientId,
+          ).then((owner) =>
+            turnNotifications.remember(owner, {
+              kind: 'workspace',
+              cwd: owner.workspaceCwd,
+            }),
           );
         },
         createDetachedStandaloneSession: (overrides) => {
@@ -4370,7 +4396,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           return DaemonSessionClient.createStandalone(client, {
             ...(modelServiceId !== undefined ? { modelServiceId } : {}),
             ...(approvalMode !== undefined ? { approvalMode } : {}),
-          });
+          }).then((owner) =>
+            turnNotifications.remember(owner, { kind: 'standalone' }),
+          );
         },
         getDefaultSessionContext: () => {
           const error = sessionContextResolutionErrorRef.current;
@@ -4394,6 +4422,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           liveJournalRepairRef.current = undefined;
         },
         onPromptAdmitted: (owner, admission) => {
+          if (sessionRef.current === owner)
+            turnNotifications.admit(owner, admission.promptId);
           if (
             sessionRef.current === owner &&
             turnNavigationStore.getSnapshot().sessionId === owner.sessionId
@@ -4402,6 +4432,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           }
         },
         onPromptRemoved: (owner, promptId) => {
+          if (sessionRef.current === owner)
+            turnNotifications.remove(owner, promptId);
           if (
             sessionRef.current === owner &&
             turnNavigationStore.getSnapshot().sessionId === owner.sessionId
@@ -4416,6 +4448,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       resolvedBaseUrl,
       resolvedToken,
       restartEventStreamOnPrompt,
+      turnNotifications,
       store,
       turnNavigationStore,
     ],

--- a/packages/web-shell/client/daemon/session/turn-notification-context.test.ts
+++ b/packages/web-shell/client/daemon/session/turn-notification-context.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DaemonEvent } from '@qwen-code/sdk/daemon';
+import { createTurnNotificationObserver } from './turn-notification-context';
+
+function terminal(promptId = 'p', stopReason = 'end_turn'): DaemonEvent {
+  return {
+    type: 'turn_complete',
+    data: { sessionId: 's', promptId, stopReason },
+  };
+}
+
+describe('turn notification observer', () => {
+  it.each([
+    ['end_turn', 'completed'],
+    ['cancelled', 'cancelled'],
+    ['max_tokens', 'ended'],
+  ])('classifies %s without implying task-wide success', (reason, outcome) => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    observer.observe('scope', 's', terminal('p', reason));
+    expect(notify).toHaveBeenCalledWith({
+      key: JSON.stringify(['scope', 'p']),
+      outcome,
+    });
+  });
+
+  it('requires a real terminal and ignores cancellation requests and transport errors', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    for (const type of [
+      'prompt_cancelled',
+      'stream_error',
+      'state_resync_required',
+    ]) {
+      observer.observe('scope', 's', {
+        type,
+        data: { sessionId: 's', promptId: 'p' },
+      });
+    }
+    expect(notify).not.toHaveBeenCalled();
+    observer.observe('scope', 's', {
+      type: 'turn_error',
+      data: { sessionId: 's', promptId: 'p', message: 'secret' },
+    });
+    expect(notify).toHaveBeenCalledWith({
+      key: JSON.stringify(['scope', 'p']),
+      outcome: 'failed',
+    });
+  });
+
+  it('keeps initial history silent but catches up admitted prompts once', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    observer.observe('scope', 's', terminal('history'), true);
+    observer.admit('scope', 'p');
+    observer.observe('scope', 's', terminal(), true);
+    observer.observe('scope', 's', terminal());
+    observer.observe('scope', 's', terminal(), true);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates multiple panes and a terminal that precedes admission', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    observer.retain('scope');
+    observer.observe('scope', 's', terminal());
+    observer.admit('scope', 'p');
+    observer.observe('scope', 's', terminal(), true);
+    expect(notify).toHaveBeenCalledTimes(1);
+    observer.retain('other-workspace');
+    observer.observe('other-workspace', 's', terminal());
+    expect(notify).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks live queued prompts but never registers historical queue records', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    const start = {
+      type: 'pending_prompt_started',
+      data: { sessionId: 's', promptId: 'p' },
+    };
+    observer.observe('scope', 's', start, true);
+    observer.observe('scope', 's', terminal(), true);
+    expect(notify).not.toHaveBeenCalled();
+    observer.observe('scope', 's', start);
+    observer.observe('scope', 's', terminal(), true);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets removed prompts even if a later terminal is replayed', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    observer.admit('scope', 'p');
+    observer.observe('scope', 's', {
+      type: 'pending_prompt_completed',
+      data: { sessionId: 's', promptId: 'p', state: 'removed' },
+    });
+    observer.observe('scope', 's', terminal(), true);
+    observer.observe('scope', 's', terminal());
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing and conflicting identities without consuming the valid terminal', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    observer.observe('scope', 'wrong-session', terminal());
+    observer.observe('scope', 's', terminal(''));
+    observer.observe('scope', 's', { ...terminal(), promptId: 'other' });
+    observer.observe('scope', 's', {
+      type: 'turn_complete',
+      data: { sessionId: 's', promptId: 'p' },
+    });
+    expect(notify).not.toHaveBeenCalled();
+    observer.observe('scope', 's', terminal());
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves tracking on immediate remount but clears it after the last pane leaves', async () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    const release = observer.retain('scope');
+    observer.admit('scope', 'p');
+    release();
+    const nextRelease = observer.retain('scope');
+    await Promise.resolve();
+    observer.observe('scope', 's', terminal(), true);
+    observer.admit('scope', 'later');
+    nextRelease();
+    await Promise.resolve();
+    observer.retain('scope');
+    observer.observe('scope', 's', terminal('later'), true);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not replay old history after the recent cache reaches its bound', () => {
+    const notify = vi.fn();
+    const observer = createTurnNotificationObserver(notify);
+    observer.retain('scope');
+    for (let index = 0; index < 1100; index++)
+      observer.observe('scope', 's', terminal(String(index)));
+    observer.observe('scope', 's', terminal('0'), true);
+    expect(notify).toHaveBeenCalledTimes(1100);
+  });
+
+  it('isolates a failing notification callback from the daemon stream', () => {
+    const observer = createTurnNotificationObserver(() => {
+      throw new Error('display unavailable');
+    });
+    observer.retain('scope');
+    expect(() => observer.observe('scope', 's', terminal())).not.toThrow();
+  });
+});

--- a/packages/web-shell/client/daemon/session/turn-notification-context.ts
+++ b/packages/web-shell/client/daemon/session/turn-notification-context.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import type { DaemonEvent } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonConnectionState,
+  DaemonProductSessionContext,
+} from './types.js';
+
+export interface TurnNotification {
+  key: string;
+  outcome: 'completed' | 'failed' | 'ended' | 'cancelled';
+}
+
+export interface TurnNotificationObserver {
+  retain(scope: string): () => void;
+  admit(scope: string, promptId: string): void;
+  remove(scope: string, promptId: string): void;
+  observe(
+    scope: string,
+    sessionId: string,
+    event: DaemonEvent,
+    replay?: boolean,
+  ): void;
+}
+
+export const TurnNotificationContext = createContext<
+  TurnNotificationObserver | undefined
+>(undefined);
+
+interface NotificationOwner {
+  sessionId: string;
+  workspaceCwd: string;
+}
+
+export function useTurnNotificationBinding(
+  baseUrl: string | undefined,
+  connection: DaemonConnectionState,
+) {
+  const observer = useContext(TurnNotificationContext);
+  const binding = useRef<
+    | {
+        scope: string;
+        sessionId: string;
+        kind: string;
+        cwd: string;
+        release(): void;
+      }
+    | undefined
+  >(undefined);
+  const generation = useRef(0);
+  const handlers = useMemo(() => {
+    const owners = new WeakMap<
+      NotificationOwner,
+      { scope: string; sessionId: string; kind: string; cwd: string }
+    >();
+    const activate = (owner: NotificationOwner) => {
+      const next = owners.get(owner);
+      if (!observer || !next) return undefined;
+      if (binding.current?.scope !== next.scope) {
+        binding.current?.release();
+        binding.current = { ...next, release: observer.retain(next.scope) };
+      }
+      return next.scope;
+    };
+    return {
+      remember<T extends NotificationOwner>(
+        owner: T,
+        context: DaemonProductSessionContext,
+      ): T {
+        if (!observer || !baseUrl) return owner;
+        const url = new URL(baseUrl, 'http://localhost');
+        const cwd = context.kind === 'workspace' ? owner.workspaceCwd : '';
+        owners.set(owner, {
+          scope: JSON.stringify([
+            url.origin,
+            url.pathname.replace(/\/$/, ''),
+            context.kind,
+            cwd,
+            owner.sessionId,
+          ]),
+          sessionId: owner.sessionId,
+          kind: context.kind,
+          cwd,
+        });
+        return owner;
+      },
+      activate,
+      admit(owner: NotificationOwner, promptId: string) {
+        const scope = activate(owner);
+        if (scope) observer?.admit(scope, promptId);
+      },
+      remove(owner: NotificationOwner, promptId: string) {
+        const scope = owners.get(owner)?.scope;
+        if (scope) observer?.remove(scope, promptId);
+      },
+      observe(owner: NotificationOwner, event: DaemonEvent, replay = false) {
+        const scope = owners.get(owner)?.scope;
+        if (scope && binding.current?.scope === scope)
+          observer?.observe(scope, owner.sessionId, event, replay);
+      },
+    };
+  }, [baseUrl, observer]);
+  useEffect(() => {
+    const current = binding.current;
+    if (
+      current &&
+      (connection.sessionId !== current.sessionId ||
+        (connection.sessionContext &&
+          connection.sessionContext.kind !== current.kind) ||
+        (current.kind === 'workspace' &&
+          connection.workspaceCwd !== undefined &&
+          connection.workspaceCwd !== current.cwd))
+    ) {
+      current.release();
+      binding.current = undefined;
+    }
+  }, [
+    connection.sessionId,
+    connection.sessionContext,
+    connection.workspaceCwd,
+  ]);
+  useEffect(() => {
+    const lifecycle = generation;
+    const current = ++lifecycle.current;
+    return () => {
+      queueMicrotask(() => {
+        if (current !== lifecycle.current) return;
+        binding.current?.release();
+        binding.current = undefined;
+      });
+    };
+  }, [handlers]);
+  return handlers;
+}
+
+const MAX_RECENT_TURNS = 1024;
+
+export function createTurnNotificationObserver(
+  notify: (notification: TurnNotification) => void,
+): TurnNotificationObserver {
+  const scopes = new Map<
+    string,
+    { references: number; pending: Set<string> }
+  >();
+  const handled = new Set<string>();
+  const keyFor = (scope: string, promptId: string) =>
+    JSON.stringify([scope, promptId]);
+  const consume = (scope: string, promptId: string) => {
+    const key = keyFor(scope, promptId);
+    scopes.get(scope)?.pending.delete(promptId);
+    if (handled.has(key)) return false;
+    handled.add(key);
+    if (handled.size > MAX_RECENT_TURNS)
+      handled.delete(handled.values().next().value!);
+    return true;
+  };
+  return {
+    retain(scope) {
+      let state = scopes.get(scope);
+      if (!state) {
+        state = { references: 0, pending: new Set() };
+        scopes.set(scope, state);
+      }
+      state.references++;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        state.references--;
+        queueMicrotask(() => {
+          if (state.references === 0 && scopes.get(scope) === state)
+            scopes.delete(scope);
+        });
+      };
+    },
+    admit(scope, promptId) {
+      if (promptId && !handled.has(keyFor(scope, promptId)))
+        scopes.get(scope)?.pending.add(promptId);
+    },
+    remove(scope, promptId) {
+      if (scopes.has(scope) && promptId) consume(scope, promptId);
+    },
+    observe(scope, sessionId, event, replay = false) {
+      const state = scopes.get(scope);
+      if (!state || state.references === 0) return;
+      const data = event.data;
+      if (!data || typeof data !== 'object') return;
+      const value = data as Record<string, unknown>;
+      const promptId = value['promptId'];
+      const envelopeSessionId = (event as DaemonEvent & { sessionId?: unknown })
+        .sessionId;
+      if (
+        value['sessionId'] !== sessionId ||
+        (envelopeSessionId !== undefined && envelopeSessionId !== sessionId) ||
+        typeof promptId !== 'string' ||
+        !promptId.trim() ||
+        (event.promptId !== undefined && event.promptId !== promptId)
+      )
+        return;
+      if (
+        !replay &&
+        (event.type === 'pending_prompt_added' ||
+          event.type === 'pending_prompt_started')
+      ) {
+        if (!handled.has(keyFor(scope, promptId))) state.pending.add(promptId);
+        return;
+      }
+      if (
+        event.type === 'pending_prompt_completed' &&
+        value['state'] === 'removed'
+      ) {
+        if (!replay || state.pending.has(promptId)) consume(scope, promptId);
+        return;
+      }
+      if (event.type !== 'turn_complete' && event.type !== 'turn_error') return;
+      if (replay && !state.pending.has(promptId)) return;
+      if (
+        event.type === 'turn_complete' &&
+        typeof value['stopReason'] !== 'string'
+      )
+        return;
+      if (!consume(scope, promptId)) return;
+      try {
+        notify({
+          key: keyFor(scope, promptId),
+          outcome:
+            event.type === 'turn_error'
+              ? 'failed'
+              : value['stopReason'] === 'cancelled'
+                ? 'cancelled'
+                : value['stopReason'] === 'end_turn'
+                  ? 'completed'
+                  : 'ended',
+        });
+      } catch {
+        // Notification observers must never interrupt session event handling.
+      }
+    },
+  };
+}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -3539,6 +3539,27 @@ const EN: Messages = {
     `Maximum of ${v?.max ?? 3} fallback models selected; deselect one to choose another.`,
   'settings.corrupted': (v) =>
     `Settings file was corrupted${v?.recovered === 'true' ? ' (recovered from backup)' : ''}`,
+  'browserNotifications.label': 'Browser task notifications',
+  'browserNotifications.description':
+    'Notify when the current chat or a split-view chat finishes or fails while this page is in the background or unfocused. Saved for this browser site only; the page must remain open.',
+  'browserNotifications.completed': 'This turn has completed.',
+  'browserNotifications.failed':
+    'This turn failed. Return to view the details.',
+  'browserNotifications.ended':
+    'This turn has ended. Return to check the result.',
+  'browserNotifications.allow': 'Allow notifications',
+  'browserNotifications.enabled': 'Enabled.',
+  'browserNotifications.disabled': 'Disabled.',
+  'browserNotifications.waiting': 'Waiting for browser permission.',
+  'browserNotifications.denied':
+    'Notifications are blocked. Allow them in your browser site settings.',
+  'browserNotifications.unavailable':
+    'Notifications are unavailable in this browser or page context.',
+  'browserNotifications.requesting': 'Waiting for your permission…',
+  'browserNotifications.error':
+    'Unable to enable or show notifications. Check your browser and system settings.',
+  'browserNotifications.temporary':
+    'This setting is saved for the current page only.',
   'settings.label.ui.chatWidth': 'Chat width',
   'settings.description.ui.chatWidth':
     'Frontend-only chat content width. Stored in this browser.',
@@ -6911,6 +6932,21 @@ const ZH: Messages = {
     `最多可选 ${v?.max ?? 3} 个回退模型；请先取消一个再选择其他。`,
   'settings.corrupted': (v) =>
     `设置文件已损坏${v?.recovered === 'true' ? '（已从备份恢复）' : ''}`,
+  'browserNotifications.label': '浏览器任务通知',
+  'browserNotifications.description':
+    '页面在后台或窗口失焦时，提醒当前聊天和分屏聊天的回合结束或失败。仅保存在此浏览器站点；网页需保持打开。',
+  'browserNotifications.completed': '本轮已完成。',
+  'browserNotifications.failed': '本轮执行失败，请返回查看。',
+  'browserNotifications.ended': '本轮已结束，请返回查看结果。',
+  'browserNotifications.allow': '允许通知',
+  'browserNotifications.enabled': '已开启。',
+  'browserNotifications.disabled': '未开启。',
+  'browserNotifications.waiting': '等待浏览器授权。',
+  'browserNotifications.denied': '浏览器已阻止通知，请在浏览器站点设置中允许。',
+  'browserNotifications.unavailable': '当前浏览器或页面环境无法使用通知。',
+  'browserNotifications.requesting': '等待你的授权…',
+  'browserNotifications.error': '无法启用或显示通知，请检查浏览器及系统设置。',
+  'browserNotifications.temporary': '设置仅在当前页面有效。',
   'settings.label.ui.chatWidth': '屏宽',
   'settings.description.ui.chatWidth':
     '纯前端的聊天内容宽度设置，保存在当前浏览器中。',

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -5,6 +5,7 @@ import {
   DaemonWorkspaceProvider,
   type DaemonProductSessionContext,
 } from '@qwen-code/web-shell/daemon-react-sdk';
+import { BrowserTurnNotifications } from './browser-turn-notifications';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootErrorFallback } from './components/RootErrorFallback';
 import { WorkspaceSessionProvider } from './components/WorkspaceSessionProvider';
@@ -199,46 +200,48 @@ export function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
         <RootErrorFallback error={error} onRetry={reset} language={language} />
       )}
     >
-      <DaemonWorkspaceProvider baseUrl={baseUrl} token={daemonToken}>
-        <WorkspaceSessionProvider
-          sessionId={sessionId}
-          workspaceId={workspaceId}
-          sessionContext={sessionContext}
-          webShellProps={{
-            theme,
-            onThemeChange: handleThemeChange,
-            language,
-            onLanguageChange: handleLanguageChange,
-            onSessionIdChange: handleSessionIdChange,
-            sidebar: { enabled: true, showLive: true },
-            header: {
-              items: [
-                'title',
-                'environment',
-                'rightPanel',
-                'tokenUsage',
-                'contextUsage',
-              ],
-            },
-            rightPanel: {
-              items: ['review', 'sideTask', 'terminal'],
-            },
-            environmentPanel: {
-              items: [
-                'environment',
-                'subagents',
-                'backgroundTasks',
-                'attachments',
-                'artifacts',
-              ],
-            },
-            compactThinking: true,
-            markdownTableMode: 'advanced',
-            composerToolbarAdditionalActions:
-              STANDALONE_COMPOSER_TOOLBAR_ADDITIONS,
-          }}
-        />
-      </DaemonWorkspaceProvider>
+      <BrowserTurnNotifications language={language}>
+        <DaemonWorkspaceProvider baseUrl={baseUrl} token={daemonToken}>
+          <WorkspaceSessionProvider
+            sessionId={sessionId}
+            workspaceId={workspaceId}
+            sessionContext={sessionContext}
+            webShellProps={{
+              theme,
+              onThemeChange: handleThemeChange,
+              language,
+              onLanguageChange: handleLanguageChange,
+              onSessionIdChange: handleSessionIdChange,
+              sidebar: { enabled: true, showLive: true },
+              header: {
+                items: [
+                  'title',
+                  'environment',
+                  'rightPanel',
+                  'tokenUsage',
+                  'contextUsage',
+                ],
+              },
+              rightPanel: {
+                items: ['review', 'sideTask', 'terminal'],
+              },
+              environmentPanel: {
+                items: [
+                  'environment',
+                  'subagents',
+                  'backgroundTasks',
+                  'attachments',
+                  'artifacts',
+                ],
+              },
+              compactThinking: true,
+              markdownTableMode: 'advanced',
+              composerToolbarAdditionalActions:
+                STANDALONE_COMPOSER_TOOLBAR_ADDITIONS,
+            }}
+          />
+        </DaemonWorkspaceProvider>
+      </BrowserTurnNotifications>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## What this PR does

Adds opt-in browser task notifications to the standalone Web Shell under Settings → UI. The preference is disabled by default, stored per browser origin, and synchronized across tabs. After an explicit permission grant, a background or unfocused page can notify when an observed chat turn completes or fails. Cancelled turns and initial history remain silent. Notifications use generic text and do not expose chat content or workspace paths.

The implementation consumes existing daemon terminal events after transcript projection, retains admitted prompts across same-session recovery, and deduplicates notification attempts across panes and, when Web Locks and storage are available, across same-origin tabs. It also corrects the shared switch's Radix state selectors so checked and unchecked states are visibly distinct. This implementation does not depend on #11251.

## Why it's needed

Daemon terminal events and sidebar unread markers do not alert users who have moved away from the Web Shell window. A browser-local switch lets each user choose notifications without changing daemon settings or requesting browser permission automatically.

## Reviewer Test Plan

### How to verify

1. Open the standalone Web Shell, go to Settings → UI, and confirm Browser task notifications is initially off even when the browser already permits notifications. Enable it explicitly, reload the page, and confirm the preference persists. Switching Workspace/User settings scope must not change it or write daemon settings.
2. Keep the current chat or a split-view chat mounted, move the page to the background, and finish or fail a turn. Confirm generic completion/failure notification attempts; cancelled turns, initial history, and turns already consumed in the foreground must remain silent.
3. Open two same-origin pages. Confirm switch changes synchronize and, with Web Locks and localStorage available, simultaneous duplicate terminal events cause one notification attempt. Reconnect an admitted prompt and confirm a replayed terminal is handled once while unrelated historical terminals remain silent.
4. Revoke notification permission and confirm the saved preference remains visible but sending stops. While one page is awaiting renewed permission, disable notifications in another page; a late permission result must not re-enable them. Confirm the switch track and thumb visibly change between states.

Validation passed: repository build, typecheck, and bundle; 365 tests across six relevant test files; ESLint and Prettier for changed files; diff whitespace checks; eight Chromium page-level acceptance groups; and an isolated real-daemon smoke test of the final bundled Web Shell. The page tests use real SSE fixtures and real Web Locks with a Notification stub. The bundled daemon smoke test verifies settings and persistence without model calls or real notifications.

<img width="447" height="175" alt="image" src="https://github.com/user-attachments/assets/95aecfd9-93ad-4033-83b0-14feab147938" />


### Evidence (Before & After)

| Scenario | Before | After |
| --- | --- | --- |
| Settings → UI | Global qwen 0.23.0 baseline has no browser notification control | Final bundled daemon exposes a default-off control; enabling survives reload and sends no daemon settings writes |
| Background terminal events | No browser notification integration | SSE fixture completion/failure creates a generic notification attempt; cancellation and duplicate terminals remain silent |
| Two background tabs | No notification coordination | Simultaneous matching terminal fixtures produce one attempt using real browser Web Locks |
| Switch appearance | Checked Radix state did not match existing CSS selectors | Track color changes and thumb position changes from 1 px to 15 px |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js 22.22.3, Playwright Chromium 149.0.7827.55. Baseline used globally installed qwen 0.23.0; implementation checks used Vite with mockDaemon SSE and the final local dist/cli.js with an isolated runtime and workspace. The repository's existing Ink patch was applied through npm run postinstall before the successful full build. All temporary servers and browser contexts were cleaned up.

## Risk & Scope

- Main risk or tradeoff: Browser permission, page scheduling, and OS policy can prevent delivery. Cross-tab deduplication requires Web Locks and usable shared storage; otherwise it falls back to page-local deduplication and notification tag replacement. A shared claim records an attempt, not successful OS delivery. The shared switch selector fix affects all consumers of that primitive.
- Not validated / out of scope: Actual OS popup display, OS notification-click focus, Safari, Firefox, mobile browsers, Windows, and Linux. The page must remain running and the chat must remain mounted. Closed-page push, background observation of unmounted chats, and Channel delivery are deferred. Embedded hosts do not automatically receive this feature.
- Breaking changes / migration notes: None. No new daemon routes, connections, settings schema, or public SDK callback. The new browser-origin preference defaults to off; notifications contain no chat body, error details, or paths.

## Linked Issues

Related: #11251 (independent implementation; no dependency and no automatic issue closure).

<details>
<summary>中文说明</summary>

## What this PR does

为独立 Web Shell 增加可选的浏览器任务通知，入口为 Settings → UI。偏好默认关闭，按浏览器站点保存，并在标签页之间同步。用户明确授权后，后台或失焦页面可以在被观察聊天的回合完成或失败时提醒。取消回合和初始历史保持静默。通知使用通用文案，不暴露聊天正文或工作目录。

实现复用已有 daemon 终态事件，在 transcript 投影后处理；同会话恢复期间保留已接收的 prompt 跟踪，并在分屏之间去重，在 Web Locks 和存储可用时还会跨同源标签页协调通知尝试。同时修正共享开关的 Radix 状态选择器，使开启和关闭在视觉上清晰可辨。本实现不依赖 #11251。

## Why it's needed

daemon 终态事件和侧边栏未读标记无法提醒已经离开 Web Shell 窗口的用户。浏览器本地开关让用户自行选择通知，无需更改 daemon 设置，也不会自动申请浏览器权限。

## Reviewer Test Plan

### How to verify

1. 打开独立 Web Shell，进入 Settings → UI，确认即使浏览器已允许通知，“浏览器任务通知”仍默认关闭。明确开启并刷新，确认偏好保留。切换 Workspace/User 设置范围不应改变它，也不应写入 daemon 设置。
2. 保持当前聊天或分屏聊天挂载，将页面切到后台，让回合完成或失败。确认仅尝试发送通用完成/失败通知；取消回合、初始历史和此前已在前台处理的回合均保持静默。
3. 打开两个同源页面，确认开关变化同步；Web Locks 与 localStorage 可用时，同时收到重复终态只尝试通知一次。让已接收的 prompt 断线重连，确认恢复终态仅处理一次，无关历史终态保持静默。
4. 撤回通知权限，确认保存的偏好仍可见，但停止发送。在一页等待重新授权时，通过另一页关闭通知；迟到的授权结果不得重新开启。确认开关轨道与滑块在开启/关闭时有明显变化。

验证已通过：全仓 build、typecheck、bundle；六个相关测试文件共 365 项测试；修改文件的 ESLint、Prettier；diff 空白检查；八组 Chromium 页面验收；最终构建 Web Shell 的隔离真实 daemon 冒烟。页面测试使用真实 SSE fixture 和真实 Web Locks，通知 API 使用 stub。产物 daemon 冒烟验证设置及持久化，不调用模型或发送真实通知。

### Evidence (Before & After)

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| Settings → UI | 全局 qwen 0.23.0 基线没有浏览器通知控件 | 最终 daemon 产物提供默认关闭的控件；开启后刷新仍保留，且没有 daemon 设置写入 |
| 后台终态事件 | 没有浏览器通知接入 | SSE fixture 的完成/失败产生通用通知尝试；取消和重复终态保持静默 |
| 两个后台标签页 | 没有通知协调 | 同时到达的相同终态 fixture 通过浏览器真实 Web Locks 仅产生一次尝试 |
| 开关外观 | 已开启的 Radix 状态无法匹配原有 CSS 选择器 | 轨道颜色变化，滑块位置从 1 px 变为 15 px |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### Environment (optional)

macOS、Node.js 22.22.3、Playwright Chromium 149.0.7827.55。基线使用全局安装的 qwen 0.23.0；实现验证使用 Vite 配合 mockDaemon SSE，以及隔离 runtime/workspace 下的最终本地 dist/cli.js。成功完成全仓构建前，已通过 npm run postinstall 应用仓库已有的 Ink 补丁。所有临时服务和浏览器 context 均已清理。

## Risk & Scope

- Main risk or tradeoff: 浏览器权限、页面调度和操作系统策略可能阻止投递。跨标签页去重需要 Web Locks 和可用的共享存储，否则退化为页面内去重和相同通知 tag 的替换。共享记录表示一次尝试，不表示操作系统投递成功。共享开关选择器修复会影响该基础组件的所有使用方。
- Not validated / out of scope: 真实系统弹窗、点击系统通知后的聚焦、Safari、Firefox、移动端、Windows、Linux。页面必须保持运行，聊天必须保持挂载。关闭网页后的推送、未挂载聊天的后台观察及 Channel 投递留待后续。嵌入式宿主不会自动启用该功能。
- Breaking changes / migration notes: 无。没有新增 daemon 路由、连接、设置 schema 或公开 SDK 回调。新浏览器站点偏好默认关闭；通知不包含聊天正文、错误详情或路径。

## Linked Issues

关联：#11251（独立实现，不构成依赖，不自动关闭 issue）。

</details>
