### PR TITLE
docs(nav): stop hiding the developer examples section

### DIFF
--- a/docs/developers/_meta.ts
+++ b/docs/developers/_meta.ts
@@ -23,7 +23,5 @@ export default {
   'qwen-serve-protocol': 'qwen serve HTTP protocol',
   daemon: 'Daemon Mode (Developer Deep Dive)',
 
-  examples: {
-    display: 'hidden',
-  },
+  examples: 'Examples',
 };


### PR DESCRIPTION
## What this PR does

One line in `docs/developers/_meta.ts`: `examples` stops being `display: 'hidden'`.

## Why it's needed

`docs/developers/examples/daemon-client-quickstart.md` is the only end-to-end walkthrough of the daemon HTTP API, and 59163a3 (merged yesterday, #11314) just rewrote it into the API-only form an external REST integrator actually wants. It is hidden from the nav on both sites, so the page is reachable only by guessing its URL — which is exactly what #11359 had to do, linking it as a GitHub blob. That issue's triage names the hidden section as a concrete gap.

`examples/proxy-script.md` is in the same position.

## Reviewer Test Plan

### How to verify

`cd docs-site && npm run link && npm run dev`, open the Developer Guide sidebar, confirm **Examples** appears with its two pages and that nothing else in the section moved.

### Evidence (Before & After)

Before: `examples` absent from the sidebar; `daemon-client-quickstart` reachable only at a directly-typed URL.
After: `Examples` renders as the last entry of the Developer Guide, after `Daemon Mode (Developer Deep Dive)`.

### Tested on

Not run locally — this box has no browser or docs-site deps installed, and the change is a nav key with no build step of its own. `prettier --check` passes on the file. Please confirm in the preview.

## Risk & Scope

- **Main risk / tradeoff**: the section was hidden deliberately at some point; if that was because the examples are unmaintained rather than because they are internal, the right fix is to update or delete them instead. This PR assumes the former is no longer true, given #11314 just refreshed the daemon quickstart. Maintainer's call.
- **Not validated / out of scope**: this changes nav only on the in-repo `docs-site`. **It does not change the published site**, which carries its own copy of this file — the docs pipeline never syncs `_meta.*` (mechanism written up in #11399). QwenLM/qwen-code-docs#263 is the other half; both are needed, or the next manual mirror re-hides it.
- **Breaking changes / migration**: none. No code, no tests reference this key; `docs-site/src/app/public-docs.js` gates on top-level roots (`users`, `developers`), which is unaffected.

## Linked Issues

Refs #11359, #11399. Pairs with QwenLM/qwen-code-docs#263.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`docs/developers/_meta.ts` 里一行：`examples` 不再是 `display: 'hidden'`。

## 为什么需要

`docs/developers/examples/daemon-client-quickstart.md` 是 daemon HTTP API 唯一的端到端示例，而 59163a3（昨天随 #11314 合并）刚把它改写成外部 REST 集成方真正需要的 API-only 形式。它在两个站点的导航里都是隐藏的，只能靠猜 URL 访问——#11359 就是因此才用 GitHub blob 链接它的，其 triage 也把这个隐藏的分区点名为一处具体缺口。`examples/proxy-script.md` 处境相同。

## 验证

`cd docs-site && npm run link && npm run dev`，打开 Developer Guide 侧栏，确认 **Examples** 出现且带两个页面，其余条目位置不变。

本机没跑（没有浏览器，也没装 docs-site 依赖；该改动是一个导航键，本身没有构建步骤）。`prettier --check` 通过。请在预览里确认。

## 风险与范围

- **主要取舍**：这个分区当初是被有意隐藏的。如果原因是示例年久失修而不是「属于内部内容」，那正确的做法是更新或删除它们，而不是本 PR。本 PR 假设前者已不成立——#11314 刚刷新了 daemon quickstart。请 maintainer 定夺。
- **未验证 / 超出范围**：本改动只影响仓库内的 `docs-site` 导航，**不影响已发布站点**——那边有自己的一份副本，文档管线从不同步 `_meta.*`（机制见 #11399）。QwenLM/qwen-code-docs#263 是另一半，两边都要改，否则下次手工镜像会再把它藏回去。
- **破坏性变更**：无。没有代码或测试引用该键；`docs-site/src/app/public-docs.js` 只按顶层 root（`users`、`developers`）过滤，不受影响。

</details>
