### PR TITLE
feat(release): ship the bun/OpenTUI preview archives by default

### DIFF
--- a/.github/scripts/run-release-step.sh
+++ b/.github/scripts/run-release-step.sh
@@ -173,8 +173,10 @@ case "${step}" in
     ;;
 
   build-archives)
+    # bun/OpenTUI preview archives ship by default; OPENTUI_PREVIEW_RELEASE_ENABLED
+    # is an opt-out kill switch — only the literal 'false' disables the flavor.
     preview_args=""
-    if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
+    if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" != "false" ]]; then
       preview_args="--include-opentui-preview"
     fi
     npm run package:standalone:release -- --version "${RELEASE_VERSION}" --out-dir dist/standalone ${preview_args}
@@ -204,7 +206,7 @@ case "${step}" in
 
   verify-archives)
     preview_args=""
-    if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
+    if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" != "false" ]]; then
       preview_args="--include-opentui-preview"
     fi
     npm run verify:installation-release -- --dir dist/standalone ${preview_args}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -687,7 +687,8 @@ jobs:
         env:
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           QWEN_STANDALONE_REQUIRE_AUDIO_CAPTURE_PREBUILD: "${{ github.repository == 'QwenLM/qwen-code' && '1' || '' }}"
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          # bun/OpenTUI preview archives ship by default; set the repo var to 'false' to opt out.
+          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED != 'false' }}"
         run: '.release-workflow/.github/scripts/run-release-step.sh build-archives'
 
       - *reset_release_workflow_scripts
@@ -707,7 +708,7 @@ jobs:
 
       - name: 'Verify Standalone Archives'
         env:
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED != 'false' }}"
         run: '.release-workflow/.github/scripts/run-release-step.sh verify-archives'
 
       - *reset_release_workflow_scripts

--- a/.github/workflows/sync-release-to-oss.yml
+++ b/.github/workflows/sync-release-to-oss.yml
@@ -75,10 +75,11 @@ jobs:
 
       - name: 'Verify Downloaded Release Assets'
         env:
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          # bun/OpenTUI preview archives ship by default; set the repo var to 'false' to opt out.
+          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED != 'false' }}"
         run: |-
           PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
+          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" != "false" ]]; then
             PREVIEW_ARGS="--include-opentui-preview"
           fi
           npm run verify:installation-release -- --dir dist/standalone ${PREVIEW_ARGS}
@@ -141,12 +142,12 @@ jobs:
         env:
           ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
           RELEASE_TAG: '${{ env.RELEASE_TAG }}'
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED != 'false' }}"
         run: |-
           set -euo pipefail
 
           PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
+          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" != "false" ]]; then
             PREVIEW_ARGS="--include-opentui-preview"
           fi
           mapfile -t release_assets < <(node scripts/verify-installation-release.js --dir dist/standalone --list-release-asset-paths ${PREVIEW_ARGS})
@@ -160,12 +161,12 @@ jobs:
         env:
           ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
           RELEASE_TAG: '${{ env.RELEASE_TAG }}'
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED != 'false' }}"
         run: |-
           set -euo pipefail
 
           PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
+          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" != "false" ]]; then
             PREVIEW_ARGS="--include-opentui-preview"
           fi
           npm run verify:installation-release -- --base-url "${ALIYUN_OSS_PUBLIC_BASE_URL}/releases/qwen-code/${RELEASE_TAG}" ${PREVIEW_ARGS}


### PR DESCRIPTION
## What this PR does

Makes every standalone release also produce the bun/OpenTUI preview archives by default, instead of only when a repository variable is explicitly switched on. The classic Node.js archives are unchanged and remain the default runtime; the bun flavor is purely additive. The existing repository variable is kept, but its meaning flips from opt-in to opt-out: the preview archives now ship unless the variable is set to the literal `false`.

## Why it's needed

The OpenTUI migration is in Phase 2 (real-device validation), tracked in #8662. Testers need a standalone archive that carries the bun runtime and the native OpenTUI render packages to exercise the flicker-free renderer on real terminals. Until now that flavor stayed dark unless someone manually flipped a repository variable before each release, which is an easy step to miss and blocks hands-on validation. Defaulting it on means every release is testable without a manual gate, while the retained variable stays available as a kill switch if the bun flavor ever threatens a release.

## Reviewer Test Plan

### How to verify

This is a release-pipeline behavior change with no runtime code touched, so verification is by reading the gate logic and the packaging tests rather than by running the CLI.

- Confirm the three gate sites now read "not equal to false" rather than "equal to true": the archive build step, the archive verify step in the release workflow, and the three download-verify / OSS-upload / OSS-verify steps in the OSS sync workflow. With the variable unset (empty), the GitHub expression evaluates true, so the preview flavor is included; setting the variable to `false` is the only way to disable it.
- Confirm the packaging tests that assert the release wiring still pass. The relevant assertions check that the workflows still reference the variable and still pass the preview flag, both of which remain true after the flip.
- The end-to-end proof (a release run emitting five classic plus five `-opentui-preview` archives) can only be observed on an actual release run after merge; it is not reproducible locally without a full cross-platform build.

### Evidence (Before & After)

N/A — release-pipeline change, no user-visible TUI surface.

Local verification performed:
- The two tests carrying the gate assertions pass in isolation: `syncs standalone and hosted installation assets during release` and `defines a standalone packaging script`.
- `bash -n` on the release step script and a YAML parse of both workflows are clean.
- The full packaging test file shows one failure, `does not package audio-capture test artifacts`, which reproduces identically on a clean tree with these changes stashed — it fails only because this worktree has no built `packages/audio-capture/dist`, unrelated to this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ (logic + tests)   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A — no local runtime exercised; release-pipeline logic and packaging tests only.

## Risk & Scope

- Main risk or tradeoff: every release now cross-builds and stores five additional bun archives and downloads the Bun runtime for each platform, roughly doubling the archive build/verify time and artifact count. A flaky Bun download could now fail a release that previously succeeded — the retained `false` kill switch mitigates this.
- Not validated / out of scope: an actual release run producing the archives (post-merge observation only); no change to which runtime the default archive uses.
- Breaking changes / migration notes: none for consumers. The repository variable's semantics invert — anyone who previously relied on it being unset to keep the flavor off must now set it to `false`.

## Linked Issues

Part of the OpenTUI migration rollout (#8662), Phase 2 real-device validation.