### PR TITLE
test(e2e): isolate permission-control suite from shared QWEN_HOME memory state

### DIFF
--- a/integration-tests/sdk-typescript/permission-control.test.ts
+++ b/integration-tests/sdk-typescript/permission-control.test.ts
@@ -41,6 +41,7 @@ const LOCAL_OPENAI_NO_PROXY = IS_CONTAINER_SANDBOX
   ? CONTAINER_SANDBOX_NO_PROXY
   : '127.0.0.1,localhost';
 const FAKE_SERVER_OPTIONS = fakeServerHostOptions();
+let isolatedQwenHome: string;
 
 function fakeModelOptions(baseUrl: string) {
   return {
@@ -53,6 +54,7 @@ function fakeModelOptions(baseUrl: string) {
       OPENAI_BASE_URL: baseUrl,
       OPENAI_MODEL: 'fake-model',
       QWEN_MODEL: 'fake-model',
+      QWEN_HOME: isolatedQwenHome,
     },
   };
 }
@@ -175,7 +177,22 @@ describe('Permission Control (E2E)', () => {
 
   beforeEach(async () => {
     helper = new SDKTestHelper();
-    testDir = await helper.setup('permission-control');
+    // This suite scripts the fake model server by request index, so nothing
+    // may issue a model request before the turn under test. Give the file its
+    // own QWEN_HOME and switch managed auto memory off: with the shared
+    // hermetic home, earlier files' memory extraction leaves docs that the
+    // pre-turn recall prefetch picks up, and that selector request consumes
+    // the scripted index-0 tool call (#11394).
+    testDir = await helper.setup('permission-control', {
+      settings: {
+        fastModel: 'openai:fake-model',
+        memory: {
+          enableManagedAutoMemory: false,
+          enableManagedAutoDream: false,
+        },
+      },
+    });
+    isolatedQwenHome = await helper.mkdir('global-qwen-home');
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## What this PR does

Gives the permission-control SDK E2E suite the same isolation the tool-control suite already has: its own QWEN_HOME per test file (passed through the query env) and managed auto memory switched off in the seeded settings, with a comment explaining why.

## Why it's needed

The docker leg of `release-sdk.yml` failed 15 of 20 permission-control tests while `sandbox:none` passed in the same run (#11394). The suite scripts its fake model server by request index, but with the run-level hermetic QWEN_HOME shared by every file in the leg, earlier files' memory extraction leaves documents behind, and this suite's pre-turn recall prefetch issues a selector model request before the agent turn, consuming the scripted index-0 tool call. The turn then lands on the trailing text response and no tool is ever invoked. The in-tree precedent (tool-control) already carries exactly this isolation; permission-control was the remaining index-scripted suite without it.

## Reviewer Test Plan

### How to verify

Run the suite twice from a repo root build (`npm run build && npm run bundle`):

```
QWEN_SANDBOX=false npx vitest run --root ./integration-tests sdk-typescript/permission-control.test.ts
```

Expected: 20/20 pass. Observed on this branch: 20/20 pass (macOS arm64).

To reproduce the original failure mode deterministically without a full leg: pre-seed a QWEN_HOME with a parseable user memory document (`memories/role.md` with `type: user` frontmatter), pin it via `QWEN_HOME=<dir>` (globalSetup keeps a pinned home by design), and run the same command on main. With the selector document present, the recall prefetch issues its model request ahead of the agent turn; on the fixed tree the suite passes identically because no selector request is issued at all.

### Evidence (Before & After)

N/A (test infrastructure only)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `npm run build && npm run bundle`, vitest with `QWEN_SANDBOX=false`.

## Risk & Scope

- Main risk or tradeoff: none for the product; the change is confined to one E2E test file. The suite no longer exercises managed auto memory, which it never asserted on.
- Not validated / out of scope: the harness-wide version of this (SDK harness defaults managed auto memory off unless a test opts in, or per-file homes for every suite) is left for maintainers; other SDK suites answer by content or any index, so an extra selector request is harmless to them.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11394

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 permission-control 的 SDK E2E 套件补上 tool-control 套件已有的同等隔离：每个测试文件独立的 QWEN_HOME（通过 query env 传入），并在写入的 settings 里关闭 managed auto memory，附注释说明原因。

## 为什么需要

`release-sdk.yml` 的 docker 腿里 permission-control 20 个测试挂了 15 个，而同一轮的 `sandbox:none` 全过（#11394）。该套件按请求序号给假模型服务器编排响应，但整个腿共享同一个运行级 hermetic QWEN_HOME，前面文件的 memory extraction 会留下文档，本套件在 agent turn 之前的 recall 预取会先发出一个 selector 模型请求，吃掉编排好的 0 号工具调用响应，turn 落到末尾的文本响应上，工具根本不会被调用。仓内已有先例（tool-control）正是这套隔离，permission-control 是剩下的唯一一个没有它的按序号编排的套件。

## 评审验证计划

### 如何验证

在仓库根构建（`npm run build && npm run bundle`）后跑两次：

```
QWEN_SANDBOX=false npx vitest run --root ./integration-tests sdk-typescript/permission-control.test.ts
```

预期：20/20 通过。本分支实测：20/20 通过（macOS arm64）。

不跑完整腿也能确定性地复现原始失败形态：预置一个带可解析 user memory 文档（`memories/role.md`，含 `type: user` frontmatter）的 QWEN_HOME，用 `QWEN_HOME=<dir>` 钉住（globalSetup 按设计保留被钉住的 home），在 main 上跑同一命令：selector 文档存在时，recall 预取会在 agent turn 之前发出模型请求；修复后的树上套件同样通过，因为根本不会发出 selector 请求。

### 证据（前后对比）

N/A（仅测试基建）

### 测试平台

macOS 已测，Windows/Linux 未测（改动为测试基建，平台无关）。

## 风险与范围

- 主要风险：对产品为零，改动只在一个 E2E 测试文件内。该套件不再经过 managed auto memory 路径，但它本来也没有断言过这条路径。
- 未验证/范围之外：harness 级别的同款修法（SDK harness 默认关 managed auto memory、或给每个套件独立 home）留给维护者决定；其它 SDK 套件按内容或任意序号应答，多一个 selector 请求对它们无害。
- 破坏性变更：无。

## 关联 Issue

Fixes #11394

</details>
