### PR TITLE
fix(cli): seed headless promptIds from the resumed transcript

### DIFF
--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -22,7 +22,6 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { ChatRecord } from '@qwen-code/qwen-code-core';
 import {
   createNonInteractivePromptId,
   main,
@@ -35,7 +34,7 @@ import { clearCiEnv } from './test-utils/ci-env.js';
 import type { CliArgs } from './config/config.js';
 import { type LoadedSettings } from './config/settings.js';
 import { appEvents, AppEvent } from './utils/events.js';
-import type { Config } from '@qwen-code/qwen-code-core';
+import type { ChatRecord, Config } from '@qwen-code/qwen-code-core';
 import { ApprovalMode, OutputFormat } from '@qwen-code/qwen-code-core';
 import { EXTERNAL_TOOL_GUARD_REQUIRED_VALUE } from '@qwen-code/acp-bridge/externalToolGuard';
 

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -22,6 +22,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { ChatRecord } from '@qwen-code/qwen-code-core';
 import {
   createNonInteractivePromptId,
   main,
@@ -1733,6 +1734,39 @@ describe('llm.tsx main function', () => {
   it('creates non-interactive prompt ids that preserve session correlation', () => {
     expect(createNonInteractivePromptId('test-session-id')).toBe(
       'test-session-id########0',
+    );
+  });
+
+  it('continues the prompt id chain when the -p run resumes a session', () => {
+    // Every headless `-p` process would otherwise mint `########0` again, and
+    // loadSession keeps only the last file-history snapshot per promptId, so
+    // the earlier run's /rewind target for turn 0 would be dropped.
+    const records = [
+      {
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId: 'test-session-id',
+        timestamp: new Date().toISOString(),
+        type: 'user',
+        cwd: '/tmp',
+        version: 'test',
+        message: { role: 'user', parts: [{ text: 'first turn' }] },
+      },
+      {
+        uuid: 'u2',
+        parentUuid: 'u1',
+        sessionId: 'test-session-id',
+        timestamp: new Date().toISOString(),
+        type: 'system',
+        subtype: 'ui_telemetry',
+        cwd: '/tmp',
+        version: 'test',
+        systemPayload: { uiEvent: { prompt_id: 'test-session-id########3' } },
+      },
+    ] as unknown as ChatRecord[];
+
+    expect(createNonInteractivePromptId('test-session-id', records)).toBe(
+      'test-session-id########4',
     );
   });
 

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -1769,6 +1769,186 @@ describe('llm.tsx main function', () => {
     );
   });
 
+  it('continues past a claimed turn 0 that the user-turn fallback cannot see', () => {
+    // computeInitialTurnFromHistory returns 0 here — highest claimed turn is
+    // 0, and the only user record has blank text so its fallback count stays
+    // 0 (`-p '   '` reaches the model, `llm.tsx` only rejects a falsy input).
+    // Seeding from that 0 would re-mint `########0`, the very collision this
+    // function exists to prevent.
+    const records = [
+      {
+        uuid: 'u1',
+        parentUuid: null,
+        sessionId: 'test-session-id',
+        timestamp: new Date().toISOString(),
+        type: 'user',
+        cwd: '/tmp',
+        version: 'test',
+        message: { role: 'user', parts: [{ text: '   ' }] },
+      },
+      {
+        uuid: 'u2',
+        parentUuid: 'u1',
+        sessionId: 'test-session-id',
+        timestamp: new Date().toISOString(),
+        type: 'system',
+        subtype: 'ui_telemetry',
+        cwd: '/tmp',
+        version: 'test',
+        systemPayload: { uiEvent: { prompt_id: 'test-session-id########0' } },
+      },
+    ] as unknown as ChatRecord[];
+
+    expect(createNonInteractivePromptId('test-session-id', records)).toBe(
+      'test-session-id########1',
+    );
+  });
+
+  it('passes the resumed transcript through to the -p prompt id', async () => {
+    // Pins the call site, not just the function: without the
+    // `getResumedSessionData()` argument in main(), the shipped `-p` path
+    // reverts to `########0` on every resume while the unit tests above stay
+    // green.
+    const originalNoRelaunch = process.env['QWEN_CODE_NO_RELAUNCH'];
+    const originalIsTTY = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      'isTTY',
+    );
+    process.env['QWEN_CODE_NO_RELAUNCH'] = 'true';
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const validatorModule = await import('./validateNonInterActiveAuth.js');
+    const nonInteractiveModule = await import('./nonInteractiveCli.js');
+    const initializerModule = await import('./core/initializer.js');
+    const startupWarningsModule = await import('./utils/startupWarnings.js');
+    const userStartupWarningsModule = await import(
+      './utils/userStartupWarnings.js'
+    );
+
+    vi.mocked(cleanupModule.runExitCleanup).mockResolvedValue(undefined);
+    vi.spyOn(initializerModule, 'initializeApp').mockResolvedValue({
+      authError: null,
+      themeError: null,
+      shouldOpenAuthDialog: false,
+      memoryFileCount: 0,
+    });
+    vi.spyOn(startupWarningsModule, 'getStartupWarnings').mockResolvedValue([]);
+    vi.spyOn(
+      userStartupWarningsModule,
+      'getUserStartupWarnings',
+    ).mockResolvedValue([]);
+    const runNonInteractiveSpy = vi
+      .spyOn(nonInteractiveModule, 'runNonInteractive')
+      .mockResolvedValue(0);
+
+    const configStub = {
+      isInteractive: () => false,
+      getQuestion: () => 'hello',
+      getSandbox: () => false,
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+      getDebugMode: () => false,
+      getListExtensions: () => false,
+      getMcpServers: () => ({}),
+      getTopTierMcpServers: () => undefined,
+      getModelProvidersConfig: () => undefined,
+      initialize: vi.fn().mockResolvedValue(undefined),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getFailedMcpServerNames: () => [],
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getMemoryFileCount: () => 0,
+      getProjectRoot: () => '/',
+      getOutputFormat: () => OutputFormat.TEXT,
+      getWarnings: () => [],
+      isSafeMode: () => false,
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getContentGeneratorConfig: () => undefined,
+      getUsageStatisticsEnabled: () => true,
+      getSessionId: () => 'test-session-id',
+      getProxy: () => undefined,
+      getResumedSessionData: () => ({
+        conversation: {
+          sessionId: 'test-session-id',
+          messages: [
+            {
+              uuid: 'u1',
+              parentUuid: null,
+              sessionId: 'test-session-id',
+              timestamp: new Date().toISOString(),
+              type: 'system',
+              subtype: 'ui_telemetry',
+              cwd: '/tmp',
+              version: 'test',
+              systemPayload: {
+                uiEvent: { prompt_id: 'test-session-id########3' },
+              },
+            },
+          ],
+        },
+      }),
+    } as unknown as Config;
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: [],
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadCliConfig).mockResolvedValue(configStub);
+    vi.spyOn(validatorModule, 'validateNonInteractiveAuth').mockResolvedValue(
+      configStub,
+    );
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    } finally {
+      processExitSpy.mockRestore();
+      if (originalIsTTY) {
+        Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+      } else {
+        delete (process.stdin as { isTTY?: unknown }).isTTY;
+      }
+      if (originalNoRelaunch !== undefined) {
+        process.env['QWEN_CODE_NO_RELAUNCH'] = originalNoRelaunch;
+      } else {
+        delete process.env['QWEN_CODE_NO_RELAUNCH'];
+      }
+    }
+
+    expect(runNonInteractiveSpy).toHaveBeenCalledTimes(1);
+    expect(runNonInteractiveSpy.mock.calls[0]?.[3]).toBe(
+      'test-session-id########4',
+    );
+  });
+
   const runSandboxRelaunch = async (
     argv: string[],
     sessionId = '123e4567-e89b-12d3-a456-426614174000',

--- a/packages/cli/src/llm.tsx
+++ b/packages/cli/src/llm.tsx
@@ -6,6 +6,8 @@
 
 import {
   AuthType,
+  type ChatRecord,
+  computeInitialTurnFromHistory,
   type Config,
   InputFormat,
   isDebugLogFileEnabled,
@@ -1419,7 +1421,10 @@ export async function main() {
       settings,
     );
 
-    const prompt_id = createNonInteractivePromptId(config.getSessionId());
+    const prompt_id = createNonInteractivePromptId(
+      config.getSessionId(),
+      config.getResumedSessionData?.()?.conversation.messages,
+    );
 
     if (inputFormat === InputFormat.STREAM_JSON) {
       const trimmedInput = (input ?? '').trim();
@@ -1493,8 +1498,24 @@ export async function main() {
   }
 }
 
-export function createNonInteractivePromptId(sessionId: string): string {
-  return `${sessionId}########0`;
+/**
+ * Mints the single promptId a headless `-p` run uses for its one turn.
+ *
+ * A fresh session keeps the historical `########0`. A resumed one
+ * (`--resume` / `--continue`) must continue past the turns the transcript
+ * already claims: every process would otherwise mint `########0` again, and
+ * `SessionService.loadSession` keeps only the LAST file-history snapshot per
+ * promptId, so a repeated headless run silently drops the previous run's
+ * `/rewind` target for that turn.
+ */
+export function createNonInteractivePromptId(
+  sessionId: string,
+  resumedRecords?: readonly ChatRecord[],
+): string {
+  const lastTurn = resumedRecords?.length
+    ? computeInitialTurnFromHistory(resumedRecords, sessionId)
+    : 0;
+  return `${sessionId}########${lastTurn > 0 ? lastTurn + 1 : 0}`;
 }
 
 /**

--- a/packages/cli/src/llm.tsx
+++ b/packages/cli/src/llm.tsx
@@ -1501,21 +1501,30 @@ export async function main() {
 /**
  * Mints the single promptId a headless `-p` run uses for its one turn.
  *
- * A fresh session keeps the historical `########0`. A resumed one
- * (`--resume` / `--continue`) must continue past the turns the transcript
- * already claims: every process would otherwise mint `########0` again, and
- * `SessionService.loadSession` keeps only the LAST file-history snapshot per
- * promptId, so a repeated headless run silently drops the previous run's
- * `/rewind` target for that turn.
+ * A run that resumes nothing keeps the historical `########0`. A resumed one
+ * (`--resume` / `--continue`) reuses the previous session's id, so without a
+ * seed every process mints `########0` again and one transcript ends up with
+ * several turns under a single promptId — the key #9466's rewind mapping
+ * anchors on, and the `prompt_id` persisted on `ui_telemetry` records, which
+ * is itself what the next resume reads back to seed from.
+ *
+ * Seed from the highest turn the transcript claims and continue past it, the
+ * same rule `Session.getNextPromptId` applies, so the two headless paths
+ * cannot drift.
  */
 export function createNonInteractivePromptId(
   sessionId: string,
   resumedRecords?: readonly ChatRecord[],
 ): string {
+  // -1 for a run that resumes nothing, so the shared `+ 1` still yields the
+  // historical `########0`. Seeding from the helper's own 0 instead would
+  // re-mint a turn the transcript already claims in the case where it returns
+  // 0 for a non-empty transcript: highest claimed turn 0, and no record with
+  // non-blank user text for its fallback to count.
   const lastTurn = resumedRecords?.length
     ? computeInitialTurnFromHistory(resumedRecords, sessionId)
-    : 0;
-  return `${sessionId}########${lastTurn > 0 ? lastTurn + 1 : 0}`;
+    : -1;
+  return `${sessionId}########${lastTurn + 1}`;
 }
 
 /**

--- a/packages/cli/src/nonInteractive/session.test.ts
+++ b/packages/cli/src/nonInteractive/session.test.ts
@@ -424,7 +424,9 @@ describe('runNonInteractiveStreamJson', () => {
 
     await runNonInteractiveStreamJson(config, '');
 
-    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########1');
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe(
+      'test-session########1',
+    );
   });
 
   it('seeds the promptId counter past turns the resumed transcript claims', async () => {
@@ -453,7 +455,9 @@ describe('runNonInteractiveStreamJson', () => {
 
     // 5 is the highest turn the transcript claims (a ui_telemetry record from
     // the previous run), not the 2 user turns it happens to contain.
-    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########6');
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe(
+      'test-session########6',
+    );
   });
 
   it('falls back to the resumed user-turn count when no promptId is persisted', async () => {
@@ -476,7 +480,9 @@ describe('runNonInteractiveStreamJson', () => {
 
     await runNonInteractiveStreamJson(config, '');
 
-    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########4');
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe(
+      'test-session########4',
+    );
   });
 
   it('processes multiple user messages sequentially', async () => {

--- a/packages/cli/src/nonInteractive/session.test.ts
+++ b/packages/cli/src/nonInteractive/session.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SendMessageType, type Config } from '@qwen-code/qwen-code-core';
+import {
+  SendMessageType,
+  type ChatRecord,
+  type Config,
+} from '@qwen-code/qwen-code-core';
 import type { Content } from '@google/genai';
 import { runNonInteractiveStreamJson } from './session.js';
 import type {
@@ -104,6 +108,33 @@ function createUserMessage(content: string): CLIUserMessage {
     },
     parent_tool_use_id: null,
   };
+}
+
+function createResumedUserRecord(text: string): ChatRecord {
+  return {
+    uuid: `uuid-${text}`,
+    parentUuid: null,
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    type: 'user',
+    cwd: '/tmp',
+    version: 'test',
+    message: { role: 'user', parts: [{ text }] },
+  } as ChatRecord;
+}
+
+function createResumedTelemetryRecord(promptId: string): ChatRecord {
+  return {
+    uuid: `uuid-${promptId}`,
+    parentUuid: null,
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    type: 'system',
+    subtype: 'ui_telemetry',
+    cwd: '/tmp',
+    version: 'test',
+    systemPayload: { uiEvent: { prompt_id: promptId } },
+  } as unknown as ChatRecord;
 }
 
 function createControlRequest(
@@ -384,6 +415,68 @@ describe('runNonInteractiveStreamJson', () => {
         adapter: mockOutputAdapter,
       }),
     );
+  });
+
+  it('mints a fresh promptId chain when nothing was resumed', async () => {
+    mockInputReader.read = async function* () {
+      yield createUserMessage('Hello world');
+    };
+
+    await runNonInteractiveStreamJson(config, '');
+
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########1');
+  });
+
+  it('seeds the promptId counter past turns the resumed transcript claims', async () => {
+    // A resumed headless chain reuses the session id, so restarting the
+    // counter at 1 would re-mint ids the previous run already persisted —
+    // loadSession keeps only the last file-history snapshot per promptId,
+    // silently dropping the earlier run's /rewind target for that turn.
+    config = createConfig({
+      getResumedSessionData: () => ({
+        conversation: {
+          sessionId: 'test-session',
+          messages: [
+            createResumedUserRecord('first turn'),
+            createResumedUserRecord('second turn'),
+            createResumedTelemetryRecord('test-session########5'),
+          ],
+        },
+      }),
+    });
+
+    mockInputReader.read = async function* () {
+      yield createUserMessage('third turn');
+    };
+
+    await runNonInteractiveStreamJson(config, '');
+
+    // 5 is the highest turn the transcript claims (a ui_telemetry record from
+    // the previous run), not the 2 user turns it happens to contain.
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########6');
+  });
+
+  it('falls back to the resumed user-turn count when no promptId is persisted', async () => {
+    config = createConfig({
+      getResumedSessionData: () => ({
+        conversation: {
+          sessionId: 'test-session',
+          messages: [
+            createResumedUserRecord('first turn'),
+            createResumedUserRecord('second turn'),
+            createResumedUserRecord('third turn'),
+          ],
+        },
+      }),
+    });
+
+    mockInputReader.read = async function* () {
+      yield createUserMessage('fourth turn');
+    };
+
+    await runNonInteractiveStreamJson(config, '');
+
+    expect(runNonInteractiveMock.mock.calls[0][3]).toBe('test-session########4');
   });
 
   it('processes multiple user messages sequentially', async () => {

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -11,6 +11,7 @@ import type {
 import { SendMessageType } from '@qwen-code/qwen-code-core/core/client.js';
 import { buildSessionRecoveryPlanFromApiHistory } from '@qwen-code/qwen-code-core/core/session-recovery.js';
 import { TURN_INTERRUPTION_HISTORY_TAIL_COUNT } from '@qwen-code/qwen-code-core/core/turn-interruption.js';
+import { computeInitialTurnFromHistory } from '@qwen-code/qwen-code-core/services/session-turn-state.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core/utils/debugLogger.js';
 import { StreamJsonInputReader } from './io/StreamJsonInputReader.js';
 import { StreamJsonOutputAdapter } from './io/StreamJsonOutputAdapter.js';
@@ -77,7 +78,7 @@ class Session {
   private activeTurnAbortController: AbortController | null = null;
   private config: Config;
   private sessionId: string;
-  private promptIdCounter: number = 0;
+  private promptIdCounter: number | null = null;
   private inputReader: StreamJsonInputReader;
   private outputAdapter: StreamJsonOutputAdapter;
   private controlContext: ControlContext | null = null;
@@ -142,7 +143,31 @@ class Session {
     });
   }
 
+  /**
+   * Mints the next promptId for this process.
+   *
+   * The counter is seeded from the resumed transcript on first use. Without
+   * that seed a `--resume`/`--continue` chain restarts at 1 every process and
+   * re-mints promptIds the previous run already persisted, which is not just a
+   * cosmetic collision: `SessionService.loadSession` keeps only the LAST
+   * file-history snapshot per promptId, so the earlier run's snapshot for that
+   * turn is dropped and `/rewind` restores the wrong workspace state. Rewind's
+   * prompt-identity mapping also fails closed to a positional walk when ids
+   * repeat. Interactive mode seeds the same way (`seedPromptCount` in
+   * AppContainer), and ACP via `computeInitialTurnFromHistory`.
+   *
+   * Seeding is lazy because resumed data only becomes authoritative after
+   * `config.initialize()` re-reads the session file, which this class defers
+   * until the first control request.
+   */
   private getNextPromptId(): string {
+    if (this.promptIdCounter === null) {
+      const records = this.config.getResumedSessionData?.()?.conversation
+        .messages;
+      this.promptIdCounter = records
+        ? computeInitialTurnFromHistory(records, this.sessionId)
+        : 0;
+    }
     this.promptIdCounter++;
     return `${this.sessionId}########${this.promptIdCounter}`;
   }

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -162,8 +162,8 @@ class Session {
    */
   private getNextPromptId(): string {
     if (this.promptIdCounter === null) {
-      const records = this.config.getResumedSessionData?.()?.conversation
-        .messages;
+      const records =
+        this.config.getResumedSessionData?.()?.conversation.messages;
       this.promptIdCounter = records
         ? computeInitialTurnFromHistory(records, this.sessionId)
         : 0;

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -148,13 +148,18 @@ class Session {
    *
    * The counter is seeded from the resumed transcript on first use. Without
    * that seed a `--resume`/`--continue` chain restarts at 1 every process and
-   * re-mints promptIds the previous run already persisted, which is not just a
-   * cosmetic collision: `SessionService.loadSession` keeps only the LAST
-   * file-history snapshot per promptId, so the earlier run's snapshot for that
-   * turn is dropped and `/rewind` restores the wrong workspace state. Rewind's
-   * prompt-identity mapping also fails closed to a positional walk when ids
-   * repeat. Interactive mode seeds the same way (`seedPromptCount` in
-   * AppContainer), and ACP via `computeInitialTurnFromHistory`.
+   * re-mints promptIds the previous run already persisted, so one transcript
+   * carries several turns under a single id: the key the rewind mapping from
+   * #9466 anchors on (it fails closed to a positional walk when ids repeat),
+   * and the `prompt_id` on persisted `ui_telemetry` records, which is what
+   * the next resume reads back to seed from. File-history snapshots are not
+   * at stake on this path — checkpointing defaults off outside interactive
+   * sessions, so headless turns write none.
+   *
+   * ACP seeds through this same helper (`primeTurnFromHistory`). Interactive
+   * mode seeds too, but by its own inline count of resumed user turns
+   * (`seedPromptCount` in AppContainer), which ignores the turns the
+   * transcript actually claims.
    *
    * Seeding is lazy because resumed data only becomes authoritative after
    * `config.initialize()` re-reads the session file, which this class defers


### PR DESCRIPTION
## What this PR does

Headless runs now continue prompt numbering from the transcript they resumed instead of restarting it in every process. Both headless entry points are covered: the stream-json session, whose counter started over at the first turn, and the single-shot `-p` run, which always minted turn `0`. Both are seeded from the resumed transcript using the core helper that already backs the same seeding in interactive mode and in ACP: the highest turn the transcript claims, falling back to the number of resumed user turns. A run that resumes nothing keeps the exact ids it mints today.

## Why it's needed

`--resume` and `--continue` reuse the previous session's id, so a headless chain that restarts numbering re-mints prompt ids the previous run already persisted, and one transcript ends up carrying several turns under a single prompt id. That id is the key the rewind mapping added in #9466 anchors on — repeated ids make that lookup fail closed to the positional walk — and it is the `prompt_id` persisted on `ui_telemetry` records, which is itself what the next resume reads back to seed from, so the ambiguity compounds along the chain. Interactive mode and ACP already seed their counters on resume; only the two headless paths were missing it, which is the deferred review finding tracked in #11408.

Correction to an earlier version of this description, from the sandboxed `/verify` run: file-history snapshots are **not** dropped on these paths. The de-dupe is real (`SessionFileHistoryAccumulator` keeps the last snapshot per prompt id), but `fileCheckpointingEnabled` defaults to `!sdkMode && interactive` and nothing in `packages/cli` overrides it, so `makeSnapshot` no-ops and headless turns write no snapshots at all — measured in the sandbox as 10 headless processes, 6 real `write_file` executions, 0 snapshot records. That is why interactive mode has always seeded, and it is a cost this PR does not remove on the headless paths.

## Reviewer Test Plan

### How to verify

Unit tests cover both paths and are the intended reviewer evidence: `npx vitest run src/nonInteractive/session.test.ts src/llm.test.tsx` in `packages/cli`. The stream-json cases assert that a session with nothing resumed still starts at turn 1, that a resumed transcript whose highest claimed turn is 5 makes the next turn 6, and that a transcript with no persisted prompt id falls back to counting resumed user turns. The `-p` case asserts that a resumed run continues past the last claimed turn while the existing fresh-session expectation of turn 0 is unchanged.

End to end, the oracle is the prompt ids persisted in the session transcript (`<runtime>/projects/<cwd>/chats/<sid>.jsonl`), read back after each process exits — not file-history snapshots, which headless never writes. Run `-p` once with `--session-id`, then `-p --resume <id>`, and compare: before this change the transcript holds one turn number for both processes, after it one per process. The sandboxed `/verify` run drove exactly that against real built base and head artifacts: `-p` went `[0] → [0]` on base versus `[0] → [0,2]` on head, and stream-json over three processes went `[1] → [1] → [1]` versus `[1] → [1,2] → [1,2,3]`.

### Evidence (Before & After)

N/A — no user-visible or TUI change; the difference is in persisted prompt ids and the snapshots keyed by them.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Not verified locally on any platform — the machine this was written on cannot run the build or test suite, so CI is the verification for lint, typecheck and unit tests.

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: a resumed `-p` run changes the single prompt id it emits (previously always turn 0), which shifts the id seen by telemetry and by any consumer that keyed on turn 0 for resumed headless runs; fresh runs are byte-identical to today.
- Not validated / out of scope: the ACP and interactive paths are untouched because they already seed, and `--continue`, `--fork-session` and resumed-from-interactive chains were not driven (the sandbox exercised `--session-id` → `--resume` only). `/rewind` itself and #9466's identity mapping were not driven either — the sandbox verified that ids repeat, not what the mapping then does with them.
- Breaking changes / migration notes: none; no persisted format or public API changes, and `createNonInteractivePromptId`'s new parameter is optional.

## Linked Issues

Closes #11408 — the single deferred finding it tracks (`ic:5582642849`, from #9466).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Headless 运行现在会从恢复的会话记录中续接 prompt 编号，而不是每个进程都重新开始。两条 headless 入口都覆盖到了：stream-json 会话（计数器每次都从第一轮重新开始）和单次 `-p` 运行（永远铸造第 0 轮）。两者都使用 core 中已有的 helper 从恢复的记录里播种——取记录中已声明的最大轮次，没有则回退到恢复的用户轮次数量；交互模式和 ACP 早就用同样的方式播种。没有恢复任何会话的运行，铸造出的 id 与今天完全一致。

## 为什么需要

`--resume` 和 `--continue` 会复用上一个会话的 id，因此重新开始编号的 headless 链会重复铸造上一次运行已经持久化的 prompt id，导致同一份 transcript 里多轮共用一个 prompt id。这个 id 正是 #9466 引入的 rewind 映射所锚定的键——id 重复会让该查找 fail-closed 退回按位置游走——同时也是持久化在 `ui_telemetry` 记录上的 `prompt_id`，而下一次 resume 又要读回它来为自己播种，于是歧义会沿着链条累积。交互模式和 ACP 在恢复时已经播种，只有这两条 headless 路径遗漏了，也就是 #11408 中记录的 deferred review finding。

对本描述早先版本的更正（来自沙箱 `/verify` 运行）：这两条路径上 file-history 快照**不会**被丢弃。去重机制确实存在（`SessionFileHistoryAccumulator` 每个 prompt id 只保留最后一份），但 `fileCheckpointingEnabled` 默认为 `!sdkMode && interactive`，且 `packages/cli` 中无人覆盖它，因此 `makeSnapshot` 直接返回，headless 轮次根本不写快照——沙箱实测：10 个 headless 进程、6 次真实 `write_file` 执行、0 条快照记录。这也正是交互模式一直播种的原因，而这项代价在 headless 路径上并不是本 PR 所消除的。

## 评审验证计划

### 如何验证

单元测试覆盖了两条路径，也是本 PR 提供给评审者的证据：在 `packages/cli` 下执行 `npx vitest run src/nonInteractive/session.test.ts src/llm.test.tsx`。stream-json 的用例断言：未恢复任何会话时仍从第 1 轮开始；恢复的记录中最大轮次为 5 时下一轮为 6；记录中没有持久化 prompt id 时回退到恢复的用户轮次计数。`-p` 的用例断言：恢复运行会续接到最后已声明轮次之后，而原有的「全新会话为第 0 轮」的期望保持不变。

端到端的 oracle 是持久化在会话 transcript（`<runtime>/projects/<cwd>/chats/<sid>.jsonl`）里的 prompt id，在每个进程退出后读回——而不是 file-history 快照，headless 根本不写快照。先带 `--session-id` 跑一次 `-p`，再跑 `-p --resume <id>` 并对比：改动前两个进程在 transcript 里只留下一个轮次号，改动后每个进程一个。沙箱 `/verify` 用真实构建的 base 与 head 产物驱动了这一点：`-p` 在 base 上是 `[0] → [0]`，head 上是 `[0] → [0,2]`；stream-json 三个进程在 base 上是 `[1] → [1] → [1]`，head 上是 `[1] → [1,2] → [1,2,3]`。

### 证据（改动前后）

N/A —— 没有用户可见或 TUI 变化，差异体现在持久化的 prompt id 以及以其为键的快照上。

### 测试平台

三个平台均未在本地验证：撰写本 PR 的机器无法运行构建和测试套件，lint、typecheck 与单元测试以 CI 为准。

### 运行环境（可选）

N/A —— 仅单元测试。

## 风险与范围

- 主要风险或取舍：恢复的 `-p` 运行所发出的那一个 prompt id 会发生变化（此前恒为第 0 轮），这会改变 telemetry 以及任何针对「恢复的 headless 运行为第 0 轮」做假设的消费方所看到的 id；全新运行与今天完全一致。
- 未验证 / 范围之外：ACP 与交互路径未改动，因为它们已经播种；`--continue`、`--fork-session` 以及「从交互会话恢复」的链路未被驱动（沙箱只跑了 `--session-id` → `--resume`）。`/rewind` 本身与 #9466 的身份映射也未被驱动——沙箱验证的是 id 会重复，而不是映射拿到重复 id 之后的行为。
- 破坏性变更 / 迁移说明：无；没有持久化格式或公开 API 变更，`createNonInteractivePromptId` 新增的参数是可选的。

## 关联 Issue

Closes #11408 —— 该 issue 追踪的唯一一条 deferred finding（`ic:5582642849`，来自 #9466）。

</details>

