### PR TITLE
fix(ci): space PR creation from release to avoid secondary rate limit

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -235,6 +235,10 @@ jobs:
           fi
 
           if [[ "${pr_state}" != "OPEN" ]]; then
+            # `gh pr create` runs right after the branch push and release
+            # creation; wait so GitHub doesn't reject the burst with its
+            # "was submitted too quickly" secondary rate limit.
+            sleep 30
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -457,6 +457,10 @@ jobs:
 
           pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base main --json url --jq '.[0].url')"
           if [[ -z "${pr_url}" ]]; then
+            # `gh pr create` runs right after the branch push and release
+            # creation; wait so GitHub doesn't reject the burst with its
+            # "was submitted too quickly" secondary rate limit.
+            sleep 30
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -420,6 +420,10 @@ jobs:
 
           pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base main --json url --jq '.[0].url')"
           if [[ -z "${pr_url}" ]]; then
+            # `gh pr create` runs right after the branch push and release
+            # creation; wait so GitHub doesn't reject the burst with its
+            # "was submitted too quickly" secondary rate limit.
+            sleep 30
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -44,4 +44,13 @@ describe('TypeScript SDK release workflow', () => {
       );
     }
   });
+
+  it('spaces PR creation out from the release to avoid secondary rate limits', () => {
+    // `gh pr create` runs right after the branch push and release creation,
+    // which can trip GitHub's "was submitted too quickly" GraphQL secondary
+    // rate limit (issue #11402). Pin the gap so a future removal lets the
+    // burst through again.
+    expect(workflow).toContain('was submitted too quickly');
+    expect(workflow).toContain('sleep 30');
+  });
 });

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -48,9 +48,18 @@ describe('TypeScript SDK release workflow', () => {
   it('spaces PR creation out from the release to avoid secondary rate limits', () => {
     // `gh pr create` runs right after the branch push and release creation,
     // which can trip GitHub's "was submitted too quickly" GraphQL secondary
-    // rate limit (issue #11402). Pin the gap so a future removal lets the
-    // burst through again.
-    expect(workflow).toContain('was submitted too quickly');
-    expect(workflow).toContain('sleep 30');
+    // rate limit (issue #11402). Pin the gap in every release workflow so a
+    // future removal lets the burst through again.
+    for (const path of [
+      '.github/workflows/release-sdk.yml',
+      '.github/workflows/release-sdk-python.yml',
+      '.github/workflows/finalize-release.yml',
+    ]) {
+      const text = readFileSync(path, 'utf8');
+      const createIndex = text.indexOf('pr_url="$(gh pr create');
+      // -1 when the create is gone or no `sleep 30` precedes it.
+      const sleepIndex = text.lastIndexOf('sleep 30', createIndex);
+      expect(sleepIndex, path).toBeGreaterThanOrEqual(0);
+    }
   });
 });


### PR DESCRIPTION
## What this PR does

The three release workflows that create the merge-back pull request after a release now wait 30 seconds before `gh pr create`, so PR creation no longer fires immediately after the release branch push and GitHub release creation.

## Why it's needed

The v0.1.10 SDK release failed (issue #11402) because PR creation ran ~2 seconds after the release branch push and GitHub release creation. GitHub's GraphQL API rejects that burst with "was submitted too quickly", and the step had no delay, so the whole job failed even though publish/tag/release had already succeeded.

## Reviewer Test Plan

### How to verify

- CI runs `scripts/tests/release-sdk-workflow.test.js`, which pins the `sleep 30` gap.
- Confirm the wait sits immediately before `gh pr create` in all three workflows.

### Evidence (Before & After)

Non-UI change: N/A.

- Before: `gh pr create` ran ~2s after `gh release create`, triggering "was submitted too quickly".
- After: a 30s wait separates the two writes.

### Tested on

| OS | Status |
| --- | --- |
| 🍏 macOS | N/A |
| 🪟 Windows | N/A |
| 🐧 Linux | ⚠️ partially tested — `actionlint` clean (YAML + shell); `vitest` not run (no `node_modules` locally) |

## Risk & Scope

- Main risk: none — a fixed 30s delay in a ~50-minute release job; the normal path is otherwise unchanged.
- Not validated: `vitest` not run locally (no `node_modules`); `shellcheck` not run (binary download timed out).
- Breaking changes: none.

## Linked Issues

Refs #11402

<details>
<summary>中文说明</summary>

### 本 PR 做了什么

三个在发布后创建回合并 PR 的发布工作流，现在会在 `gh pr create` 之前等待 30 秒，使创建 PR 不再紧跟在发布分支推送和 GitHub Release 创建之后立即执行。

### 为什么需要

v0.1.10 SDK 发布失败（issue #11402），原因是创建 PR 发生在发布分支推送和 GitHub Release 创建之后约 2 秒，GitHub 的 GraphQL API 以 "was submitted too quickly" 拒绝了这一突发，而该步骤没有任何延时，导致整个 job 失败——尽管 publish/tag/release 其实都已成功。

### 评审测试计划

#### 如何验证

- CI 会运行 `scripts/tests/release-sdk-workflow.test.js`，其中固定了 `sleep 30` 的间隔。
- 确认等待紧贴在三个工作流的 `gh pr create` 之前。

#### 证据（修复前后）

非 UI 变更：N/A。

- 修复前：`gh pr create` 在 `gh release create` 之后约 2 秒执行，触发 "was submitted too quickly"。
- 修复后：30 秒的等待把两次写操作隔开。

#### 测试环境

| 系统 | 状态 |
| --- | --- |
| 🍏 macOS | N/A |
| 🪟 Windows | N/A |
| 🐧 Linux | ⚠️ 部分测试 —— `actionlint` 通过（YAML + shell）；`vitest` 未跑（本地无 `node_modules`） |

### 风险与范围

- 主要风险：无 —— 在约 50 分钟的发布 job 里增加固定的 30 秒延时；正常路径除此之外不变。
- 未验证：`vitest` 未在本地运行（无 `node_modules`）；`shellcheck` 未运行（二进制下载超时）。
- 破坏性变更：无。

### 关联 Issue

Refs #11402

</details>

