### PR TITLE
fix(cli): restore OpenTUI banner, footer, and loading states; fix the OSS mirror flavor

### DIFF
--- a/.github/workflows/sync-release-to-oss.yml
+++ b/.github/workflows/sync-release-to-oss.yml
@@ -73,14 +73,28 @@ jobs:
           mkdir -p dist/standalone
           gh release download "${RELEASE_TAG}" --dir dist/standalone --pattern '*.tar.gz' --pattern '*.zip' --pattern 'SHA256SUMS'
 
+      - name: 'Detect OpenTUI Preview Assets'
+        id: 'flavor'
+        run: |-
+          set -euo pipefail
+
+          # These steps come from the default branch while the checkout and the
+          # downloaded assets come from the tag being synced, which on a
+          # re-dispatch can predate the preview flavor entirely. A repository
+          # variable describes the default branch, not that tag, so derive the
+          # flavor from the archives this release actually shipped.
+          shopt -s nullglob
+          preview_archives=(dist/standalone/*-opentui-preview.*)
+          preview_args=''
+          if [[ ${#preview_archives[@]} -gt 0 ]]; then
+            preview_args='--include-opentui-preview'
+          fi
+          echo "preview_args=${preview_args}" >> "${GITHUB_OUTPUT}"
+
       - name: 'Verify Downloaded Release Assets'
         env:
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          PREVIEW_ARGS: '${{ steps.flavor.outputs.preview_args }}'
         run: |-
-          PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
-            PREVIEW_ARGS="--include-opentui-preview"
-          fi
           npm run verify:installation-release -- --dir dist/standalone ${PREVIEW_ARGS}
 
       - name: 'Package Hosted Installation Assets'
@@ -141,14 +155,10 @@ jobs:
         env:
           ALIYUN_OSS_BUCKET: "${{ vars.ALIYUN_OSS_BUCKET || 'qwen-code-assets' }}"
           RELEASE_TAG: '${{ env.RELEASE_TAG }}'
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          PREVIEW_ARGS: '${{ steps.flavor.outputs.preview_args }}'
         run: |-
           set -euo pipefail
 
-          PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
-            PREVIEW_ARGS="--include-opentui-preview"
-          fi
           mapfile -t release_assets < <(node scripts/verify-installation-release.js --dir dist/standalone --list-release-asset-paths ${PREVIEW_ARGS})
           node scripts/upload-aliyun-oss-assets.js \
             --bucket "${ALIYUN_OSS_BUCKET}" \
@@ -160,14 +170,10 @@ jobs:
         env:
           ALIYUN_OSS_PUBLIC_BASE_URL: "${{ vars.ALIYUN_OSS_PUBLIC_BASE_URL || 'https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com' }}"
           RELEASE_TAG: '${{ env.RELEASE_TAG }}'
-          OPENTUI_PREVIEW_RELEASE_ENABLED: "${{ vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true' }}"
+          PREVIEW_ARGS: '${{ steps.flavor.outputs.preview_args }}'
         run: |-
           set -euo pipefail
 
-          PREVIEW_ARGS=""
-          if [[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]; then
-            PREVIEW_ARGS="--include-opentui-preview"
-          fi
           npm run verify:installation-release -- --base-url "${ALIYUN_OSS_PUBLIC_BASE_URL}/releases/qwen-code/${RELEASE_TAG}" ${PREVIEW_ARGS}
 
       - name: 'Sync Hosted Installation Assets to Aliyun OSS'

--- a/docs/developers/development/deployment.md
+++ b/docs/developers/development/deployment.md
@@ -115,3 +115,9 @@ The release process is automated through GitHub Actions. The release workflow pe
 1.  Build the NPM packages using `tsc`.
 2.  Publish the NPM packages to the artifact registry.
 3.  Create GitHub releases with bundled assets.
+
+**OpenTUI preview flavor**
+
+Standalone archives ship in the classic Node.js flavor by default. Setting the `OPENTUI_PREVIEW_RELEASE_ENABLED` repository variable to `true` additionally builds the bun/OpenTUI preview flavor, whose archives carry an `-opentui-preview` suffix and whose launcher defaults `QWEN_TUI_RENDERER` to `opentui`. Leaving the variable unset keeps that flavor off.
+
+The variable decides only what a new release builds. The workflow that mirrors a release to Aliyun OSS does not read it: that workflow can be re-dispatched for any tag, and a tag cut before the flavor existed has no preview archives to verify, so it derives the flavor from the archives the release actually shipped.

--- a/packages/cli/src/ui/components/ContextUsageDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextUsageDisplay.tsx
@@ -6,17 +6,10 @@
 
 import { Text } from 'ink';
 import { theme } from '../semantic-colors.js';
-import { t } from '../../i18n/index.js';
-
-/**
- * Format percentage for display, showing ">100" when exceeding limit.
- */
-function formatPercentageUsed(percentage: number): string {
-  if (percentage > 1) {
-    return '>100';
-  }
-  return (percentage * 100).toFixed(1);
-}
+import {
+  contextUsageLabel,
+  formatPercentageUsed,
+} from '../utils/formatters.js';
 
 export const ContextUsageDisplay = ({
   promptTokenCount,
@@ -35,7 +28,7 @@ export const ContextUsageDisplay = ({
   const percentageUsed = formatPercentageUsed(percentage);
   const isOverLimit = percentage > 1;
 
-  const label = terminalWidth < 100 ? t('% used') : t('% context used');
+  const label = contextUsageLabel(terminalWidth);
 
   // Show warning when over limit
   if (isOverLimit) {

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -18,6 +18,7 @@ import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { getRenderableGradientColors } from '../utils/gradientUtils.js';
 import { pickAsciiArtTier } from '../utils/customBanner.js';
 import { t } from '../../i18n/index.js';
+import { formatVersionLabel } from '../../utils/version.js';
 
 /**
  * Auth display type for the Header component.
@@ -50,16 +51,6 @@ function formatAuthDisplayType(
     default:
       return authDisplayType;
   }
-}
-
-/**
- * Format the version for display. Real semver releases get a "v" prefix
- * ("v0.19.4"); a non-semver fallback such as "unknown" (from getCliVersion when
- * the package version can't be resolved) is shown as-is so we never render a
- * bogus "vunknown".
- */
-function formatVersionLabel(version: string): string {
-  return /^\d/.test(version) ? `v${version}` : version;
 }
 
 interface HeaderProps {

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -50,3 +50,20 @@ export const ICON = {
   CHECK: `✓${_VS15}`,
   CROSS: `✖${_VS15}`,
 } as const;
+
+// cli-spinners' `dots`, the frames ink's responding spinner animates. Shared so
+// a frame or rate change cannot land in one renderer only.
+export const SPINNER_FRAMES = [
+  '⠋',
+  '⠙',
+  '⠹',
+  '⠸',
+  '⠼',
+  '⠴',
+  '⠦',
+  '⠧',
+  '⠇',
+  '⠏',
+];
+
+export const SPINNER_INTERVAL_MS = 80;

--- a/packages/cli/src/ui/opentui/opentui-app-shell.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-app-shell.test.tsx
@@ -68,6 +68,9 @@ const mocks = vi.hoisted(() => {
     toolConfirmProps: null as Record<string, unknown> | null,
     shellConfirmProps: null as Record<string, unknown> | null,
     actionConfirmProps: null as Record<string, unknown> | null,
+    bannerProps: null as Record<string, unknown> | null,
+    footerProps: null as Record<string, unknown> | null,
+    loadingProps: null as Record<string, unknown> | null,
     keyboardHandlers: [] as Array<(key: unknown) => void>,
     exitInProgress: false,
     /** Runs while a dispatched command is still awaiting its outcome. */
@@ -194,6 +197,22 @@ vi.mock('./input-prompt.js', () => ({
     return 'input-prompt';
   },
 }));
+vi.mock('./opentui-header.js', () => ({
+  OpenTuiBanner: (props: Record<string, unknown>) => {
+    mocks.state.bannerProps = props;
+    return <span>banner</span>;
+  },
+}));
+vi.mock('./opentui-footer.js', () => ({
+  OpenTuiFooter: (props: Record<string, unknown>) => {
+    mocks.state.footerProps = props;
+    return <span>footer</span>;
+  },
+  OpenTuiLoadingIndicator: (props: Record<string, unknown>) => {
+    mocks.state.loadingProps = props;
+    return <span>loading-indicator</span>;
+  },
+}));
 vi.mock('./dialogs-confirm.js', () => ({
   OpenTuiToolConfirmation: (props: Record<string, unknown>) => {
     mocks.state.toolConfirmProps = props;
@@ -263,6 +282,9 @@ describe('OpenTuiApp shell wiring', () => {
     mocks.state.toolConfirmProps = null;
     mocks.state.shellConfirmProps = null;
     mocks.state.actionConfirmProps = null;
+    mocks.state.bannerProps = null;
+    mocks.state.footerProps = null;
+    mocks.state.loadingProps = null;
     mocks.state.keyboardHandlers.length = 0;
     mocks.state.exitInProgress = false;
     mocks.state.onHandle = null;
@@ -279,6 +301,15 @@ describe('OpenTuiApp shell wiring', () => {
     renderApp();
     await settle();
     expect(screen.getByText('input-prompt')).toBeTruthy();
+  });
+
+  it('mounts the restored banner and footer, and feeds them the streaming flag', async () => {
+    renderApp({ streaming: true });
+    await settle();
+    expect(screen.getByText('banner')).toBeTruthy();
+    expect(screen.getByText('footer')).toBeTruthy();
+    expect(mocks.state.footerProps?.['streaming']).toBe(true);
+    expect(mocks.state.loadingProps?.['streaming']).toBe(true);
   });
 
   it('builds one host, and one dispatcher, across re-renders', async () => {

--- a/packages/cli/src/ui/opentui/opentui-app-shell.tsx
+++ b/packages/cli/src/ui/opentui/opentui-app-shell.tsx
@@ -69,6 +69,8 @@ import { injectCapturedInput } from './early-input.js';
 import { OpenTuiErrorBoundary } from './opentui-error-boundary.js';
 import { OpenTuiDialogMount } from './opentui-dialog-mount.js';
 import { OpenTuiInputPrompt } from './input-prompt.js';
+import { OpenTuiBanner } from './opentui-header.js';
+import { OpenTuiFooter, OpenTuiLoadingIndicator } from './opentui-footer.js';
 import {
   OpenTuiActionConfirmation,
   OpenTuiShellConfirmation,
@@ -751,6 +753,7 @@ export function OpenTuiApp(props: OpenTuiAppProps) {
       onError={(error) => onRenderError?.(error)}
     >
       <box flexDirection="column" flexGrow={1} flexShrink={0}>
+        <OpenTuiBanner config={config} settings={settings} />
         {renderMain ? renderMain() : null}
         {!dialog && !activeModal && !activeToolCall && updateNotice ? (
           <text>{updateNotice}</text>
@@ -796,26 +799,36 @@ export function OpenTuiApp(props: OpenTuiAppProps) {
             availableTerminalHeight={props.availableTerminalHeight}
           />
         ) : (
-          <OpenTuiInputPrompt
-            onSubmit={(text, imagePaths) => {
-              void onSubmit(text, imagePaths);
-            }}
-            userMessages={userMessages}
-            config={config}
-            focus
-            streaming={streaming}
-            onInterrupt={onInterrupt}
-            approvalMode={approvalMode}
-            queueLength={queueLength}
-            onPopQueue={onPopQueue}
-            composerHandle={props.composerHandle}
-            promptSuggestion={promptSuggestion}
-            onPromptSuggestionDismiss={onPromptSuggestionDismiss}
-            onPromptSuggestionAbort={onPromptSuggestionAbort}
-            shellModeActive={shellModeActive}
-            onToggleShellMode={toggleShellMode}
-          />
+          <>
+            <OpenTuiLoadingIndicator streaming={Boolean(streaming)} />
+            <OpenTuiInputPrompt
+              onSubmit={(text, imagePaths) => {
+                void onSubmit(text, imagePaths);
+              }}
+              userMessages={userMessages}
+              config={config}
+              focus
+              streaming={streaming}
+              onInterrupt={onInterrupt}
+              approvalMode={approvalMode}
+              queueLength={queueLength}
+              onPopQueue={onPopQueue}
+              composerHandle={props.composerHandle}
+              promptSuggestion={promptSuggestion}
+              onPromptSuggestionDismiss={onPromptSuggestionDismiss}
+              onPromptSuggestionAbort={onPromptSuggestionAbort}
+              shellModeActive={shellModeActive}
+              onToggleShellMode={toggleShellMode}
+            />
+          </>
         )}
+        <OpenTuiFooter
+          config={config}
+          streaming={Boolean(streaming)}
+          approvalMode={approvalMode}
+          queueLength={queueLength}
+          sessionName={host.sessionName}
+        />
       </box>
     </OpenTuiErrorBoundary>
   );

--- a/packages/cli/src/ui/opentui/opentui-footer.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-footer.test.tsx
@@ -6,9 +6,9 @@
 // @vitest-environment jsdom
 
 /**
- * Tests for the restored OpenTUI footer + loading indicator: the approval-mode
- * label mapping, the status-line render, and the responding spinner that shows
- * only while a turn is in flight.
+ * Tests for the restored OpenTUI footer + responding indicator: the status-line
+ * render, the responding spinner that shows only while a turn is in flight, and
+ * the loading phrases resolved through the shared locale-aware cycler.
  */
 
 import { beforeEach, describe, it, expect, vi } from 'vitest';
@@ -26,6 +26,8 @@ const mocks = vi.hoisted(() => {
     dimensions: { width: 110, height: 40 },
     gitBranch: 'main' as string | undefined,
     promptTokens: 0,
+    /** Stands in for a loaded locale's WITTY_LOADING_PHRASES array. */
+    localePhrases: [] as string[],
   };
   async function buildJsxRuntime() {
     const React = await import('react');
@@ -75,12 +77,23 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   };
 });
 
+// The phrases come from the active locale through the shared cycler; this lets
+// a test load one without booting the whole i18n layer.
+vi.mock('../../i18n/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../i18n/index.js')>();
+  return {
+    ...actual,
+    ta: (key: string) =>
+      key === 'WITTY_LOADING_PHRASES' && mocks.state.localePhrases.length > 0
+        ? mocks.state.localePhrases
+        : actual.ta(key),
+  };
+});
+
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import type { Config } from '@qwen-code/qwen-code-core';
-import {
-  approvalModeLabel,
-  OpenTuiFooter,
-  OpenTuiLoadingIndicator,
-} from './opentui-footer.js';
+import { WITTY_LOADING_PHRASES } from '../hooks/usePhraseCycler.js';
+import { OpenTuiFooter, OpenTuiLoadingIndicator } from './opentui-footer.js';
 
 function fakeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -91,23 +104,11 @@ function fakeConfig(overrides: Partial<Config> = {}): Config {
   } as unknown as Config;
 }
 
-describe('approvalModeLabel', () => {
-  it.each([
-    ['yolo', 'YOLO'],
-    ['auto', 'Auto'],
-    ['auto-edit', 'Auto-edit'],
-    ['accepting-edits', 'Auto-edit'],
-    ['plan', 'Plan'],
-    ['', 'Default'],
-    ['unknown-mode', 'Default'],
-  ])('maps %s to %s', (input, expected) => {
-    expect(approvalModeLabel(input)).toBe(expected);
-  });
-});
-
 describe('OpenTuiLoadingIndicator', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    mocks.state.localePhrases = [];
+    mocks.state.dimensions = { width: 110, height: 40 };
   });
 
   it('renders nothing when not streaming', () => {
@@ -115,9 +116,9 @@ describe('OpenTuiLoadingIndicator', () => {
     expect(container.textContent).toBe('');
   });
 
-  it('shows the spinner row with an Esc-to-cancel hint while streaming', () => {
+  it('shows the spinner row with an esc-to-cancel hint while streaming', () => {
     const { container } = render(<OpenTuiLoadingIndicator streaming />);
-    expect(container.textContent).toContain('Esc to cancel');
+    expect(container.textContent).toContain('esc to cancel');
     expect(container.textContent).toContain('(0s');
   });
 
@@ -128,10 +129,49 @@ describe('OpenTuiLoadingIndicator', () => {
     });
     expect(container.textContent).toContain('(3s');
   });
+
+  it('takes its phrase from the shared cycler fallback list', () => {
+    const { container } = render(<OpenTuiLoadingIndicator streaming />);
+    expect(container.textContent).toContain(WITTY_LOADING_PHRASES[0]);
+  });
+
+  it('takes its phrase from the active locale when one is loaded', () => {
+    mocks.state.localePhrases = ['正在努力搬砖，请稍候...'];
+    const { container } = render(<OpenTuiLoadingIndicator streaming />);
+    expect(container.textContent).toContain('正在努力搬砖，请稍候...');
+  });
+
+  it('truncates a long phrase on a narrow terminal, keeping the cancel hint', () => {
+    mocks.state.dimensions = { width: 40, height: 40 };
+    mocks.state.localePhrases = ['正在努力搬砖，请稍候，马上就好，别催我'];
+    const { container } = render(<OpenTuiLoadingIndicator streaming />);
+    const text = container.textContent ?? '';
+    expect(text).toContain('esc to cancel');
+    expect(text).toContain('…');
+    expect(text).not.toContain('别催我');
+  });
 });
 
 describe('OpenTuiFooter', () => {
-  it('renders the project name, model and approval-mode row', () => {
+  beforeEach(() => {
+    mocks.state.promptTokens = 0;
+    mocks.state.gitBranch = 'main';
+    mocks.state.dimensions = { width: 110, height: 40 };
+  });
+
+  it('truncates the status row to the terminal width instead of wrapping', () => {
+    mocks.state.dimensions = { width: 40, height: 40 };
+    mocks.state.gitBranch = 'a-very-long-branch-name-that-cannot-fit';
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    const line = (container.textContent ?? '').trim();
+    expect(line.length).toBeLessThanOrEqual(40);
+    expect(line.endsWith('…')).toBe(true);
+    expect(line).not.toContain('qwen3-coder-plus');
+  });
+
+  it('renders the project name, git branch and model', () => {
     const { container } = render(
       <OpenTuiFooter config={fakeConfig()} streaming={false} />,
     );
@@ -139,36 +179,108 @@ describe('OpenTuiFooter', () => {
     expect(text).toContain('qwen-code');
     expect(text).toContain('qwen3-coder-plus');
     expect(text).toContain('git:(main)');
-    expect(text).toContain('Default mode');
-    expect(text).toContain('(shift + tab to cycle)');
   });
 
-  it('shows the context indicator only after tokens are used', () => {
-    mocks.state.promptTokens = 0;
-    const { container, rerender } = render(
+  it('omits the git segment outside a repository', () => {
+    mocks.state.gitBranch = undefined;
+    const { container } = render(
       <OpenTuiFooter config={fakeConfig()} streaming={false} />,
     );
-    expect(container.textContent).not.toContain('Context');
-
-    mocks.state.promptTokens = 50_000;
-    rerender(<OpenTuiFooter config={fakeConfig()} streaming={false} />);
-    expect(container.textContent).toContain('Context');
-    expect(container.textContent).toContain('5% used');
+    expect(container.textContent).not.toContain('git:(');
   });
 
-  it('adds the steer hint and the queue badge while streaming', () => {
+  it('leaves out the hint row when nothing is live to report', () => {
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    expect(container.textContent).not.toContain('Enter to steer');
+    expect(container.textContent).not.toContain('queued');
+  });
+
+  it('labels the mode from the shared mapping, not a local table', () => {
+    const { container, rerender } = render(
+      <OpenTuiFooter
+        config={fakeConfig()}
+        streaming
+        approvalMode={ApprovalMode.AUTO_EDIT}
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('auto-accept edits');
+    expect(text).not.toContain('Auto-edit mode');
+    // shift+tab is not bound to cycle modes in this renderer, so ink's
+    // `(shift + tab to cycle)` suffix would be a dead affordance here.
+    expect(text).not.toContain('shift + tab');
+
+    rerender(
+      <OpenTuiFooter
+        config={fakeConfig()}
+        streaming
+        approvalMode={ApprovalMode.YOLO}
+      />,
+    );
+    expect(container.textContent).toContain('YOLO mode');
+  });
+
+  it('orders the hint row as steer, mode, queue', () => {
     const { container } = render(
       <OpenTuiFooter
         config={fakeConfig()}
         streaming
-        approvalMode={'yolo' as never}
         queueLength={2}
+        approvalMode={ApprovalMode.AUTO}
       />,
+    );
+    expect(container.textContent).toContain(
+      'Enter to steer · Ctrl+Q to queue · Auto mode · ⏳ 2 queued',
+    );
+  });
+
+  it('shows the context indicator only after tokens are used', () => {
+    const { container, rerender } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    expect(container.textContent).not.toContain('% context used');
+
+    mocks.state.promptTokens = 50_000;
+    rerender(<OpenTuiFooter config={fakeConfig()} streaming={false} />);
+    expect(container.textContent).toContain('5.0% context used');
+  });
+
+  it('reports over-limit usage as >100 like the ink indicator', () => {
+    mocks.state.promptTokens = 1_500_000;
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    expect(container.textContent).toContain('>100% context used');
+  });
+
+  it('shortens the usage label below 100 columns', () => {
+    mocks.state.dimensions = { width: 90, height: 40 };
+    mocks.state.promptTokens = 50_000;
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    expect(container.textContent).toContain('5.0% used');
+    expect(container.textContent).not.toContain('% context used');
+  });
+
+  it('adds the steer hint and the queue badge while streaming', () => {
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming queueLength={2} />,
     );
     const text = container.textContent ?? '';
     expect(text).toContain('Enter to steer');
-    expect(text).toContain('YOLO mode');
     expect(text).toContain('2 queued');
+  });
+
+  it('shows the queue badge on its own when queued but idle', () => {
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} queueLength={1} />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('1 queued');
+    expect(text).not.toContain('Enter to steer');
   });
 
   it('includes the session name when one is set', () => {

--- a/packages/cli/src/ui/opentui/opentui-footer.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-footer.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// @vitest-environment jsdom
+
+/**
+ * Tests for the restored OpenTUI footer + loading indicator: the approval-mode
+ * label mapping, the status-line render, and the responding spinner that shows
+ * only while a turn is in flight.
+ */
+
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+
+// theme.ts builds a SyntaxStyle at module scope, which needs the OpenTUI
+// native FFI — unavailable in the test runtime. Stub the graphics surface.
+vi.mock('@opentui/core', () => ({
+  SyntaxStyle: { fromStyles: () => ({}) },
+  MouseButton: { LEFT: 0 },
+}));
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    dimensions: { width: 110, height: 40 },
+    gitBranch: 'main' as string | undefined,
+    promptTokens: 0,
+  };
+  async function buildJsxRuntime() {
+    const React = await import('react');
+    const jsx = (
+      type: unknown,
+      props: { children?: unknown; key?: React.Key } | null,
+      key?: React.Key,
+    ) => {
+      const config = key === undefined ? props : { ...props, key };
+      const children = (config?.children ?? null) as React.ReactNode;
+      if (type === 'box' || type === 'text') {
+        return React.createElement(
+          type === 'box' ? 'div' : 'span',
+          key === undefined ? null : { key },
+          children,
+        );
+      }
+      return React.createElement(
+        type as React.ElementType,
+        config as Record<string, unknown>,
+        children,
+      );
+    };
+    return { jsx, jsxs: jsx, jsxDEV: jsx, Fragment: React.Fragment };
+  }
+  return { state, buildJsxRuntime };
+});
+
+vi.mock('@opentui/react', () => ({
+  useTerminalDimensions: () => mocks.state.dimensions,
+}));
+vi.mock('@opentui/react/jsx-runtime', () => mocks.buildJsxRuntime());
+vi.mock('@opentui/react/jsx-dev-runtime', () => mocks.buildJsxRuntime());
+
+vi.mock('../hooks/useGitBranchName.js', () => ({
+  useGitBranchName: () => mocks.state.gitBranch,
+}));
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    uiTelemetryService: {
+      getLastPromptTokenCount: () => mocks.state.promptTokens,
+    },
+  };
+});
+
+import type { Config } from '@qwen-code/qwen-code-core';
+import {
+  approvalModeLabel,
+  OpenTuiFooter,
+  OpenTuiLoadingIndicator,
+} from './opentui-footer.js';
+
+function fakeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    getTargetDir: () => '/home/user/projects/qwen-code',
+    getModel: () => 'qwen3-coder-plus',
+    getContentGeneratorConfig: () => ({ contextWindowSize: 1_000_000 }),
+    ...overrides,
+  } as unknown as Config;
+}
+
+describe('approvalModeLabel', () => {
+  it.each([
+    ['yolo', 'YOLO'],
+    ['auto', 'Auto'],
+    ['auto-edit', 'Auto-edit'],
+    ['accepting-edits', 'Auto-edit'],
+    ['plan', 'Plan'],
+    ['', 'Default'],
+    ['unknown-mode', 'Default'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(approvalModeLabel(input)).toBe(expected);
+  });
+});
+
+describe('OpenTuiLoadingIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('renders nothing when not streaming', () => {
+    const { container } = render(<OpenTuiLoadingIndicator streaming={false} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows the spinner row with an Esc-to-cancel hint while streaming', () => {
+    const { container } = render(<OpenTuiLoadingIndicator streaming />);
+    expect(container.textContent).toContain('Esc to cancel');
+    expect(container.textContent).toContain('(0s');
+  });
+
+  it('ticks the elapsed counter once per second', () => {
+    const { container } = render(<OpenTuiLoadingIndicator streaming />);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(container.textContent).toContain('(3s');
+  });
+});
+
+describe('OpenTuiFooter', () => {
+  it('renders the project name, model and approval-mode row', () => {
+    const { container } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('qwen-code');
+    expect(text).toContain('qwen3-coder-plus');
+    expect(text).toContain('git:(main)');
+    expect(text).toContain('Default mode');
+    expect(text).toContain('(shift + tab to cycle)');
+  });
+
+  it('shows the context indicator only after tokens are used', () => {
+    mocks.state.promptTokens = 0;
+    const { container, rerender } = render(
+      <OpenTuiFooter config={fakeConfig()} streaming={false} />,
+    );
+    expect(container.textContent).not.toContain('Context');
+
+    mocks.state.promptTokens = 50_000;
+    rerender(<OpenTuiFooter config={fakeConfig()} streaming={false} />);
+    expect(container.textContent).toContain('Context');
+    expect(container.textContent).toContain('5% used');
+  });
+
+  it('adds the steer hint and the queue badge while streaming', () => {
+    const { container } = render(
+      <OpenTuiFooter
+        config={fakeConfig()}
+        streaming
+        approvalMode={'yolo' as never}
+        queueLength={2}
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('Enter to steer');
+    expect(text).toContain('YOLO mode');
+    expect(text).toContain('2 queued');
+  });
+
+  it('includes the session name when one is set', () => {
+    const { container } = render(
+      <OpenTuiFooter
+        config={fakeConfig()}
+        streaming={false}
+        sessionName="my-session"
+      />,
+    );
+    expect(container.textContent).toContain('my-session');
+  });
+});

--- a/packages/cli/src/ui/opentui/opentui-footer.tsx
+++ b/packages/cli/src/ui/opentui/opentui-footer.tsx
@@ -7,54 +7,38 @@
  */
 
 /**
- * OpenTUI footer + loading indicator — visual-parity restore of the ink
- * `Footer` status line and the responding spinner, ported back from the
- * pre-batch `feat/opentui-migrate` implementation the batched merge dropped.
+ * OpenTUI footer + responding indicator — visual-parity restore of the ink
+ * `Footer` status line and `LoadingIndicator`, ported back from the pre-batch
+ * `feat/opentui-migrate` implementation the batched merge dropped.
  *
- * Footer mirrors the original: `➜ project · session · git:(branch) · model ·
- * context% used` plus an approval-mode row. The loading indicator
- * (self-contained spinner + rotating witty phrase + elapsed seconds)
- * sits above the composer while a turn is in flight.
+ * The mode segment is labelled by `formatApprovalModeName`, the mapping the rest
+ * of the UI already uses, and stays dim: the row is truncated as one unit, and
+ * the composer keeps the coloured label for the modes where colour carries
+ * weight. ink's `(shift + tab to cycle)` suffix is omitted because shift+tab is
+ * not bound in this renderer.
  */
 
 import { useEffect, useState } from 'react';
 import nodePath from 'node:path';
+import { useTerminalDimensions } from '@opentui/react';
 import type { ApprovalMode, Config } from '@qwen-code/qwen-code-core';
 import { uiTelemetryService } from '@qwen-code/qwen-code-core';
+import { t } from '../../i18n/index.js';
+import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from '../constants.js';
+import { usePhraseCycler } from '../hooks/usePhraseCycler.js';
 import { useGitBranchName } from '../hooks/useGitBranchName.js';
 import { fmtTokens } from '../components/stats-helpers.js';
+import { formatApprovalModeName } from '../utils/approvalModeDisplay.js';
+import {
+  contextUsageLabel,
+  formatPercentageUsed,
+} from '../utils/formatters.js';
+import { getCachedStringWidth, truncateToWidth } from '../utils/textUtils.js';
 import { C } from './theme.js';
 
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-
-// 80ms matches cli-spinners' `dots`, the spinner ink's responding indicator
-// uses, and the OpenTUI compaction spinner — so both renderers tick alike.
-const SPINNER_INTERVAL_MS = 80;
-
-/** Original witty loading phrases (i18n WITTY_LOADING_PHRASES, en subset). */
-const WITTY_LOADING_PHRASES = [
-  "I'm Feeling Lucky",
-  'Shipping awesomeness... ',
-  'Reticulating splines...',
-  'Consulting the digital spirits...',
-  'Warming up the AI hamsters...',
-  'Generating witty retort...',
-  'Polishing the algorithms...',
-  'Brewing fresh bytes...',
-  'Engaging cognitive processors...',
-  'Untangling neural nets...',
-  'Compiling brilliance...',
-  'Crafting a response worthy of your patience...',
-];
-
-const randomPhrase = () =>
-  WITTY_LOADING_PHRASES[
-    Math.floor(Math.random() * WITTY_LOADING_PHRASES.length)
-  ];
-
 /**
- * Self-contained spinner: owns its frame timer so the high-frequency tick
- * re-renders ONLY this 1-cell component, not the whole transcript tree.
+ * Owns its frame timer so the high-frequency tick re-renders ONLY this 1-cell
+ * component, not the whole transcript tree.
  */
 function Spinner() {
   const [frame, setFrame] = useState(0);
@@ -69,28 +53,6 @@ function Spinner() {
   );
 }
 
-export function approvalModeLabel(mode: string): string {
-  switch (mode) {
-    case 'yolo':
-      return 'YOLO';
-    case 'auto-edit':
-    case 'accepting-edits':
-      return 'Auto-edit';
-    case 'auto':
-      return 'Auto';
-    case 'plan':
-      return 'Plan';
-    default:
-      return 'Default';
-  }
-}
-
-/** `5%` not `5.0%` (original status-line parity). */
-const formatPercentUsed = (pct: number): string => {
-  const rounded = Math.round(pct * 10) / 10;
-  return Number.isInteger(rounded) ? rounded.toFixed(0) : String(rounded);
-};
-
 export interface OpenTuiLoadingIndicatorProps {
   streaming: boolean;
 }
@@ -100,23 +62,32 @@ export function OpenTuiLoadingIndicator({
   streaming,
 }: OpenTuiLoadingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
-  const [phrase, setPhrase] = useState(WITTY_LOADING_PHRASES[0]);
+  const { width } = useTerminalDimensions();
+  // The shared cycler resolves the phrase list for all nine locales and owns
+  // the 15s rotation, so this renderer cannot drift from ink's.
+  const phrase = usePhraseCycler(streaming, false);
   useEffect(() => {
     if (!streaming) return;
     setElapsed(0);
-    setPhrase(randomPhrase());
     const tick = setInterval(() => setElapsed((s) => s + 1), 1000);
-    const rotate = setInterval(() => setPhrase(randomPhrase()), 15000);
-    return () => {
-      clearInterval(tick);
-      clearInterval(rotate);
-    };
+    return () => clearInterval(tick);
   }, [streaming]);
   if (!streaming) return null;
+  const suffix = t('({{time}}{{tokens}} · esc to cancel)', {
+    time: `${elapsed}s`,
+    tokens: '',
+  });
+  // ink truncates the phrase (`wrap="truncate-end"`) rather than letting it wrap,
+  // so the cancel hint survives a narrow terminal. Budget = width − 2 padding −
+  // 2 spinner cells − 1 separating space − the suffix.
+  const phraseBudget = Math.max(0, width - 5 - getCachedStringWidth(suffix));
+  const line = [truncateToWidth(phrase, phraseBudget), suffix]
+    .filter(Boolean)
+    .join(' ');
   return (
     <box paddingLeft={1} paddingRight={1} flexDirection="row">
       <Spinner />
-      <text fg={C.dim}>{`${phrase} (${elapsed}s · Esc to cancel)`}</text>
+      <text fg={C.dim}>{line}</text>
     </box>
   );
 }
@@ -124,86 +95,59 @@ export function OpenTuiLoadingIndicator({
 export interface OpenTuiFooterProps {
   config: Config;
   streaming: boolean;
-  approvalMode?: ApprovalMode;
   queueLength?: number;
   sessionName?: string | null;
+  approvalMode?: ApprovalMode;
 }
 
-/** The status line + approval-mode row (ink `Footer` parity). */
+/** The status line (ink `Footer` parity). */
 export function OpenTuiFooter({
   config,
   streaming,
-  approvalMode,
   queueLength = 0,
   sessionName = null,
+  approvalMode,
 }: OpenTuiFooterProps) {
-  const cfg = config as unknown as
-    | {
-        getTargetDir?: () => string;
-        getModel?: () => unknown;
-        getContentGeneratorConfig?: () =>
-          | { contextWindowSize?: number }
-          | undefined;
-      }
-    | undefined;
-  const targetDir = cfg?.getTargetDir?.() ?? process.cwd();
+  const { width } = useTerminalDimensions();
+  const targetDir = config.getTargetDir();
   const gitBranch = useGitBranchName(targetDir) ?? '';
-
-  const footerProject = nodePath.basename(targetDir);
-  const fm = cfg?.getModel?.();
-  const footerModel =
-    typeof fm === 'string'
-      ? fm
-      : ((fm as { id?: string } | undefined)?.id ?? '');
+  const footerModel = config.getModel();
   const promptTokenCount = uiTelemetryService.getLastPromptTokenCount();
   const contextWindowSize =
-    cfg?.getContentGeneratorConfig?.()?.contextWindowSize;
+    config.getContentGeneratorConfig()?.contextWindowSize;
   // Original status-line parity: the context indicator only appears once tokens
   // have been used, never bare.
-  const contextPct =
-    contextWindowSize && promptTokenCount > 0
-      ? Math.min(
-          100,
-          Math.round((promptTokenCount / contextWindowSize) * 1000) / 10,
-        )
-      : null;
   const contextLabel =
-    contextWindowSize && contextPct != null
-      ? ` · ${fmtTokens(contextWindowSize)} Context ${formatPercentUsed(
-          contextPct,
-        )}% used`
+    contextWindowSize && promptTokenCount > 0
+      ? ` · ${fmtTokens(contextWindowSize)} ${formatPercentageUsed(
+          promptTokenCount / contextWindowSize,
+        )}${contextUsageLabel(width)}`
       : '';
   const footerLine1 =
-    `➜ ${footerProject}` +
+    `➜ ${nodePath.basename(targetDir)}` +
     (sessionName ? ` · ${sessionName}` : '') +
     (gitBranch ? ` · git:(${gitBranch})` : '') +
     (footerModel ? ` · ${footerModel}` : '') +
     contextLabel;
+  const hintSegments = [
+    streaming ? t('Enter to steer · Ctrl+Q to queue') : null,
+    approvalMode ? formatApprovalModeName(approvalMode) : null,
+    queueLength > 0
+      ? `⏳ ${t('{{count}} queued', { count: String(queueLength) })}`
+      : null,
+  ].filter((segment): segment is string => segment !== null);
+  const footerLine2 = hintSegments.join(' · ');
 
-  const modeName = approvalModeLabel(String(approvalMode ?? ''));
-  const modeUpper = modeName.toUpperCase();
-  const modeColor =
-    modeUpper === 'YOLO'
-      ? C.red
-      : modeUpper === 'AUTO' || modeUpper === 'AUTO-EDIT'
-        ? C.green
-        : modeUpper === 'PLAN'
-          ? C.accent
-          : C.dim;
+  // ink Footer parity: the status rows are truncated, never wrapped, so a long
+  // branch or path cannot grow the footer mid-turn (#8667/#8666).
+  const rowBudget = Math.max(0, width - 2);
 
   return (
     <box flexDirection="column" paddingLeft={1} paddingRight={1} flexShrink={0}>
-      <text fg={C.dim}>{footerLine1}</text>
-      <box flexDirection="row">
-        {streaming && (
-          <text fg={C.dim}>{'Enter to steer · Ctrl+Q to queue · '}</text>
-        )}
-        <text fg={modeColor}>{`${modeName} mode`}</text>
-        <text fg={C.dim}>{' (shift + tab to cycle)'}</text>
-        {queueLength > 0 && (
-          <text fg={C.dim}>{` · ⏳ ${queueLength} queued`}</text>
-        )}
-      </box>
+      <text fg={C.dim}>{truncateToWidth(footerLine1, rowBudget)}</text>
+      {footerLine2 && (
+        <text fg={C.dim}>{truncateToWidth(footerLine2, rowBudget)}</text>
+      )}
     </box>
   );
 }

--- a/packages/cli/src/ui/opentui/opentui-footer.tsx
+++ b/packages/cli/src/ui/opentui/opentui-footer.tsx
@@ -1,0 +1,205 @@
+/* eslint-disable react/no-unknown-property */
+/** @jsxImportSource @opentui/react */
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OpenTUI footer + loading indicator — visual-parity restore of the ink
+ * `Footer` status line and the responding spinner, ported back from the
+ * pre-batch `feat/opentui-migrate` implementation the batched merge dropped.
+ *
+ * Footer mirrors the original: `➜ project · session · git:(branch) · model ·
+ * context% used` plus an approval-mode row. The loading indicator
+ * (self-contained 120ms spinner + rotating witty phrase + elapsed seconds)
+ * sits above the composer while a turn is in flight.
+ */
+
+import { useEffect, useState } from 'react';
+import nodePath from 'node:path';
+import type { ApprovalMode, Config } from '@qwen-code/qwen-code-core';
+import { uiTelemetryService } from '@qwen-code/qwen-code-core';
+import { useGitBranchName } from '../hooks/useGitBranchName.js';
+import { fmtTokens } from '../components/stats-helpers.js';
+import { C } from './theme.js';
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/** Original witty loading phrases (i18n WITTY_LOADING_PHRASES, en subset). */
+const WITTY_LOADING_PHRASES = [
+  "I'm Feeling Lucky",
+  'Shipping awesomeness... ',
+  'Reticulating splines...',
+  'Consulting the digital spirits...',
+  'Warming up the AI hamsters...',
+  'Generating witty retort...',
+  'Polishing the algorithms...',
+  'Brewing fresh bytes...',
+  'Engaging cognitive processors...',
+  'Untangling neural nets...',
+  'Compiling brilliance...',
+  'Crafting a response worthy of your patience...',
+];
+
+const randomPhrase = () =>
+  WITTY_LOADING_PHRASES[
+    Math.floor(Math.random() * WITTY_LOADING_PHRASES.length)
+  ];
+
+/**
+ * Self-contained spinner: owns its 120ms frame timer so the high-frequency tick
+ * re-renders ONLY this 1-cell component, not the whole transcript tree.
+ */
+function Spinner() {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const spin = setInterval(() => setFrame((f) => f + 1), 120);
+    return () => clearInterval(spin);
+  }, []);
+  return (
+    <box width={2}>
+      <text fg={C.dim}>{SPINNER_FRAMES[frame % SPINNER_FRAMES.length]}</text>
+    </box>
+  );
+}
+
+export function approvalModeLabel(mode: string): string {
+  switch (mode) {
+    case 'yolo':
+      return 'YOLO';
+    case 'auto-edit':
+    case 'accepting-edits':
+      return 'Auto-edit';
+    case 'auto':
+      return 'Auto';
+    case 'plan':
+      return 'Plan';
+    default:
+      return 'Default';
+  }
+}
+
+/** `5%` not `5.0%` (original status-line parity). */
+const formatPercentUsed = (pct: number): string => {
+  const rounded = Math.round(pct * 10) / 10;
+  return Number.isInteger(rounded) ? rounded.toFixed(0) : String(rounded);
+};
+
+export interface OpenTuiLoadingIndicatorProps {
+  streaming: boolean;
+}
+
+/** Spinner + witty phrase + elapsed seconds, shown above the composer. */
+export function OpenTuiLoadingIndicator({
+  streaming,
+}: OpenTuiLoadingIndicatorProps) {
+  const [elapsed, setElapsed] = useState(0);
+  const [phrase, setPhrase] = useState(WITTY_LOADING_PHRASES[0]);
+  useEffect(() => {
+    if (!streaming) return;
+    setElapsed(0);
+    setPhrase(randomPhrase());
+    const tick = setInterval(() => setElapsed((s) => s + 1), 1000);
+    const rotate = setInterval(() => setPhrase(randomPhrase()), 15000);
+    return () => {
+      clearInterval(tick);
+      clearInterval(rotate);
+    };
+  }, [streaming]);
+  if (!streaming) return null;
+  return (
+    <box paddingLeft={1} paddingRight={1} flexDirection="row">
+      <Spinner />
+      <text fg={C.dim}>{`${phrase} (${elapsed}s · Esc to cancel)`}</text>
+    </box>
+  );
+}
+
+export interface OpenTuiFooterProps {
+  config: Config;
+  streaming: boolean;
+  approvalMode?: ApprovalMode;
+  queueLength?: number;
+  sessionName?: string | null;
+}
+
+/** The status line + approval-mode row (ink `Footer` parity). */
+export function OpenTuiFooter({
+  config,
+  streaming,
+  approvalMode,
+  queueLength = 0,
+  sessionName = null,
+}: OpenTuiFooterProps) {
+  const cfg = config as unknown as
+    | {
+        getTargetDir?: () => string;
+        getModel?: () => unknown;
+        getContentGeneratorConfig?: () =>
+          | { contextWindowSize?: number }
+          | undefined;
+      }
+    | undefined;
+  const targetDir = cfg?.getTargetDir?.() ?? process.cwd();
+  const gitBranch = useGitBranchName(targetDir) ?? '';
+
+  const footerProject = nodePath.basename(targetDir);
+  const fm = cfg?.getModel?.();
+  const footerModel =
+    typeof fm === 'string'
+      ? fm
+      : ((fm as { id?: string } | undefined)?.id ?? '');
+  const promptTokenCount = uiTelemetryService.getLastPromptTokenCount();
+  const contextWindowSize =
+    cfg?.getContentGeneratorConfig?.()?.contextWindowSize;
+  // Original status-line parity: the context indicator only appears once tokens
+  // have been used, never bare.
+  const contextPct =
+    contextWindowSize && promptTokenCount > 0
+      ? Math.min(
+          100,
+          Math.round((promptTokenCount / contextWindowSize) * 1000) / 10,
+        )
+      : null;
+  const contextLabel =
+    contextWindowSize && contextPct != null
+      ? ` · ${fmtTokens(contextWindowSize)} Context ${formatPercentUsed(
+          contextPct,
+        )}% used`
+      : '';
+  const footerLine1 =
+    `➜ ${footerProject}` +
+    (sessionName ? ` · ${sessionName}` : '') +
+    (gitBranch ? ` · git:(${gitBranch})` : '') +
+    (footerModel ? ` · ${footerModel}` : '') +
+    contextLabel;
+
+  const modeName = approvalModeLabel(String(approvalMode ?? ''));
+  const modeUpper = modeName.toUpperCase();
+  const modeColor =
+    modeUpper === 'YOLO'
+      ? C.red
+      : modeUpper === 'AUTO' || modeUpper === 'AUTO-EDIT'
+        ? C.green
+        : modeUpper === 'PLAN'
+          ? C.accent
+          : C.dim;
+
+  return (
+    <box flexDirection="column" paddingLeft={1} paddingRight={1} flexShrink={0}>
+      <text fg={C.dim}>{footerLine1}</text>
+      <box flexDirection="row">
+        {streaming && (
+          <text fg={C.dim}>{'Enter to steer · Ctrl+Q to queue · '}</text>
+        )}
+        <text fg={modeColor}>{`${modeName} mode`}</text>
+        <text fg={C.dim}>{' (shift + tab to cycle)'}</text>
+        {queueLength > 0 && (
+          <text fg={C.dim}>{` · ⏳ ${queueLength} queued`}</text>
+        )}
+      </box>
+    </box>
+  );
+}

--- a/packages/cli/src/ui/opentui/opentui-footer.tsx
+++ b/packages/cli/src/ui/opentui/opentui-footer.tsx
@@ -13,7 +13,7 @@
  *
  * Footer mirrors the original: `➜ project · session · git:(branch) · model ·
  * context% used` plus an approval-mode row. The loading indicator
- * (self-contained 120ms spinner + rotating witty phrase + elapsed seconds)
+ * (self-contained spinner + rotating witty phrase + elapsed seconds)
  * sits above the composer while a turn is in flight.
  */
 
@@ -26,6 +26,10 @@ import { fmtTokens } from '../components/stats-helpers.js';
 import { C } from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+// 80ms matches cli-spinners' `dots`, the spinner ink's responding indicator
+// uses, and the OpenTUI compaction spinner — so both renderers tick alike.
+const SPINNER_INTERVAL_MS = 80;
 
 /** Original witty loading phrases (i18n WITTY_LOADING_PHRASES, en subset). */
 const WITTY_LOADING_PHRASES = [
@@ -49,13 +53,13 @@ const randomPhrase = () =>
   ];
 
 /**
- * Self-contained spinner: owns its 120ms frame timer so the high-frequency tick
+ * Self-contained spinner: owns its frame timer so the high-frequency tick
  * re-renders ONLY this 1-cell component, not the whole transcript tree.
  */
 function Spinner() {
   const [frame, setFrame] = useState(0);
   useEffect(() => {
-    const spin = setInterval(() => setFrame((f) => f + 1), 120);
+    const spin = setInterval(() => setFrame((f) => f + 1), SPINNER_INTERVAL_MS);
     return () => clearInterval(spin);
   }, []);
   return (

--- a/packages/cli/src/ui/opentui/opentui-header.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-header.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// @vitest-environment jsdom
+
+/**
+ * Tests for the restored OpenTUI header banner: it renders the title, model and
+ * directory, and suppresses itself in screen-reader mode or when `ui.hideBanner`
+ * is set — the same conditions the ink AppHeader honours.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+// theme.ts builds a SyntaxStyle at module scope, which needs the OpenTUI
+// native FFI — unavailable in the test runtime. Stub the graphics surface.
+vi.mock('@opentui/core', () => ({
+  SyntaxStyle: { fromStyles: () => ({}) },
+  MouseButton: { LEFT: 0 },
+}));
+
+const mocks = vi.hoisted(() => {
+  const state = { dimensions: { width: 110, height: 40 } };
+  async function buildJsxRuntime() {
+    const React = await import('react');
+    const jsx = (
+      type: unknown,
+      props: { children?: unknown; key?: React.Key } | null,
+      key?: React.Key,
+    ) => {
+      const config = key === undefined ? props : { ...props, key };
+      const children = (config?.children ?? null) as React.ReactNode;
+      if (type === 'box' || type === 'text') {
+        return React.createElement(
+          type === 'box' ? 'div' : 'span',
+          key === undefined ? null : { key },
+          children,
+        );
+      }
+      return React.createElement(
+        type as React.ElementType,
+        config as Record<string, unknown>,
+        children,
+      );
+    };
+    return { jsx, jsxs: jsx, jsxDEV: jsx, Fragment: React.Fragment };
+  }
+  return { state, buildJsxRuntime };
+});
+
+vi.mock('@opentui/react', () => ({
+  useTerminalDimensions: () => mocks.state.dimensions,
+}));
+vi.mock('@opentui/react/jsx-runtime', () => mocks.buildJsxRuntime());
+vi.mock('@opentui/react/jsx-dev-runtime', () => mocks.buildJsxRuntime());
+
+import type { Config } from '@qwen-code/qwen-code-core';
+import type { LoadedSettings } from '../../config/settings.js';
+import { OpenTuiBanner } from './opentui-header.js';
+
+function fakeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    getScreenReader: () => false,
+    getContentGeneratorConfig: () => ({ contextWindowSize: 1_000_000 }),
+    getModelDisplayName: () => 'qwen3-coder-plus',
+    getTargetDir: () => '/home/user/projects/qwen-code',
+    ...overrides,
+  } as unknown as Config;
+}
+
+function fakeSettings(ui: Record<string, unknown> = {}): LoadedSettings {
+  return {
+    merged: { ui },
+    isTrusted: true,
+    system: { settings: {} },
+    workspace: { settings: {} },
+    user: { settings: {} },
+    systemDefaults: { settings: {} },
+  } as unknown as LoadedSettings;
+}
+
+describe('OpenTuiBanner', () => {
+  it('renders the title, model and project directory', () => {
+    const { container } = render(
+      <OpenTuiBanner config={fakeConfig()} settings={fakeSettings()} />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('>_ Qwen Code');
+    expect(text).toContain('qwen3-coder-plus');
+    expect(text).toContain('qwen-code');
+  });
+
+  it('suppresses the banner when ui.hideBanner is set', () => {
+    const { container } = render(
+      <OpenTuiBanner
+        config={fakeConfig()}
+        settings={fakeSettings({ hideBanner: true })}
+      />,
+    );
+    expect(container.textContent).toBe('');
+  });
+
+  it('suppresses the banner in screen-reader mode', () => {
+    const { container } = render(
+      <OpenTuiBanner
+        config={fakeConfig({ getScreenReader: () => true } as Partial<Config>)}
+        settings={fakeSettings()}
+      />,
+    );
+    expect(container.textContent).toBe('');
+  });
+});

--- a/packages/cli/src/ui/opentui/opentui-header.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-header.test.tsx
@@ -63,6 +63,7 @@ import { OpenTuiBanner } from './opentui-header.js';
 function fakeConfig(overrides: Partial<Config> = {}): Config {
   return {
     getScreenReader: () => false,
+    getCliVersion: () => '9.9.9-test',
     getContentGeneratorConfig: () => ({ contextWindowSize: 1_000_000 }),
     getModelDisplayName: () => 'qwen3-coder-plus',
     getTargetDir: () => '/home/user/projects/qwen-code',
@@ -90,6 +91,39 @@ describe('OpenTuiBanner', () => {
     expect(text).toContain('>_ Qwen Code');
     expect(text).toContain('qwen3-coder-plus');
     expect(text).toContain('qwen-code');
+  });
+
+  it('renders the version reported by the config with a v prefix', () => {
+    const { container } = render(
+      <OpenTuiBanner config={fakeConfig()} settings={fakeSettings()} />,
+    );
+    expect(container.textContent).toContain('(v9.9.9-test)');
+  });
+
+  it('shows a non-semver version as-is instead of prefixing it', () => {
+    const { container } = render(
+      <OpenTuiBanner
+        config={fakeConfig({
+          getCliVersion: () => 'nightly',
+        } as Partial<Config>)}
+        settings={fakeSettings()}
+      />,
+    );
+    expect(container.textContent).toContain('(nightly)');
+  });
+
+  it('falls back to unknown rather than an empty label', () => {
+    const { container } = render(
+      <OpenTuiBanner
+        config={fakeConfig({
+          getCliVersion: () => undefined,
+        } as Partial<Config>)}
+        settings={fakeSettings()}
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).toContain('(unknown)');
+    expect(text).not.toContain('()');
   });
 
   it('suppresses the banner when ui.hideBanner is set', () => {

--- a/packages/cli/src/ui/opentui/opentui-header.tsx
+++ b/packages/cli/src/ui/opentui/opentui-header.tsx
@@ -1,0 +1,256 @@
+/* eslint-disable react/no-unknown-property */
+/** @jsxImportSource @opentui/react */
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OpenTUI header banner — visual-parity restore of the ink `AppHeader`/`Header`
+ * (ASCII logo + info panel), ported back from the pre-batch
+ * `feat/opentui-migrate` implementation that the batched merge dropped.
+ *
+ * Stable by construction: depends only on config/settings/width, so it does not
+ * re-render on streaming; resize re-renders without flicker via the erase-free
+ * painter. Honours the same custom-banner resolution as ink (hideBanner /
+ * customAsciiArt / customBannerTitle / customBannerSubtitle) and suppresses in
+ * screen-reader mode.
+ */
+
+import { useMemo } from 'react';
+import { useTerminalDimensions } from '@opentui/react';
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import type { Config } from '@qwen-code/qwen-code-core';
+import {
+  findProviderByCredentials,
+  resolveMetadataKey,
+  shortenPath,
+  tildeifyPath,
+} from '@qwen-code/qwen-code-core';
+import type { LoadedSettings } from '../../config/settings.js';
+import { C } from './theme.js';
+import { shortAsciiLogo } from '../components/AsciiArt.js';
+import { getAsciiArtWidth, getCachedStringWidth } from '../utils/textUtils.js';
+import {
+  pickAsciiArtTier,
+  resolveCustomBanner,
+} from '../utils/customBanner.js';
+
+const LOGO_GRADIENT = ['#4796E4', '#847ACE', '#C3677F'];
+
+function lerpHex(a: string, b: string, t: number): string {
+  const pa = [1, 3, 5].map((i) => parseInt(a.slice(i, i + 2), 16));
+  const pb = [1, 3, 5].map((i) => parseInt(b.slice(i, i + 2), 16));
+  return (
+    '#' +
+    pa
+      .map((v, i) =>
+        Math.round(v + (pb[i] - v) * t)
+          .toString(16)
+          .padStart(2, '0'),
+      )
+      .join('')
+  );
+}
+
+function gradientAt(stops: string[], t: number): string {
+  if (stops.length === 0) return C.accent;
+  if (stops.length === 1) return stops[0];
+  const seg = Math.min(stops.length - 1, Math.floor(t * (stops.length - 1)));
+  const lt = t * (stops.length - 1) - seg;
+  return lerpHex(stops[seg], stops[seg + 1], lt);
+}
+
+/** ASCII logo with the original horizontal gradient (themes GradientColors). */
+function GradientLogo({ logo }: { logo: string }) {
+  const lines = logo.replace(/^\n/, '').split('\n');
+  const w = Math.max(...lines.map((l) => [...l].length), 1);
+  return (
+    <box flexDirection="column" flexShrink={0}>
+      {lines.map((line, li) => (
+        <box key={li} flexDirection="row">
+          {[...line].map((ch, ci) => (
+            <text key={ci} fg={gradientAt(LOGO_GRADIENT, ci / w)}>
+              {ch}
+            </text>
+          ))}
+        </box>
+      ))}
+    </box>
+  );
+}
+
+/**
+ * Faithful port of the ink `Header`: a single-border info panel with 4 lines —
+ * title(+version), blank spacer (or subtitle), auth|model(+hint), directory —
+ * laid out two-column (gradient logo + panel) when wide, panel-only when
+ * narrow. Same data sources as the original, including the AppHeader
+ * custom-banner resolution.
+ */
+function buildBanner(
+  config: Config | undefined,
+  settings: LoadedSettings,
+  width: number,
+) {
+  let versionLabel = '';
+  try {
+    const cliPkg = nodePath.join(
+      nodePath.dirname(process.argv[1]),
+      '..',
+      'package.json',
+    );
+    const v = (JSON.parse(readFileSync(cliPkg, 'utf8')) as { version?: string })
+      .version;
+    versionLabel = v ? (/^\d/.test(v) ? `v${v}` : v) : '';
+  } catch {
+    versionLabel = '';
+  }
+  const cfg = config as unknown as
+    | {
+        getContentGeneratorConfig?: () =>
+          | { authType?: string; baseUrl?: string; apiKeyEnvKey?: string }
+          | undefined;
+        getModelDisplayName?: () => string;
+        getTargetDir?: () => string;
+      }
+    | undefined;
+  const cg = cfg?.getContentGeneratorConfig?.();
+  const model = cfg?.getModelDisplayName?.() ?? 'qwen';
+  const targetDir = cfg?.getTargetDir?.() ?? process.cwd();
+  // auth label (mirrors AppHeader.getAuthDisplayType)
+  let authLabel = '';
+  try {
+    if (cg?.authType) {
+      const matched = findProviderByCredentials(cg.baseUrl, cg.apiKeyEnvKey);
+      authLabel =
+        (matched && resolveMetadataKey(matched) && matched.label) ||
+        (cg.authType === 'qwen-oauth' ? 'Qwen OAuth' : 'API Key');
+    }
+  } catch {
+    authLabel = '';
+  }
+  const authModelText = authLabel ? `${authLabel} | ${model}` : model;
+  const hint = ' (/model to change)';
+
+  const custom = resolveCustomBanner(settings);
+  const containerMarginX = 2;
+  const logoGap = 2;
+  const infoPanelChromeWidth = 2 + 1 * 2; // border(2) + paddingX(1*2)
+  const minInfoPanelWidth = 40 + infoPanelChromeWidth;
+  const available = Math.max(0, width - containerMarginX * 2);
+  // ink Header parity: a fitting custom tier wins; custom art that fits
+  // nowhere hides the logo column (no silent fallback to the bundled logo —
+  // that would undo a white-label deployment on narrow terminals); no custom
+  // art falls through to the bundled shortAsciiLogo.
+  const hasCustomArt = Boolean(custom.asciiArt.small || custom.asciiArt.large);
+  const customTier = pickAsciiArtTier(
+    custom.asciiArt.small,
+    custom.asciiArt.large,
+    available,
+    logoGap,
+    minInfoPanelWidth,
+    getAsciiArtWidth,
+  );
+  const displayLogo = customTier ?? (hasCustomArt ? '' : shortAsciiLogo);
+  const logoWidth = getAsciiArtWidth(displayLogo);
+  const showLogo =
+    displayLogo !== '' && available >= logoWidth + logoGap + minInfoPanelWidth;
+  const maxInfoPanelWidth = 60;
+  const infoPanelWidth = showLogo
+    ? Math.min(available - logoWidth - logoGap, maxInfoPanelWidth)
+    : available;
+  const maxPathLength = Math.max(0, infoPanelWidth - infoPanelChromeWidth);
+  const infoPanelContentWidth = Math.max(
+    0,
+    infoPanelWidth - infoPanelChromeWidth,
+  );
+  const showModelHint =
+    infoPanelContentWidth > 0 &&
+    getCachedStringWidth(authModelText + hint) <= infoPanelContentWidth;
+  const shortenedPath = shortenPath(
+    tildeifyPath(targetDir),
+    Math.max(3, maxPathLength),
+  );
+  const displayPath =
+    maxPathLength <= 0
+      ? ''
+      : shortenedPath.length > maxPathLength
+        ? shortenedPath.slice(0, maxPathLength)
+        : shortenedPath;
+
+  const infoPanel = (
+    <box
+      flexDirection="column"
+      borderStyle="single"
+      paddingX={1}
+      width={infoPanelWidth}
+      flexGrow={showLogo ? 0 : 1}
+    >
+      <box flexDirection="row">
+        <text fg={C.accent} attributes={1}>
+          {custom.title ?? '>_ Qwen Code'}
+        </text>
+        <text fg={C.dim}>{` (${versionLabel})`}</text>
+      </box>
+      {/* Subtitle (when set) replaces the blank spacer row so the auth line
+       * keeps its vertical position (ink Header parity). */}
+      {custom.subtitle ? (
+        <text fg={C.dim}>{custom.subtitle}</text>
+      ) : (
+        <text> </text>
+      )}
+      <box flexDirection="row">
+        <text fg={C.dim}>{authModelText}</text>
+        {showModelHint && <text fg={C.dim}>{hint}</text>}
+      </box>
+      <text fg={C.dim}>{displayPath}</text>
+    </box>
+  );
+
+  if (!showLogo) {
+    return (
+      <box
+        marginLeft={containerMarginX}
+        marginRight={containerMarginX}
+        flexShrink={0}
+      >
+        {infoPanel}
+      </box>
+    );
+  }
+  return (
+    <box
+      flexDirection="row"
+      alignItems="center"
+      marginLeft={containerMarginX}
+      marginRight={containerMarginX}
+      flexShrink={0}
+    >
+      <GradientLogo logo={displayLogo} />
+      <box width={logoGap} />
+      {infoPanel}
+    </box>
+  );
+}
+
+export interface OpenTuiBannerProps {
+  config: Config;
+  settings: LoadedSettings;
+}
+
+/**
+ * Renders the header banner, or nothing when suppressed (screen-reader mode or
+ * `ui.hideBanner`). Memoized on its inputs so streaming does not re-render it.
+ */
+export function OpenTuiBanner({ config, settings }: OpenTuiBannerProps) {
+  const { width } = useTerminalDimensions();
+  const screenReaderMode = config.getScreenReader?.() ?? false;
+  const showBanner = !screenReaderMode && !settings.merged.ui?.hideBanner;
+  const banner = useMemo(
+    () => (showBanner ? buildBanner(config, settings, width) : null),
+    [showBanner, config, settings, width],
+  );
+  return banner;
+}

--- a/packages/cli/src/ui/opentui/opentui-header.tsx
+++ b/packages/cli/src/ui/opentui/opentui-header.tsx
@@ -20,8 +20,6 @@
 
 import { useMemo } from 'react';
 import { useTerminalDimensions } from '@opentui/react';
-import { readFileSync } from 'node:fs';
-import nodePath from 'node:path';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {
   findProviderByCredentials,
@@ -30,6 +28,7 @@ import {
   tildeifyPath,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
+import { formatVersionLabel } from '../../utils/version.js';
 import { C } from './theme.js';
 import { shortAsciiLogo } from '../components/AsciiArt.js';
 import { getAsciiArtWidth, getCachedStringWidth } from '../utils/textUtils.js';
@@ -89,36 +88,11 @@ function GradientLogo({ logo }: { logo: string }) {
  * narrow. Same data sources as the original, including the AppHeader
  * custom-banner resolution.
  */
-function buildBanner(
-  config: Config | undefined,
-  settings: LoadedSettings,
-  width: number,
-) {
-  let versionLabel = '';
-  try {
-    const cliPkg = nodePath.join(
-      nodePath.dirname(process.argv[1]),
-      '..',
-      'package.json',
-    );
-    const v = (JSON.parse(readFileSync(cliPkg, 'utf8')) as { version?: string })
-      .version;
-    versionLabel = v ? (/^\d/.test(v) ? `v${v}` : v) : '';
-  } catch {
-    versionLabel = '';
-  }
-  const cfg = config as unknown as
-    | {
-        getContentGeneratorConfig?: () =>
-          | { authType?: string; baseUrl?: string; apiKeyEnvKey?: string }
-          | undefined;
-        getModelDisplayName?: () => string;
-        getTargetDir?: () => string;
-      }
-    | undefined;
-  const cg = cfg?.getContentGeneratorConfig?.();
-  const model = cfg?.getModelDisplayName?.() ?? 'qwen';
-  const targetDir = cfg?.getTargetDir?.() ?? process.cwd();
+function buildBanner(config: Config, settings: LoadedSettings, width: number) {
+  const versionLabel = formatVersionLabel(config.getCliVersion() ?? 'unknown');
+  const cg = config.getContentGeneratorConfig();
+  const model = config.getModelDisplayName();
+  const targetDir = config.getTargetDir();
   // auth label (mirrors AppHeader.getAuthDisplayType)
   let authLabel = '';
   try {
@@ -246,8 +220,8 @@ export interface OpenTuiBannerProps {
  */
 export function OpenTuiBanner({ config, settings }: OpenTuiBannerProps) {
   const { width } = useTerminalDimensions();
-  const screenReaderMode = config.getScreenReader?.() ?? false;
-  const showBanner = !screenReaderMode && !settings.merged.ui?.hideBanner;
+  const showBanner =
+    !config.getScreenReader() && !settings.merged.ui?.hideBanner;
   const banner = useMemo(
     () => (showBanner ? buildBanner(config, settings, width) : null),
     [showBanner, config, settings, width],

--- a/packages/cli/src/ui/opentui/session-compaction.tsx
+++ b/packages/cli/src/ui/opentui/session-compaction.tsx
@@ -17,7 +17,7 @@
 import { useEffect, useState } from 'react';
 import { CompressionStatus } from '@qwen-code/qwen-code-core/core/turn.js';
 import { t } from '../../i18n/index.js';
-import { ICON } from '../constants.js';
+import { ICON, SPINNER_FRAMES, SPINNER_INTERVAL_MS } from '../constants.js';
 import { C } from './theme.js';
 
 export interface CompactionViewProps {
@@ -97,9 +97,6 @@ export function compactionView(props: CompactionViewProps): CompactionView {
     iconGlyph: ICON.DIAMOND,
   };
 }
-
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-const SPINNER_INTERVAL_MS = 80;
 
 /** The compaction history row: spinner (pending) or diamond, then the text. */
 export function CompressionNotice(props: { view: CompactionView }) {

--- a/packages/cli/src/ui/utils/formatters.test.ts
+++ b/packages/cli/src/ui/utils/formatters.test.ts
@@ -6,8 +6,10 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  contextUsageLabel,
   formatDuration,
   formatMemoryUsage,
+  formatPercentageUsed,
   formatRelativeTime,
   formatTokenCount,
 } from './formatters.js';
@@ -212,6 +214,33 @@ describe('formatters', () => {
       expect(formatTokenCount(10000)).toBe('10k');
       expect(formatTokenCount(15000)).toBe('15k');
       expect(formatTokenCount(100000)).toBe('100k');
+    });
+  });
+
+  describe('formatPercentageUsed', () => {
+    it('renders the used fraction with one decimal', () => {
+      expect(formatPercentageUsed(0)).toBe('0.0');
+      expect(formatPercentageUsed(0.045)).toBe('4.5');
+    });
+
+    it('treats exactly 100% as in limit', () => {
+      expect(formatPercentageUsed(1)).toBe('100.0');
+    });
+
+    it('reports past-limit usage as >100', () => {
+      expect(formatPercentageUsed(1.5)).toBe('>100');
+    });
+  });
+
+  describe('contextUsageLabel', () => {
+    it('uses the full label at 100 columns and wider', () => {
+      expect(contextUsageLabel(100)).toBe('% context used');
+      expect(contextUsageLabel(110)).toBe('% context used');
+    });
+
+    it('drops "context" below 100 columns', () => {
+      expect(contextUsageLabel(99)).toBe('% used');
+      expect(contextUsageLabel(40)).toBe('% used');
     });
   });
 });

--- a/packages/cli/src/ui/utils/formatters.ts
+++ b/packages/cli/src/ui/utils/formatters.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { t } from '../../i18n/index.js';
+
 // Re-exported from core so the CLI UI, the shell/diagnostics paths in core
 // and the serve daemon all render a byte count identically.
 export { formatMemoryUsage } from '@qwen-code/qwen-code-core';
@@ -57,6 +59,18 @@ export const formatTokenCount = (count: number): string => {
   }
   return `${Math.floor(count / 1000)}k`;
 };
+
+/** Context-window usage from the used fraction: `4.5`, or `>100` past the limit. */
+export const formatPercentageUsed = (percentage: number): string => {
+  if (percentage > 1) {
+    return '>100';
+  }
+  return (percentage * 100).toFixed(1);
+};
+
+/** Narrow terminals drop "context" so the indicator still fits. */
+export const contextUsageLabel = (terminalWidth: number): string =>
+  terminalWidth < 100 ? t('% used') : t('% context used');
 
 export interface FormatDurationOptions {
   /**

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -10,3 +10,13 @@ export async function getCliVersion(): Promise<string> {
   const pkgJson = await getPackageJson();
   return process.env['CLI_VERSION'] || pkgJson?.version || 'unknown';
 }
+
+/**
+ * Format the version for display. Real semver releases get a "v" prefix
+ * ("v0.19.4"); a non-semver fallback such as "unknown" (from getCliVersion when
+ * the package version can't be resolved) is shown as-is so we never render a
+ * bogus "vunknown".
+ */
+export function formatVersionLabel(version: string): string {
+  return /^\d/.test(version) ? `v${version}` : version;
+}

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -2460,7 +2460,15 @@ describe('standalone release packaging', () => {
     expect(releaseStepScript).toContain(
       'npm run verify:installation-release -- --dir dist/standalone',
     );
-    expect(releaseWorkflow).toContain('vars.OPENTUI_PREVIEW_RELEASE_ENABLED');
+    // Pin the operator, not just the variable name: these two sites are the
+    // build-time decision, and an assertion that accepts either comparison
+    // lets the flavor's default polarity flip without the suite noticing.
+    expect(releaseWorkflow).toContain(
+      "vars.OPENTUI_PREVIEW_RELEASE_ENABLED == 'true'",
+    );
+    expect(releaseStepScript).toContain(
+      '[[ "${OPENTUI_PREVIEW_RELEASE_ENABLED}" == "true" ]]',
+    );
     expect(releaseStepScript).toContain('--include-opentui-preview');
     expect(releaseWorkflow).not.toContain('package:installation-assets');
     expect(releaseWorkflow).not.toContain('verify_node_checksum()');
@@ -2482,7 +2490,14 @@ describe('standalone release packaging', () => {
     expect(ossWorkflow).toContain(
       'npm run verify:installation-release -- --dir dist/standalone',
     );
-    expect(ossWorkflow).toContain('vars.OPENTUI_PREVIEW_RELEASE_ENABLED');
+    // The sync workflow can be re-dispatched for any tag, and its steps come
+    // from the default branch while the checkout and the assets come from that
+    // tag, so it derives the flavor from the archives the release actually
+    // shipped. A repository variable describes the default branch instead, and
+    // asking a pre-flavor tag for preview archives fails the sync.
+    expect(ossWorkflow).not.toContain('vars.OPENTUI_PREVIEW_RELEASE_ENABLED');
+    expect(ossWorkflow).toContain('dist/standalone/*-opentui-preview.*');
+    expect(ossWorkflow).toContain('steps.flavor.outputs.preview_args');
     expect(ossWorkflow).toContain('--include-opentui-preview');
     expect(ossWorkflow).toContain('secrets.ALIYUN_OSS_ACCESS_KEY_ID');
     expect(ossWorkflow).toContain('secrets.ALIYUN_OSS_ACCESS_KEY_SECRET');


### PR DESCRIPTION
## What this PR does

**Scope note: two independent changes ride in this PR.** The main one restores the missing OpenTUI terminal chrome — banner, status line, responding indicator — under `packages/cli`. The second is a release-pipeline fix carried in its own commit and touching only the object-storage mirror workflow, that workflow's test pin, and one deployment doc: it changes how the mirror decides whether the tag being synced shipped the bun/OpenTUI preview archives. The two share no code, and the second can be dropped from this PR without affecting the first. It is detailed in the fourth paragraph below, verified in its own Reviewer Test Plan subsection, and bounded in Risk & Scope; the reason it is bundled rather than filed separately is in Linked Issues.

Restores three pieces of the terminal chrome that the opt-in OpenTUI renderer has been missing since it became reachable: the startup banner (gradient logo plus the bordered info panel carrying the title, version, auth and model, and working directory), the bottom status line (project, session name, git branch, model, context-window usage, and the approval-mode row with its mid-turn steering hint and queued-message count), and the responding indicator that sits above the composer while a turn is in flight (animated spinner, rotating phrase, elapsed seconds, and the cancel affordance).

All three are rebuilt as their own modules and mounted in the shell in the same positions the ink renderer uses — banner at the top, responding indicator directly above the composer, status line at the bottom. The banner keeps honouring the screen-reader setting and the hide-banner setting, resolves custom banner art through the same per-scope tier logic, and switches from the two-column logo layout to a panel-only layout when the terminal is too narrow, matching the original.

The restored modules originally re-derived several facts main already owns, so this pass routes each one through the existing shared helper instead, keeping a single source of truth per fact and removing the room for the two renderers to drift. The approval-mode name now comes from the same mapping ink's footer, dialog and command use, rendered in the dim status colour while the composer keeps the coloured label for the modes where colour carries weight; the local label table and its colour check are gone. The context-usage figure and its narrow-versus-wide label are extracted into an ink-free helper that both ink's indicator and this status line consume, so the percent sign, the one-decimal value and the past-limit ">100" case have one definition. The loading phrases come from the shared locale-aware cycler that resolves all nine locales rather than a re-declared English subset, and the spinner's frames and tick rate are lifted into shared constants used by both this spinner and the compaction spinner, so the animation runs at the same 80ms ink uses instead of the 120ms the source ran at. The version label shares ink's formatting rule and is read from the Config accessor, which honours an injected version and falls back to "unknown" the way ink does, replacing a hand-rolled package.json read that printed a bare empty parenthetical on failure. Every string the footer and indicator draw now goes through translation, and both status rows and the indicator phrase are truncated to the terminal width so a long branch, path or phrase cannot wrap the chrome mid-turn.

One unrelated fix rides along, folded in from the review record of #11422 so the release flavor gate is corrected in a single pass instead of two. The workflow that mirrors a published release to the object-storage bucket decided whether to expect the bun/OpenTUI preview archives by reading a repository variable. A repository variable describes the default branch, but that workflow checks out and downloads the tag being synced and can be re-dispatched for any tag, so re-syncing a tag cut before the preview flavor existed asked that tag's own verification script for archives the release never shipped. The flavor is now derived once from the archives actually downloaded, and all three places that need it read that derived value, which makes the mirror follow the release rather than the branch. Two gaps around the same gate are closed alongside it: the test covering it asserted only the variable name, so inverting the comparison and silently changing the flavor's default polarity kept the suite green, and it now pins the operator; and the variable appeared in no documentation at all, so the deployment guide now records what it controls and that leaving it unset is what keeps the flavor off.

## Why it's needed

Enabling the OpenTUI renderer today produces a screen that does not resemble the one it is meant to replace: it opens with no banner, runs a turn with no visible indication that anything is happening, and shows no status line at all. The renderer is still opt-in and ink remains the default, but this is the surface people are asked to validate during real-device testing, and a chrome-less screen makes that validation hard to take seriously and hides genuine parity problems behind an obviously unfinished appearance.

These three pieces are not new work that was never attempted — they exist in the pre-batch implementation branch the migration was cut from. Checking main's history for the symbols involved returns zero commits for every one of them, so they were never carried into any of the batched landing PRs rather than being removed after landing. The batching split one large file into modules, and the chrome was left behind in the split. This closes that omission, which is also why it is worth tracking as a parity gap in the migration issue rather than treating it as a cosmetic request.

The context-file count that the original status line also carried is deliberately not restored: the shell no longer tracks that number and the current ink status line dropped it too, so restoring it would mean reintroducing plumbing for a field neither renderer displays.

The bundled release fix is not an artifact of the PR it came from and does not depend on any decision made there. It is live on main today and reproduces under either gate polarity, because the mismatch is between where the decision is read from and what the decision is about: a branch-wide setting cannot describe a tag. Replaying it against real tags makes the shape of the failure concrete — the oldest of the three fails with an unknown-option error because its verification script predates the flag entirely, the middle one fails listing five missing preview checksums because the flag was known by then but the flavor was not built for that release, and the current one passes. Deriving the flag from the archives that were actually downloaded produces the right answer for all three.

## Reviewer Test Plan

### How to verify

Enable the OpenTUI renderer and start an interactive session. Confirm the banner appears at startup with the logo and the info panel, that it disappears under the hide-banner setting and in screen-reader mode, and that on a terminal narrower than roughly 60 columns the logo column drops away while the panel remains.

Submit a prompt. While the turn is in flight, confirm a spinner animates above the composer alongside a rotating phrase and a rising elapsed-seconds count with a cancel hint, and that all of it disappears once the turn settles. Open a dialog or trigger a tool confirmation mid-turn and note that the responding indicator is not shown while the composer is replaced — this is a deliberate, minor divergence from the pre-batch implementation, which also kept it up during command processing.

Look at the bottom of the screen. Confirm the status line shows the project name, the session name when one is set, the git branch when the working directory is inside a repository, the model, and — only after tokens have been used — the context-window size and a one-decimal percentage-used figure that includes its percent sign, reads ">100" past the limit, and drops the word "context" below 100 columns. On the second row, confirm the approval-mode name appears in the dim status colour, labelled the same way ink labels it (so auto-edit reads "auto-accept edits", not a renderer-specific string), and that the steering hint and the queued count appear while a turn is in flight. Narrow the terminal and confirm both status rows truncate with an ellipsis rather than wrapping onto a second line, and that the responding indicator's phrase truncates while its cancel hint stays visible.

Because the OpenTUI renderer needs Bun >= 1.3.0 or Node >= 26.4.0, verifying under plain Node 24 will silently fall back to ink and show the old chrome; run under Bun, or set the strict renderer variable so an unsupported runtime fails loudly instead of falling back.

Unit coverage: the footer and indicator tests pin the status-line contents, the context figure's one-decimal and past-limit forms and its narrow-label switch, the mode label coming from the shared mapping rather than a local table, the hint-row segment order, the indicator's streaming gate, elapsed tick and phrase truncation, and the banner's version-label and suppression paths; the shared context-usage helpers now carry their own direct tests; and the shell test asserts all three are mounted and fed the streaming flag.

```
cd packages/cli && npx vitest run src/ui/opentui/opentui-footer.test.tsx src/ui/opentui/opentui-header.test.tsx src/ui/opentui/opentui-app-shell.test.tsx src/ui/utils/formatters.test.ts
#  Test Files  4 passed (4)
#       Tests  110 passed (110)
```

For the release fix, the behaviour to confirm is that re-dispatching the mirror workflow for a tag that predates the preview flavor now completes instead of failing at verification, while a current tag still uploads and verifies all five preview archives. Running that workflow end to end needs the production-release environment and the bucket credentials, so what was verified here is narrower and is stated as such: the detection step's own code was executed against each tag's real asset list, and each tag's own verification script was then run with and without the flag it would now be given.

```
# detection, executed against each tag's real published asset list
v0.23.1: preview_assets=5 -> preview_args=--include-opentui-preview
v0.23.0: preview_assets=0 -> preview_args=
v0.22.3: preview_assets=0 -> preview_args=

# the flag the old branch-wide gate passed, replayed against each tag's own script
v0.22.3 -> ERROR: Unknown option: --include-opentui-preview
v0.23.0 -> ERROR: Missing release asset checksum: qwen-code-darwin-arm64-opentui-preview.tar.gz, (5 entries)

# the same scripts with no flag, which is what the derived value now gives them
v0.22.3 -> argument parsing succeeds, proceeds to the checksum lookup
v0.23.0 -> the expected-set assertion succeeds, proceeds to hash verification
```

The last two ran against empty fixture archives, so each stops at its first hash or checksum complaint rather than completing; what they establish is that the failure moved past the flavor gate. The gate's new assertions were also mutation-checked: reverting the workflow to the variable, and separately inverting the build-time comparison, each fail the covering test on their own.

### Evidence (Before & After)

Both frames below were captured through the real OpenTUI reconciler (`testRender` + `captureCharFrame()` from the renderer's own test utilities, run under Bun 1.4.0 at 110x26) rather than through the jsdom harness, so they also demonstrate that none of the restored markup trips the nested-text crash the migration issue tracks as an unguarded risk. ANSI is stripped, so the logo gradient is not visible in the capture; the mode segment is dim by design.

The "after" frame is the restored components themselves, mounted with a synthetic transcript row and a placeholder composer row standing in for the real composer; the version, the tilde-shortened directory, and the git branch in it are all resolved live from this checkout, which is why the branch shown is this PR's own. The "before" frame is the same mount with the three restored components removed — it is a stand-in for main's layout, not a capture of main's binary. What is verified directly about main is code-level: searching main's OpenTUI tree for the banner, status-line, and responding-indicator symbols returns nothing, and its shell layout renders the transcript and the composer with nothing above or below them.

Before — transcript and composer only:

```
 › tell me about the OpenTUI renderer
 The OpenTUI renderer keeps a virtual scrollbox
 as the single viewport.
 │ Type your message here
```

After — banner above, responding indicator above the composer, status line below (auto-edit mode, two messages queued, tokens used):

```
   ▄▄▄▄▄▄  ▄▄     ▄▄ ▄▄▄▄▄▄▄ ▄▄▄    ▄▄   ┌──────────────────────────────────────────────────────────┐
  ██╔═══██╗██║    ██║██╔════╝████╗  ██║  │ >_ Qwen Code (v0.23.1)                                   │
  ██║   ██║██║ █╗ ██║█████╗  ██╔██╗ ██║  │                                                          │
  ██║▄▄ ██║██║███╗██║██╔══╝  ██║╚██╗██║  │ Qwen OAuth | qwen3-coder-plus (/model to change)         │
  ╚██████╔╝╚███╔███╔╝███████╗██║ ╚████║  │ ~/Documents/codebase/github/qwen-code                    │
   ╚══▀▀═╝  ╚══╝╚══╝ ╚══════╝╚═╝  ╚═══╝  └──────────────────────────────────────────────────────────┘
 › tell me about the OpenTUI renderer
 The OpenTUI renderer keeps a virtual scrollbox
 as the single viewport.
 ⠋ I'm Feeling Lucky (0s · esc to cancel)
│ Type your message here
 ➜ qwen-code · restore-chrome · git:(fix/opentui-restore-banner-footer-loading) · qwen3-coder-plus · 1.0m 4.…
 Enter to steer · Ctrl+Q to queue · auto-accept edits · ⏳ 2 queued
```

After at 40 columns — cropped to the responding indicator and the status line (YOLO mode here): the phrase and both rows truncate with an ellipsis instead of wrapping, and the cancel hint survives.

```
 ⠋ I'm Feeling Lu… (0s · esc to cancel)
│ Type your message here
 ➜ qwen-code · restore-chrome · git:(f…
 Enter to steer · Ctrl+Q to queue · YO…
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Bun 1.4.0 for the reconciler captures above; vitest with the jsdom harness for the unit tests. The local Node is 24.19.0, which is below the renderer's Node floor of 26.4.0, so the interactive path was not exercised under plain Node.

## Risk & Scope

- Main risk or tradeoff: the chrome is mounted unconditionally in the shell, so it now occupies roughly eight rows (six for the banner, two for the status line) on the opt-in renderer, reducing the transcript viewport by that amount. The banner already collapses its logo column when narrow and hides entirely under the existing settings, but the status line has no equivalent off switch — matching ink, which also always shows it.
- Scope tradeoff: the release fix is unrelated to the renderer and is bundled only so the flavor gate is corrected once rather than in a second PR after the one it was found in is closed. It touches no code the chrome restore depends on, so it can be dropped from this PR and landed separately without affecting anything above.
- Not validated / out of scope: no end-to-end interactive session against a live model was run, so the responding indicator is verified by unit test and by reconciler capture rather than by a real streaming turn; Windows and Linux were not exercised; the context-file count is intentionally not restored. Several divergences from ink are deliberate and disclosed rather than hidden: the status line is a single left-aligned truncated row, not ink's two-column layout with right-aligned sandbox/debug/context pills and a custom statusline; the mode segment is dim rather than mode-coloured, because the colour helper reads ink's theme manager, which this renderer's mutable palette does not use, and the composer already carries the colour for the modes where it matters; ink's "(shift + tab to cycle)" suffix is omitted because shift+tab is not bound to cycle modes here, so the hint would be a dead affordance; the responding indicator does not distinguish the waiting-for-confirmation state, so it shows a witty phrase rather than ink's "Waiting for user confirmation..." while a tool approval is pending; and there is no tmux spinner fallback. The mirror workflow was likewise never executed end to end — it needs the production-release environment and bucket credentials — so the release fix is evidenced by running its detection logic and each tag's own verification script directly, not by a workflow run.
- Breaking changes / migration notes: none. Ink remains the default renderer and is untouched; this changes only what the opt-in OpenTUI path draws. The release change alters no published artifact and no build-time decision: what a new release builds is still governed by the same repository variable as before, and only the mirroring of an already-published release now follows that release's own contents.

## Linked Issues

Part of the OpenTUI migration tracked in #8662 — recorded there as a parity gap that the batched landing PRs never carried, and as a prerequisite for the real-device validation phase.

#11422 is being closed rather than merged, and the release fix above is what survives of it. That PR proposed flipping the build-time gate to default-on with an explicit off value, on the premise that shipping the preview flavor took a manual step per release. The premise no longer holds: the repository variable was set to `true` on 2026-09-08, before the v0.23.1 release run, and both v0.23.1 and v0.23.2-preview.0 already carry all five preview archives, so merging it would not change what any release produces while replacing a positive gate with a double negative. What its review record did surface were two real defects that stand on their own and are fixed here: the old-tag re-sync failure, and a gate whose polarity no test pinned and whose variable no document mentioned.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

**范围说明：本 PR 同时带着两处互不依赖的改动。** 主体是恢复 OpenTUI 缺失的终端外壳——横幅、状态行、响应指示器——位于 `packages/cli` 下。第二处是一处发布流水线修复，独立成一个提交，只触碰对象存储镜像 workflow、该 workflow 的测试钉住，以及一份部署文档：它改变的是镜像如何判断「正在同步的这个 tag 是否产出了 bun/OpenTUI preview 归档」。两者不共用任何代码，第二处可以从本 PR 中摘掉而不影响第一处。它的细节在下面第四段，验证在 Reviewer Test Plan 的独立小节，边界在「风险与范围」；为什么随行合入而不是单独开 PR，理由在 Linked Issues。

恢复 OpenTUI 渲染器自可用以来一直缺失的三块终端外壳：启动横幅（渐变 logo 加上带边框的信息面板，面板内含标题、版本、鉴权与模型、工作目录）、底部状态行（项目、会话名、git 分支、模型、上下文窗口用量，以及审批模式行连同回合进行中的转向提示与排队消息计数），以及回合进行中停在输入框上方的响应指示器（动画 spinner、轮换短语、已用秒数和取消提示）。

三者都重建为各自独立的模块，并按 ink 渲染器相同的位置挂载到外壳中——横幅在顶部，响应指示器紧贴输入框上方，状态行在底部。横幅继续遵守读屏设置与隐藏横幅设置，通过相同的按作用域分层逻辑解析自定义横幅素材，并在终端过窄时从双栏 logo 布局切换为仅面板布局，与原版一致。

被恢复的那几个模块原先重新推导了若干 main 已经拥有的事实，因此这一遍把每一项都改为走既有的共享 helper，让每个事实只保留一个真相来源，消除两个渲染器各自漂移的空间。审批模式名现在来自 ink 的状态行、对话框与命令共用的同一套映射，以暗色状态色渲染，颜色则交给输入框组件去承载（在颜色真正有分量的小部分模式上）；本地的标签表与其颜色判断已删除。上下文用量数字及其「窄/宽」标签被抽进一个不依赖 ink 的共享 helper，由 ink 的指示器与本状态行共同消费，因此百分号、保留一位小数的数值以及超限时的 ">100" 都只有一个定义。加载短语来自解析全部九种语言的共享轮换器，而不再是一份重新声明的英文子集；spinner 的帧集与刷新频率被提为共享常量，由本 spinner 与压缩 spinner 共用，因此动画跑在 ink 所用的 80ms 而非源实现的 120ms。版本号标签共用 ink 的格式化规则，并改为从 Config 访问器读取——它会尊重注入的版本、并像 ink 一样回退到 "unknown"，取代了原先手写的 package.json 读取（失败时会印出一个空的括号）。状态行与指示器绘制的每个字符串现在都经过翻译，且两条状态行与指示器短语都按终端宽度截断，因此过长的分支、路径或短语不会在回合进行中把外壳挤到换行。

另有一处不相关的修复随行合入，来自 #11422 的评审记录，目的是让 release flavor 门控一次性修好而不是分两次。把已发布 release 镜像到对象存储桶的那个 workflow，原先通过读取一个仓库级变量来决定是否应当期待 bun/OpenTUI preview 归档。仓库级变量描述的是默认分支，而该 workflow 会 checkout 并下载被同步的那个 tag，并且可以对任意 tag 重新触发，因此重新同步一个在 preview flavor 出现之前切出的 tag，就会去要求那个 tag 自己的校验脚本提供该 release 从未产出过的归档。现在 flavor 由实际下载到的归档一次性推导得出，三个需要它的地方都读这个推导值，镜像因此跟随 release 而不是跟随分支。同一门控周边的两个缺口也一并补上：覆盖它的测试原先只断言了变量名，因此把比较操作符反转、悄悄改掉 flavor 的默认极性也能让测试套件保持绿色，现在钉住了操作符；而该变量此前在任何文档里都没有出现，因此部署文档现在记录了它控制什么，以及不设置它才是保持该 flavor 关闭的方式。

## 为什么需要

今天启用 OpenTUI 渲染器得到的画面与它本应替代的那个毫不相似：启动时没有横幅，跑一个回合时没有任何可见迹象表明有事在发生，并且完全没有状态行。该渲染器仍是可选启用、ink 仍是默认，但这正是请大家在真机验证阶段去用的界面，一个没有外壳的画面让这种验证很难被认真对待，也会把真正的 parity 问题藏在一个明显未完成的外观后面。

这三块并不是从未尝试过的新工作——它们存在于迁移切分之前的那个实现分支上。在 main 的历史中检索相关符号，每一个都返回零次提交，所以它们从未被任何一批落地 PR 带进来，而不是落地之后又被删掉。分批把一个大文件拆成模块，外壳在拆分中被落下了。本 PR 补上这个遗漏，这也是为什么它值得作为 parity 缺口记进迁移 issue，而不是当成一个外观诉求处理。

原状态行还带的上下文文件计数被有意不恢复：外壳已不再跟踪这个数字，当前 ink 的状态行也去掉了它，恢复它意味着为一个两个渲染器都不展示的字段重新接回管线。

随行合入的这处 release 修复并不是它所来自那个 PR 的附属品，也不依赖在那里做过的任何决定。它今天在 main 上就是活的，并且在门控的任一极性下都能复现，因为错配发生在「决策从哪里读取」与「决策针对什么」之间：一个分支级的设置无法描述某个 tag。用真实 tag 重放能把失败的形状说具体——三者中最老的那个报未知选项错误，因为它的校验脚本完全早于这个 flag；中间那个报出五条缺失的 preview 校验和，因为那时 flag 已存在但该 release 并未构建这个 flavor；当前这个则通过。改为由实际下载到的归档推导 flag，三者都能得到正确答案。

## 评审测试计划

### 如何验证

启用 OpenTUI 渲染器并开启一个交互会话。确认启动时出现横幅，含 logo 与信息面板；确认在隐藏横幅设置下以及读屏模式下它消失；确认在窄于约 60 列的终端上 logo 栏消失而面板保留。

提交一个提示词。回合进行中，确认输入框上方有 spinner 在动，同时有轮换短语、递增的已用秒数和取消提示，并确认回合结束后这些全部消失。回合中打开一个对话框或触发一次工具确认，注意此时响应指示器不再显示——这是相对切分前实现的一处有意的小差异，那份实现在命令处理期间也会保留它。

看屏幕底部。确认状态行显示项目名、设置了会话名时的会话名、工作目录位于仓库内时的 git 分支、模型，以及——仅在已消耗 token 之后——上下文窗口大小和一个保留一位小数、带百分号的已用百分比，超限时显示 ">100"，并在窄于 100 列时省去 "context" 一词。第二行确认审批模式名以暗色状态色出现，并按 ink 相同的方式标注（因此 auto-edit 显示 "auto-accept edits"，而非渲染器自造的字符串），并确认回合进行中会出现转向提示与排队计数。把终端收窄，确认两条状态行都以省略号截断而非换到第二行，且响应指示器的短语被截断时其取消提示仍然可见。

由于 OpenTUI 渲染器需要 Bun >= 1.3.0 或 Node >= 26.4.0，在纯 Node 24 下验证会静默回落到 ink 并显示旧外壳；请在 Bun 下运行，或设置严格渲染器变量，让不支持的运行时直接报错而不是回落。

单元覆盖：状态行与指示器的测试钉住了状态行内容、上下文数字的一位小数与超限形式及其窄屏标签切换、模式标签来自共享映射而非本地表、提示行的分段顺序、指示器的 streaming 门控、秒数跳动与短语截断，以及横幅的版本号标签与两条抑制路径；共享的上下文用量 helper 现在也带有自己的直接测试；外壳测试断言三者均已挂载并被喂入 streaming 标志。

对于 release 修复，要确认的行为是：对一个早于 preview flavor 的 tag 重新触发镜像 workflow 现在能够跑完，而不是在校验步骤失败；同时对当前 tag 仍然会上传并校验全部五个 preview 归档。端到端跑该 workflow 需要 production-release 环境与桶凭据，因此这里验证的范围更窄，并如实说明：执行了检测步骤自身的代码，输入是各 tag 真实的资产清单；随后对各 tag 自己的校验脚本，分别在「会给它 flag」与「不会给它 flag」两种情况下运行。

```
# 检测逻辑，对各 tag 真实已发布的资产清单执行
v0.23.1: preview_assets=5 -> preview_args=--include-opentui-preview
v0.23.0: preview_assets=0 -> preview_args=
v0.22.3: preview_assets=0 -> preview_args=

# 旧的分支级门控会传入的 flag，对各 tag 自己的脚本重放
v0.22.3 -> ERROR: Unknown option: --include-opentui-preview
v0.23.0 -> ERROR: Missing release asset checksum: qwen-code-darwin-arm64-opentui-preview.tar.gz, (共 5 条)

# 同样的脚本在不带 flag 时，也就是推导值现在会给它们的情况
v0.22.3 -> 参数解析通过，继续走到校验和查找
v0.23.0 -> 期望集合断言通过，继续走到哈希校验
```

后两条是对空的 fixture 归档运行的，因此各自停在第一个哈希或校验和抱怨处而没有跑完；它们确立的事实是失败点已经越过了 flavor 门控。门控的新断言也做了变异检验：把 workflow 退回变量形式、以及单独把构建期的比较反转，各自都能让覆盖它的测试失败。

### 证据（前后对比）

下面两帧都通过真实的 OpenTUI reconciler 抓取（渲染器自带测试工具中的 `testRender` + `captureCharFrame()`，在 Bun 1.4.0 下以 110x26 运行），而不是通过 jsdom 测试架，因此它们同时证明恢复的标记没有触发迁移 issue 中记为尚无防护的嵌套 text 崩溃。ANSI 已被剥离，所以 logo 渐变在抓帧中不可见；模式分段则是有意以暗色呈现。

"后"帧是恢复出来的组件本身，挂载时用了合成的 transcript 行和占位的输入框行来代替真实输入框；其中的版本号、波浪号缩短后的目录和 git 分支都是从当前这个 checkout 实时解析出来的，这也是画面里显示的分支正是本 PR 自己分支的原因。"前"帧是同一个挂载去掉这三块恢复组件——它是对 main 布局的替身，而不是对 main 二进制的抓取。关于 main 被直接核实的是代码层面的事实：在 main 的 OpenTUI 目录中检索横幅、状态行和响应指示器的符号均无结果，其外壳布局只渲染 transcript 与输入框，上下都没有任何东西。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

上述 reconciler 抓帧使用 Bun 1.4.0；单元测试使用 vitest 配合 jsdom 测试架。本地 Node 为 24.19.0，低于渲染器 26.4.0 的 Node 下限，因此交互路径未在纯 Node 下跑过。

## 风险与范围

- 主要风险或权衡：外壳现在无条件挂载，因此在可选启用的渲染器上会占据约八行（横幅六行、状态行两行），transcript 视口相应减少这么多。横幅在窄终端已会收起 logo 栏，并可通过既有设置整体隐藏，但状态行没有对应的关闭开关——这与 ink 一致，ink 也始终显示它。
- 范围权衡：release 修复与渲染器无关，合入这里只是为了让 flavor 门控修一次，而不是在发现它的那个 PR 关闭之后再开第二个 PR。它不触碰外壳恢复所依赖的任何代码，因此可以从本 PR 中摘出单独落地，不影响上面任何内容。
- 未验证 / 范围之外：没有跑针对真实模型的端到端交互会话，因此响应指示器是由单元测试和 reconciler 抓帧验证的，而不是由真实流式回合验证；未验证 Windows 与 Linux；上下文文件计数有意不恢复。与 ink 的若干差异是有意为之并如实披露，而非隐藏：状态行是单条左对齐、按宽度截断的行，而非 ink 的双栏布局（右侧对齐 sandbox/debug/context 药丸，外加自定义状态行）；模式分段为暗色而非按模式着色，因为着色 helper 读取的是 ink 的主题管理器，而本渲染器用的是可变的调色板、并不消费它，且输入框组件已经在颜色真正有分量的模式上承载了颜色；ink 的 "(shift + tab to cycle)" 后缀被省略，因为此处 shift+tab 未绑定到循环模式，该提示会是一个失效的可供性；响应指示器不区分「等待确认」状态，因此在工具审批挂起时显示的是轮换短语而非 ink 的 "Waiting for user confirmation..."；并且没有 tmux spinner 回退。镜像 workflow 同样从未端到端执行过——它需要 production-release 环境与桶凭据——因此 release 修复的证据来自直接运行其检测逻辑与各 tag 自己的校验脚本，而不是来自一次 workflow 运行。
- 破坏性变更 / 迁移说明：无。ink 仍是默认渲染器且未被触碰；本 PR 只改变可选启用的 OpenTUI 路径所绘制的内容。release 侧的改动不改变任何已发布产物，也不改变构建期决策：一个新 release 构建什么，仍由与之前相同的仓库级变量决定，改变的只是把一个已发布 release 镜像出去时，现在跟随该 release 自身的内容。

## 关联 Issue

属于 #8662 跟踪的 OpenTUI 迁移的一部分——在那里记录为分批落地 PR 从未带上的一处 parity 缺口，同时也是真机验证阶段的前置条件。

#11422 将被关闭而不是合并，上面那处 release 修复是它留下来的成果。那个 PR 提议把构建期门控翻转为默认开、并以一个显式的关闭值作为 kill switch，前提是「发布 preview flavor 每次都需要一个人工步骤」。这个前提已不成立：仓库级变量在 2026-09-08 就被设为 `true`，早于 v0.23.1 的发布运行，而 v0.23.1 与 v0.23.2-preview.0 都已带上全部五个 preview 归档，因此合并它不会改变任何 release 的产出，只是把一个正向门控换成双重否定。它的评审记录真正暴露出的是两个能独立成立的缺陷，已在此处修掉：老 tag 重新同步会失败，以及一个极性没有任何测试钉住、变量在任何文档里都没有提及的门控。

</details>



