### PR TITLE
fix(web-shell): restore transcript layout and navigation presentation

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -118,7 +118,7 @@
 .contextBodyWithEnvironmentPanel [data-web-shell-message-list] {
   box-sizing: border-box;
   width: calc(100% + 332px);
-  padding-right: 356px;
+  padding-right: 352px;
 }
 
 .chatPane {

--- a/packages/web-shell/client/components/GlobalTurnNavigation.tsx
+++ b/packages/web-shell/client/components/GlobalTurnNavigation.tsx
@@ -123,20 +123,21 @@ export function GlobalTurnNavigation({
     <TooltipProvider disableHoverableContent>
       <nav
         aria-label={t('timeline.sessionTimeline')}
-        className="flex h-full min-h-0 w-16 shrink-0 flex-col justify-center px-3 py-4 text-muted-foreground"
+        className="pointer-events-none flex h-full min-h-0 w-full shrink-0 flex-col justify-center px-[min(12px,25%)] py-4 text-muted-foreground"
         data-global-turn-navigation
       >
         <span className="sr-only">
           {t('timeline.sessionTimeline')} · {count}
         </span>
+        {/* Allow hover ticks to expand past the gutter without covering message hit targets. */}
         <div
           ref={viewport}
-          className="min-h-0 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="-mr-8 min-h-0 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ height: Math.min(count * ROW_HEIGHT, 360) }}
           onScroll={(event) => setTop(event.currentTarget.scrollTop)}
         >
           <ol
-            className="relative m-0 list-none p-0"
+            className="relative my-0 mr-8 ml-0 list-none p-0"
             style={{ height: count * ROW_HEIGHT }}
           >
             {Array.from({ length: end - start }, (_, index) => {
@@ -162,7 +163,7 @@ export function GlobalTurnNavigation({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        className={`${timelineStyles.sessionTimelineButton} ${state.selected?.ordinal === ordinal ? timelineStyles.sessionTimelineButtonCurrent : ''}`}
+                        className={`${timelineStyles.sessionTimelineButton} pointer-events-auto ${state.selected?.ordinal === ordinal ? timelineStyles.sessionTimelineButtonCurrent : ''}`}
                         style={{ top: 0, width: '100%' }}
                         aria-label={title}
                         aria-current={
@@ -220,7 +221,7 @@ export function GlobalTurnNavigation({
                       side="right"
                       sideOffset={8}
                       collisionPadding={12}
-                      className="!animate-none grid w-[350px] max-w-[calc(100vw-100px)] gap-1.5 rounded-xl border border-border bg-background px-3.5 py-3 text-foreground shadow-lg [&_[data-slot=tooltip-arrow]]:hidden"
+                      className={`${timelineStyles.sessionTimelinePreview} !animate-none max-w-none ring-0 [&_[data-slot=tooltip-arrow]]:hidden!`}
                     >
                       <span className="line-clamp-2 text-sm font-semibold">
                         {label ??
@@ -242,6 +243,7 @@ export function GlobalTurnNavigation({
           <Button
             variant="ghost"
             size="sm"
+            className="pointer-events-auto"
             onClick={() => setRetry((value) => value + 1)}
           >
             {t('history.retry')}

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -5115,8 +5115,8 @@ describe('MessageList — turn collapse (DOM)', () => {
     scrollIntoView.mockRestore();
   });
 
-  it('hides the session timeline when the message list is narrow', async () => {
-    const rectSpy = mockMessageListWidth(1000);
+  it('hides the session timeline below the default content width', async () => {
+    const rectSpy = mockMessageListWidth(999);
 
     const c = mount(simpleTurns(4));
     await nextFrame();

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -198,28 +198,33 @@
   position: sticky;
   top: 50vh;
   z-index: 4;
-  width: 0 !important;
+  width: 100% !important;
   height: 0;
   margin-right: 0 !important;
   margin-left: 0 !important;
   transition: none;
-  transform: translateX(-22px);
+  transform: translateX(-20px);
   pointer-events: none;
 }
 
 .sessionTimelinePanel {
   position: absolute;
   top: 0;
-  left: 22px;
-  width: 86px;
+  left: 0;
+  width: clamp(
+    20px,
+    calc((100% + 40px - var(--chat-content-width, 1000px)) / 2),
+    86px
+  );
+  padding-left: 5px;
   overflow: visible;
   color: var(--muted-foreground);
-  pointer-events: auto;
+  pointer-events: none;
   transform: translateY(-50%);
 }
 
 .sessionTimelineViewport {
-  width: 70px;
+  width: calc(100% + 32px);
   max-height: min(640px, max(220px, calc(100vh - 220px)));
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -271,7 +276,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin: 0;
+  margin: 0 32px 0 0;
   padding: 32px 0;
   list-style: none;
 }
@@ -286,7 +291,8 @@
   top: -6.5px;
   display: flex;
   align-items: center;
-  width: 58px;
+  width: 100%;
+  pointer-events: auto;
   height: 16px;
   padding: 0;
   border: 0;
@@ -308,6 +314,7 @@
 
 .sessionTimelineTick {
   display: block;
+  pointer-events: none;
   width: 10px;
   height: 3px;
   border-radius: 1px;
@@ -485,11 +492,5 @@
 
   .sessionTimelineDetails {
     animation: none;
-  }
-}
-
-@media (max-width: 720px) {
-  .sessionTimelinePanel {
-    display: none;
   }
 }

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -1,7 +1,7 @@
 .list {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 24px calc(8px + var(--web-shell-bottom-panel-inset, 0px));
+  padding: 12px 20px calc(8px + var(--web-shell-bottom-panel-inset, 0px));
   scroll-padding-bottom: calc(8px + var(--web-shell-bottom-panel-inset, 0px));
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
@@ -405,6 +405,13 @@
 .sessionTimelineDetails {
   position: fixed;
   z-index: 999;
+  transform: translate3d(0, -50%, 0) scale(1);
+  transform-origin: left center;
+  animation: sessionTimelineDetailsIn 120ms ease-out;
+}
+
+.sessionTimelineDetails,
+.sessionTimelinePreview.sessionTimelinePreview {
   box-sizing: border-box;
   display: grid;
   gap: 6px;
@@ -419,9 +426,6 @@
   pointer-events: none;
   text-align: left;
   opacity: 1;
-  transform: translate3d(0, -50%, 0) scale(1);
-  transform-origin: left center;
-  animation: sessionTimelineDetailsIn 120ms ease-out;
 }
 
 @keyframes sessionTimelineDetailsIn {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -61,6 +61,7 @@ import {
 } from './artifacts/TurnOutputs';
 import { ParallelAgentsGroup } from './messages/tools/ParallelAgentsGroup';
 import { useSharedNow } from '../hooks/useSharedNow';
+import { useChatNavigationVisible } from '../hooks/useChatNavigationVisible';
 import {
   isActiveToolStatus,
   toolContainsCallId,
@@ -69,7 +70,10 @@ import { getMcpAppDisplay } from './messages/McpApp';
 import turnCollapseStyles from './TurnCollapseRow.module.css';
 import flashStyles from './MessageLocateFlash.module.css';
 import styles from './MessageList.module.css';
-import { WEB_SHELL_TRANSCRIPT_RELOAD_BLOCKS } from '../constants/sessions';
+import {
+  SESSION_TIMELINE_MIN_VISIBLE_ENTRIES,
+  WEB_SHELL_TRANSCRIPT_RELOAD_BLOCKS,
+} from '../constants/sessions';
 import type { AttachmentPreviewRequest } from '../adapters/messageTypes';
 
 const noopTurnOutputAction = () => undefined;
@@ -2206,7 +2210,6 @@ const FOLLOW_BOTTOM_THRESHOLD_PX = 30;
 const LOAD_OLDER_HISTORY_THRESHOLD_PX = 160;
 const OLDER_HISTORY_ANCHOR_WAIT_FRAMES = 30;
 export const VIRTUAL_SCROLL_THRESHOLD = 200;
-const SESSION_TIMELINE_MIN_VISIBLE_ENTRIES = 4;
 
 export function shouldUseVirtualScroll(
   totalCount: number,
@@ -3266,8 +3269,11 @@ export const MessageList = memo(
       }
       return { key: null };
     }, [backgroundSummaryGraceActive, displayItems]);
-    const [isSessionTimelineVisible, setIsSessionTimelineVisible] =
-      useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const isSessionTimelineVisible = useChatNavigationVisible(
+      containerRef,
+      !hideSessionTimeline,
+    );
     const [automaticallyExpandedAgentKeys, setAutomaticallyExpandedAgentKeys] =
       useState<ReadonlySet<string>>(() => new Set());
     const handleAutomaticAgentExpansionChange = useCallback(
@@ -3287,8 +3293,7 @@ export const MessageList = memo(
       t: typeof t;
       entries: SessionTimelineEntry[];
     } | null>(null);
-    // Signature + entries are O(transcript text); only pay for them while the
-    // rail can actually show (container >= 1160px — never on mobile).
+    // Signature + entries are O(transcript text); only pay while the rail can show.
     const sessionTimelineEntries = useMemo(() => {
       if (!isSessionTimelineVisible) return EMPTY_SESSION_TIMELINE_ENTRIES;
       const signature = getSessionTimelineSignature(mergedMessages);
@@ -3433,7 +3438,6 @@ export const MessageList = memo(
     const pendingFollowRecheckFrame = useRef<number | undefined>(undefined);
     const pendingOverflowFrame = useRef<number | undefined>(undefined);
     catchingUpRef.current = catchingUp;
-    const containerRef = useRef<HTMLDivElement>(null);
     const olderHistoryRetryBlocked = useRef(false);
     const olderHistoryAnchorFrame = useRef<number | undefined>(undefined);
     const olderHistoryAnchorWaitFrame = useRef<number | undefined>(undefined);
@@ -3755,30 +3759,6 @@ export const MessageList = memo(
 
     const hasEnoughSessionTimelineEntries =
       sessionTimelineEntries.length >= SESSION_TIMELINE_MIN_VISIBLE_ENTRIES;
-
-    useLayoutEffect(() => {
-      if (hideSessionTimeline) {
-        setIsSessionTimelineVisible((prev) => (prev ? false : prev));
-        return;
-      }
-
-      const el = containerRef.current;
-      if (!el) return;
-
-      const updateVisibility = () => {
-        const width = el.getBoundingClientRect().width;
-        const nextVisible = width >= 1160;
-        setIsSessionTimelineVisible((prev) =>
-          prev === nextVisible ? prev : nextVisible,
-        );
-      };
-
-      updateVisibility();
-      if (typeof ResizeObserver === 'undefined') return;
-      const observer = new ResizeObserver(updateVisibility);
-      observer.observe(el);
-      return () => observer.disconnect();
-    }, [hideSessionTimeline]);
 
     // ── Scroll-follow state ──────────────────────────────────────────────
     //

--- a/packages/web-shell/client/components/TranscriptViewport.module.css
+++ b/packages/web-shell/client/components/TranscriptViewport.module.css
@@ -4,18 +4,18 @@
 
 .navigation {
   display: none;
+  position: absolute;
+  inset: 0 auto 0 0;
+  z-index: 4;
+  width: clamp(
+    20px,
+    calc((100% - var(--chat-content-width, 1000px)) / 2),
+    64px
+  );
 }
 
 @container (min-width: 600px) {
   .navigation {
     display: flex;
-  }
-
-  /* The in-flow navigation rail (w-16, see GlobalTurnNavigation) narrows this
-     column, so the margin-centered content column sits half a rail width
-     right of the pane axis the composer below is centered on. Mirror the
-     rail on the right to keep both on one axis. */
-  .columnWithRail {
-    padding-right: 4rem;
   }
 }

--- a/packages/web-shell/client/components/TranscriptViewport.module.css
+++ b/packages/web-shell/client/components/TranscriptViewport.module.css
@@ -14,8 +14,6 @@
   );
 }
 
-@container (min-width: 600px) {
-  .navigation {
-    display: flex;
-  }
+.navigation:not([hidden]) {
+  display: flex;
 }

--- a/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.pending.test.tsx
@@ -53,9 +53,14 @@ const head: DaemonSessionTurnIndexPage = {
   v: 1,
   sessionId: 'session',
   snapshot: 'snapshot',
-  totalTurns: 1,
+  totalTurns: 4,
   start: 0,
-  turns: [{ ordinal: 0, turnId: 'old', kind: 'prompt', label: 'old' }],
+  turns: Array.from({ length: 4 }, (_, ordinal) => ({
+    ordinal,
+    turnId: ordinal === 0 ? 'old' : `turn-${ordinal}`,
+    kind: 'prompt' as const,
+    label: 'old',
+  })),
 };
 const page: DaemonSessionTranscriptPage = {
   v: 1,

--- a/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.scroll.test.tsx
@@ -210,9 +210,14 @@ async function setup(
         v: 1,
         sessionId: 'session',
         snapshot: 's',
-        totalTurns: 1,
+        totalTurns: 4,
         start: 0,
-        turns: [{ ordinal: 0, turnId: 'u1', kind: 'prompt', label: 'u1' }],
+        turns: Array.from({ length: 4 }, (_, ordinal) => ({
+          ordinal,
+          turnId: ordinal === 0 ? 'u1' : `turn-${ordinal}`,
+          kind: 'prompt' as const,
+          label: 'u1',
+        })),
       };
     });
   const client: DaemonTurnNavigationClient = {

--- a/packages/web-shell/client/components/TranscriptViewport.test.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.test.tsx
@@ -70,7 +70,7 @@ afterEach(() => {
 const live: Message[] = [
   { id: 'live', role: 'user', content: 'live', timestamp: 1 },
 ];
-async function setup(supported = true, cursorOnly = false) {
+async function setup(supported = true, cursorOnly = false, turnCount = 4) {
   vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   vi.stubGlobal('requestAnimationFrame', () => 1);
   vi.stubGlobal('cancelAnimationFrame', () => undefined);
@@ -97,9 +97,14 @@ async function setup(supported = true, cursorOnly = false) {
       v: 1,
       sessionId: 'session',
       snapshot: 'snapshot',
-      totalTurns: 1,
+      totalTurns: turnCount,
       start: 0,
-      turns: [{ ordinal: 0, turnId: 'old', kind: 'prompt', label: 'old' }],
+      turns: Array.from({ length: turnCount }, (_, ordinal) => ({
+        ordinal,
+        turnId: ordinal === 0 ? 'old' : `turn-${ordinal}`,
+        kind: 'prompt' as const,
+        label: 'old',
+      })),
     }),
     getTranscriptPage,
     materializeTranscriptEvents: () => ({
@@ -159,6 +164,15 @@ async function setup(supported = true, cursorOnly = false) {
 }
 
 describe('TranscriptViewport', () => {
+  it.each([0, 3, 4])(
+    'requires at least four indexed turns (count=%i)',
+    async (count) => {
+      await setup(true, false, count);
+      expect(
+        container!.querySelector('[data-global-turn-navigation]') !== null,
+      ).toBe(count >= 4);
+    },
+  );
   it('pins the visible child of an expanded cross-page tool group', async () => {
     const { store, client, click, getTranscriptPage } = await setup();
     let toolId = 'newer-tool';

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -299,7 +299,7 @@ export const TranscriptViewport = forwardRef<
         </div>
       )}
       <div
-        className={`${globalNavigation ? styles.columnWithRail : ''} flex min-h-0 min-w-0 flex-1 flex-col`}
+        className="flex min-h-0 min-w-0 flex-1 flex-col"
         onWheelCapture={(event) => {
           handleScrollIntent();
           loadAtEdge(event.deltaY < 0 ? 'older' : 'newer');

--- a/packages/web-shell/client/components/TranscriptViewport.tsx
+++ b/packages/web-shell/client/components/TranscriptViewport.tsx
@@ -20,7 +20,9 @@ import { Button } from './ui/button';
 import { GlobalTurnNavigation } from './GlobalTurnNavigation';
 import styles from './TranscriptViewport.module.css';
 import { useTranscriptViewport } from '../hooks/useTranscriptViewport';
+import { useChatNavigationVisible } from '../hooks/useChatNavigationVisible';
 import { useI18n } from '../i18n';
+import { SESSION_TIMELINE_MIN_VISIBLE_ENTRIES } from '../constants/sessions';
 
 interface ReadingAnchor {
   source: string;
@@ -49,8 +51,10 @@ export const TranscriptViewport = forwardRef<
     !props.hideSessionTimeline &&
     (viewport.navigation.mode === 'ready' ||
       viewport.navigation.mode === 'loading') &&
-    viewport.navigation.effectiveTurnCount > 0;
+    viewport.navigation.effectiveTurnCount >=
+      SESSION_TIMELINE_MIN_VISIBLE_ENTRIES;
   const root = useRef<HTMLDivElement>(null);
+  const navigationVisible = useChatNavigationVisible(root, globalNavigation);
   const list = useRef<MessageListHandle>(null);
   const anchor = useRef<ReadingAnchor | undefined>(undefined);
   const entryDirection = useRef<'older' | 'newer'>('older');
@@ -286,7 +290,7 @@ export const TranscriptViewport = forwardRef<
       data-history-viewport={historical ? 'historical' : 'live'}
     >
       {globalNavigation && (
-        <div className={styles.navigation}>
+        <div className={styles.navigation} hidden={!navigationVisible}>
           <GlobalTurnNavigation
             state={viewport.navigation}
             store={viewport.store}

--- a/packages/web-shell/client/constants/sessions.ts
+++ b/packages/web-shell/client/constants/sessions.ts
@@ -15,6 +15,7 @@ export const SESSION_LIVE_STATE_FEATURE = 'workspace_session_live_state';
 export const SESSION_TRANSCRIPT_PAGINATION_FEATURE =
   'session_transcript_pagination';
 export const SESSION_TURN_NAVIGATION_FEATURE = 'session_turn_navigation';
+export const SESSION_TIMELINE_MIN_VISIBLE_ENTRIES = 4;
 export const SESSION_MONITOR_TOOL_CORRELATION_FEATURE =
   'session_monitor_tool_correlation';
 export const SESSION_SIDE_TASK_FEATURE = 'session_side_task';

--- a/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
@@ -8,23 +8,24 @@ import {
   userTextEvent,
 } from './utils/mockDaemon';
 
-async function expectSameAxis(message: Locator, composer: Locator) {
+async function expectSameEdges(message: Locator, composer: Locator) {
   await expect
     .poll(async () => {
       const messageBox = await message.boundingBox();
       const composerBox = await composer.boundingBox();
       if (!messageBox || !composerBox) return Infinity;
-      return Math.abs(
-        messageBox.x +
-          messageBox.width / 2 -
-          (composerBox.x + composerBox.width / 2),
+      return Math.max(
+        Math.abs(messageBox.x - composerBox.x),
+        Math.abs(
+          messageBox.x + messageBox.width - composerBox.x - composerBox.width,
+        ),
       );
     })
     .toBeLessThanOrEqual(1);
 }
 
 for (const navigation of [true, false]) {
-  test(`transcript stays on the composer axis with turn navigation ${navigation ? 'enabled' : 'unsupported'} @smoke`, async ({
+  test(`transcript matches composer edges with turn navigation ${navigation ? 'enabled' : 'unsupported'} @smoke`, async ({
     page,
     baseURL,
   }, testInfo) => {
@@ -63,6 +64,7 @@ for (const navigation of [true, false]) {
               turnId: 'record-0',
               kind: 'prompt',
               label: 'What is the weather?',
+              detail: 'The weather report includes the weekly forecast.',
             },
           ],
         },
@@ -97,30 +99,53 @@ for (const navigation of [true, false]) {
         ),
       )
       .toBeGreaterThan(0);
-    await expectSameAxis(message, composer);
-    const column = page.locator('[data-history-viewport] > div').last();
-    await expect(column).toHaveCSS(
-      'padding-right',
-      navigation ? '64px' : '0px',
-    );
-
-    // The columns have different widths in this band but still share an axis.
-    await page.setViewportSize({ width: 1300, height: 900 });
-    if (navigation) {
-      await expect(rail).toBeVisible();
+    for (const width of [1440, 1300, 1000, 802, 700, 599]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expectSameEdges(message, composer);
+      const viewport = page.locator('[data-history-viewport]');
       await expect
         .poll(async () => {
-          const messageBox = await message.boundingBox();
-          const composerBox = await composer.boundingBox();
-          return (composerBox?.width ?? 0) - (messageBox?.width ?? Infinity);
+          const scrollBox = await messageList.boundingBox();
+          const viewportBox = await viewport.boundingBox();
+          if (!scrollBox || !viewportBox) return Infinity;
+          return Math.abs(
+            scrollBox.x + scrollBox.width - viewportBox.x - viewportBox.width,
+          );
         })
-        .toBeGreaterThan(1);
+        .toBeLessThanOrEqual(1);
+      const viewportBox = await viewport.boundingBox();
+      if (navigation && viewportBox && viewportBox.width >= 600) {
+        await expect(rail).toBeVisible();
+        const railBox = await rail.boundingBox();
+        const messageBox = await message.boundingBox();
+        expect(railBox!.x + railBox!.width).toBeLessThanOrEqual(messageBox!.x);
+      } else {
+        await expect(rail).toBeHidden();
+      }
     }
-    await expectSameAxis(message, composer);
-
-    await page.setViewportSize({ width: 599, height: 900 });
-    await expect(rail).toBeHidden();
-    await expect(column).toHaveCSS('padding-right', '0px');
-    await expectSameAxis(message, composer);
+    for (const width of navigation ? [1440, 700] : []) {
+      await page.setViewportSize({ width, height: 900 });
+      const tick = rail.locator('[data-turn-ordinal] > span');
+      await rail.locator('[data-turn-ordinal]').hover();
+      await expect
+        .poll(async () => (await tick.boundingBox())?.width ?? 0)
+        .toBeGreaterThan(27);
+      const tickBox = await tick.boundingBox();
+      const railScrollBox = await rail.locator(':scope > div').boundingBox();
+      expect(tickBox!.x + tickBox!.width).toBeLessThanOrEqual(
+        railScrollBox!.x + railScrollBox!.width,
+      );
+      const preview = page.locator('[data-slot="tooltip-content"]');
+      await expect(preview).toBeVisible();
+      await expect(preview).toContainText('What is the weather?');
+      await expect(preview).toContainText(
+        'The weather report includes the weekly forecast.',
+      );
+      await expect(preview).toHaveCSS('border-radius', '14px');
+      await expect(preview).toHaveCSS('padding', '12px 14px');
+      await expect(preview.locator('[data-slot="tooltip-arrow"]')).toBeHidden();
+      await page.mouse.move(500, 10);
+      await expect(preview).toHaveCount(0);
+    }
   });
 }

--- a/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
@@ -31,17 +31,19 @@ for (const navigation of [true, false]) {
   }, testInfo) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     const scenario = createWebShellDaemonScenario({
-      events: [
-        userTextEvent('What is the weather?', { id: 1 }),
+      events: Array.from({ length: 4 }, (_, index) => [
+        userTextEvent('What is the weather?', { id: index * 3 + 1 }),
         assistantTextEvent(
-          `the weather report is ready\n\n${Array.from(
-            { length: 80 },
-            (_, index) => `Forecast detail ${index + 1}.`,
-          ).join('\n\n')}`,
-          { id: 2 },
+          index < 3
+            ? 'Earlier forecast.'
+            : `the weather report is ready\n\n${Array.from(
+                { length: 80 },
+                (_, index) => `Forecast detail ${index + 1}.`,
+              ).join('\n\n')}`,
+          { id: index * 3 + 2 },
         ),
-        turnCompleteEvent('prompt-alignment', { id: 3 }),
-      ],
+        turnCompleteEvent(`prompt-alignment-${index}`, { id: index * 3 + 3 }),
+      ]).flat(),
     });
     if (navigation)
       scenario.capabilities.features.push('session_turn_navigation');
@@ -56,17 +58,15 @@ for (const navigation of [true, false]) {
           v: 1,
           sessionId: scenario.sessionId,
           snapshot: 'mock-snapshot',
-          totalTurns: 1,
+          totalTurns: 4,
           start: 0,
-          turns: [
-            {
-              ordinal: 0,
-              turnId: 'record-0',
-              kind: 'prompt',
-              label: 'What is the weather?',
-              detail: 'The weather report includes the weekly forecast.',
-            },
-          ],
+          turns: Array.from({ length: 4 }, (_, ordinal) => ({
+            ordinal,
+            turnId: `record-${ordinal}`,
+            kind: 'prompt',
+            label: 'What is the weather?',
+            detail: 'The weather report includes the weekly forecast.',
+          })),
         },
       });
     });
@@ -81,9 +81,10 @@ for (const navigation of [true, false]) {
     );
     await expect(page.getByText('Loading...')).toHaveCount(0);
 
-    const rail = page.locator('[data-global-turn-navigation]');
-    if (navigation) await expect(rail).toBeVisible();
-    else await expect(rail).toHaveCount(0);
+    const rail = navigation
+      ? page.locator('[data-global-turn-navigation]')
+      : page.getByTestId('session-timeline');
+    await expect(rail).toBeVisible();
 
     const messageList = page.locator('[data-web-shell-message-list]');
     const message = messageList
@@ -99,7 +100,7 @@ for (const navigation of [true, false]) {
         ),
       )
       .toBeGreaterThan(0);
-    for (const width of [1440, 1300, 1000, 802, 700, 599]) {
+    for (const width of [1440, 1300, 1261, 1260, 1259, 1000, 802, 700, 599]) {
       await page.setViewportSize({ width, height: 900 });
       await expectSameEdges(message, composer);
       const viewport = page.locator('[data-history-viewport]');
@@ -114,7 +115,7 @@ for (const navigation of [true, false]) {
         })
         .toBeLessThanOrEqual(1);
       const viewportBox = await viewport.boundingBox();
-      if (navigation && viewportBox && viewportBox.width >= 600) {
+      if (viewportBox && viewportBox.width >= 1000) {
         await expect(rail).toBeVisible();
         const railBox = await rail.boundingBox();
         const messageBox = await message.boundingBox();
@@ -123,10 +124,39 @@ for (const navigation of [true, false]) {
         await expect(rail).toBeHidden();
       }
     }
-    for (const width of navigation ? [1440, 700] : []) {
+    {
+      const shell = page.locator('[data-web-shell-root]');
+      for (const minWidth of [800, 1200, 1000]) {
+        await shell.evaluate((element, width) => {
+          element.style.setProperty(
+            '--chat-regular-content-width',
+            `${width}px`,
+          );
+        }, minWidth);
+        for (const offset of [-1, 0, 1]) {
+          await page.setViewportSize({
+            width: minWidth + 260 + offset,
+            height: 900,
+          });
+          if (offset < 0) await expect(rail).toBeHidden();
+          else await expect(rail).toBeVisible();
+        }
+      }
+      await page.setViewportSize({ width: 1260, height: 900 });
+      await shell.evaluate((element) => {
+        element.style.setProperty('--chat-regular-content-width', '1200px');
+      });
+      await expect(rail).toBeHidden();
+      await shell.evaluate((element) => {
+        element.style.setProperty('--chat-regular-content-width', '1000px');
+      });
+      await expect(rail).toBeVisible();
+    }
+    for (const width of [1440, 1260]) {
       await page.setViewportSize({ width, height: 900 });
-      const tick = rail.locator('[data-turn-ordinal] > span');
-      await rail.locator('[data-turn-ordinal]').hover();
+      const button = rail.locator('button').first();
+      const tick = button.locator(':scope > span').first();
+      await button.hover();
       await expect
         .poll(async () => (await tick.boundingBox())?.width ?? 0)
         .toBeGreaterThan(27);
@@ -135,15 +165,37 @@ for (const navigation of [true, false]) {
       expect(tickBox!.x + tickBox!.width).toBeLessThanOrEqual(
         railScrollBox!.x + railScrollBox!.width,
       );
-      const preview = page.locator('[data-slot="tooltip-content"]');
+      const preview = page.locator(
+        navigation
+          ? '[data-slot="tooltip-content"]'
+          : '#session-timeline-detail-tooltip',
+      );
       await expect(preview).toBeVisible();
       await expect(preview).toContainText('What is the weather?');
-      await expect(preview).toContainText(
-        'The weather report includes the weekly forecast.',
-      );
+      if (navigation)
+        await expect(preview).toContainText(
+          'The weather report includes the weekly forecast.',
+        );
       await expect(preview).toHaveCSS('border-radius', '14px');
       await expect(preview).toHaveCSS('padding', '12px 14px');
       await expect(preview.locator('[data-slot="tooltip-arrow"]')).toBeHidden();
+      await preview.evaluate((element) => {
+        element.style.pointerEvents = 'none';
+      });
+      const buttonBox = await button.boundingBox();
+      expect(
+        await message.evaluate(
+          (element, y) =>
+            Boolean(
+              document
+                .elementFromPoint(element.getBoundingClientRect().x + 5, y)
+                ?.closest(
+                  '[data-global-turn-navigation], [data-testid="session-timeline"]',
+                ),
+            ),
+          buttonBox!.y + buttonBox!.height / 2,
+        ),
+      ).toBe(false);
       await page.mouse.move(500, 10);
       await expect(preview).toHaveCount(0);
     }

--- a/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
@@ -199,5 +199,17 @@ for (const navigation of [true, false]) {
       await page.mouse.move(500, 10);
       await expect(preview).toHaveCount(0);
     }
+    await test.step('docked environment panel preserves composer alignment', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      const toggle = page.locator('[data-web-shell-environment-toggle]');
+      const panel = page.getByTestId('environment-panel');
+      await toggle.click();
+      await expect(panel).toBeVisible();
+      await expect(panel).toHaveAttribute('data-floating', 'false');
+      await expectSameEdges(message, composer);
+      await toggle.click();
+      await expect(panel).toBeHidden();
+      await expectSameEdges(message, composer);
+    });
   });
 }

--- a/packages/web-shell/client/hooks/useChatNavigationVisible.ts
+++ b/packages/web-shell/client/hooks/useChatNavigationVisible.ts
@@ -1,0 +1,38 @@
+import { useLayoutEffect, useState, type RefObject } from 'react';
+
+export function useChatNavigationVisible(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  const [visible, setVisible] = useState(false);
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || !enabled) {
+      setVisible(false);
+      return;
+    }
+    const container = element.closest('[data-history-viewport]') ?? element;
+    const update = () => {
+      const minWidth =
+        Number.parseFloat(
+          getComputedStyle(element).getPropertyValue(
+            '--chat-regular-content-width',
+          ),
+        ) || 1000;
+      setVisible(container.getBoundingClientRect().width >= minWidth);
+    };
+    update();
+    const resize =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(update);
+    resize?.observe(container);
+    const shell = element.closest('[data-web-shell-root]');
+    const mutation = new MutationObserver(update);
+    if (shell)
+      mutation.observe(shell, { attributes: true, attributeFilter: ['style'] });
+    return () => {
+      resize?.disconnect();
+      mutation.disconnect();
+    };
+  }, [ref, enabled]);
+  return visible;
+}


### PR DESCRIPTION
## What this PR does

Restores the conversation scrollbar to the right edge of the chat pane and aligns message content with the composer at constrained widths, including when the environment panel is docked. Navigation occupies the existing left gutter without reserving space in the transcript layout.

Preserves global turn indexing, virtualized navigation, historical jumps and paging. Both global navigation and its legacy fallback now require at least four turns and an actual chat-container width greater than or equal to `chatMaxWidth` (default 1000px). Resizing, changing the supplied width, and receiving the fourth turn update visibility automatically. Existing wide-mode and split-view restrictions remain in place; an expanded environment panel does not inflate the measured chat width.

Restores the previous hover card appearance (rounded surface, border, shadow, spacing and no arrow) while keeping the current multiline title and summary. Expanded ticks remain visible in narrow gutters without intercepting message clicks.

## Why it's needed

The in-flow navigation rail introduced with #11208 and the compensating right padding in #11338 reserved space on both sides of the transcript. This left the scrollbar 64px inside the chat pane and made messages 136px narrower than the composer at constrained widths. Even with the rail hidden, differing horizontal padding left an 8px width mismatch. The new global-navigation behavior should not change the original conversation layout.

## Reviewer Test Plan

### How to verify

1. Open a conversation with at least four turns and resize between wide and narrow layouts. Message and composer edges should match, and the conversation scrollbar should reach the chat pane's right edge. Open and close the docked environment panel and confirm alignment is preserved.
2. With default settings, confirm navigation is hidden at a 999px chat-container width and visible at 1000px. Repeat with a custom `chatMaxWidth`; change that value without resizing. Fewer than four turns should stay hidden, and receiving the fourth turn should show navigation when enough width is available. Check both global-navigation support and the legacy fallback.
3. Hover and focus navigation entries. Confirm the previous card appearance with the current multiline content, no arrow, and unclipped expanded ticks. Message-side interactions should remain reachable. Select a distant turn and continue paging through history.

### Evidence (Before & After)

Measured with Chromium at a 900px browser height:

| Scenario | Before | After |
| --- | --- | --- |
| 1440px browser, global navigation | Scrollbar inset 64px | Scrollbar reaches the chat pane edge |
| 1300px browser | Message 864px; composer 1000px | Both 1000px |
| 700px browser | Message 524px; composer 660px | Both 660px; navigation hidden under the new width rule |
| Docked environment panel at 1440px browser | Negative control with old 356px padding: message 804px; composer 808px | Both 808px with corrected padding |

209 focused unit tests and five layout/history browser tests passed. The two layout cases were rerun successfully after adding docked-panel coverage for both navigation modes. Temporarily restoring the old panel padding made the same alignment assertion fail on a 4px mismatch in both cases. Web Shell build, typecheck, targeted ESLint and Prettier passed.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | ✅ Chromium E2E, unit tests and package checks |
| 🪟 Windows | ⚠️ Not tested |
| 🐧 Linux | ⚠️ Not tested |

### Environment (optional)

Local Web Shell source served through Vite, Chromium and deterministic mock-daemon fixtures. Additional browser checks exercised the actual `chatMaxWidth` prop and live transition from three to four turns.

## Risk & Scope

- Main risk or tradeoff: navigation now intentionally disappears below the configured content width or before the fourth turn. Both navigation implementations share the visibility rule.
- Not validated / out of scope: full-repository build and typecheck are not green. An unmodified base-main snapshot (`c069801657`) with the same dependencies already exceeds the HTML-export runtime budget (4,206,136 bytes versus 4,200,000). Full-repository typecheck also reports an unchanged ACP bridge string/buffer return mismatch and the export module not generated after that build failure. These unrelated issues were not changed. Cross-platform UI behavior was not tested locally.
- Breaking changes / migration notes: no new public options, daemon protocol changes or data migrations. Existing `chatMaxWidth` controls navigation visibility.

## Linked Issues

Follow-up to #11208 and #11338. No issue is auto-closed.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

将会话滚动条恢复到聊天区域最右侧，并让受限宽度下的消息内容与输入框左右对齐，包括环境面板停靠时的布局。导航仅占用既有的左侧留白，不再挤占正文布局空间。

保留全局回合索引、导航虚拟化、历史回合跳转和分页。新导航与旧版回退导航统一为：至少四个回合，且实际聊天容器宽度大于等于 `chatMaxWidth`（默认 1000px）时才展示。调整容器尺寸、动态修改传入宽度，以及收到第四个回合时，显隐都会自动更新。原有宽屏模式和分屏限制保持不变；展开环境面板不会导致聊天宽度被高估。

恢复旧版悬停卡片的外观（圆角、边框、阴影、内边距、无箭头），保留当前标题与摘要的多行排版。窄导航区域内放大的刻度完整可见，且不会拦截消息点击。

## 修改原因

#11208 引入占据布局空间的导航栏，#11338 又增加右侧补偿内边距，两者在正文左右各预留了一块空间。这导致滚动条距离聊天区域右侧 64px，受限宽度下正文比输入框窄 136px。即使导航隐藏，横向内边距的差异仍会造成 8px 的宽度不一致。新全局导航的行为不应改变原有会话布局。

## 审阅者测试计划

### 如何验证

1. 打开至少四个回合的会话，在宽窄布局之间调整窗口。正文与输入框左右边缘应一致，会话滚动条应贴聊天区域最右侧。打开并关闭停靠的环境面板，确认仍然对齐。
2. 默认设置下，聊天容器宽 999px 时导航隐藏，1000px 时显示。设置自定义 `chatMaxWidth` 后重复验证，并在不调整窗口的情况下动态修改该值。少于四个回合应隐藏；收到第四个回合且宽度足够时应展示。分别检查支持新导航和回退旧导航的场景。
3. 悬停或聚焦导航项，确认卡片恢复旧外观、保留当前多行内容、无箭头，放大刻度不被裁剪。正文侧的交互应仍可触达。选择远处回合并继续翻阅历史消息。

### 修改前后证据

以下数据由 Chromium 在浏览器高度 900px 时测得：

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| 浏览器宽 1440px，启用新导航 | 滚动条向内偏移 64px | 滚动条贴聊天区域右侧 |
| 浏览器宽 1300px | 正文 864px，输入框 1000px | 两者均为 1000px |
| 浏览器宽 700px | 正文 524px，输入框 660px | 两者均为 660px；按新宽度规则隐藏导航 |
| 浏览器宽 1440px，环境面板停靠 | 反向验证恢复旧 356px 内边距：正文 804px，输入框 808px | 修正内边距后两者均为 808px |

209 个相关单测与五个布局/历史导航浏览器测试通过。补充环境面板停靠断言后，新旧导航的两个布局用例再次通过。临时恢复面板旧内边距时，同一对齐断言在两种场景中均能捕获 4px 错位并失败。Web Shell 构建、类型检查、定向 ESLint 和 Prettier 均通过。

### 测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ✅ Chromium E2E、单测与包级检查 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 测试环境

本地 Vite 提供 Web Shell 源码，使用 Chromium 和确定性的模拟 daemon 测试数据。额外浏览器验证覆盖真实 `chatMaxWidth` 属性及实时从三个回合增至四个回合的过程。

## 风险与范围

- 主要风险或取舍：低于配置的内容宽度，或尚未达到第四个回合时，导航将按要求隐藏。两种导航共用显隐规则。
- 未验证或范围外：全仓构建与类型检查尚未通过。使用相同依赖的未修改基线 main 快照（`c069801657`）已超过 HTML 导出运行时代码体积限制（4,206,136 字节，限制 4,200,000 字节）。全仓类型检查还报告既有 ACP bridge 字符串/缓冲区返回类型不匹配，以及构建失败后未生成的导出模块。本次未修改这些无关问题；未在本地验证跨平台 UI 行为。
- 破坏性变更与迁移：无新增公共选项、daemon 协议变更或数据迁移。沿用已有 `chatMaxWidth` 控制导航显隐。

## 关联事项

#11208、#11338 的后续修复，不自动关闭任何 issue。

</details>
