### PR TITLE
fix(web-shell): make light-theme terminal text selection visible

### DIFF
--- a/packages/web-shell/client/components/terminal/TerminalPanel.test.tsx
+++ b/packages/web-shell/client/components/terminal/TerminalPanel.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../../i18n', () => ({
   }),
 }));
 
+import { Terminal } from '@xterm/xterm';
 import {
   releaseDetachedWebTerminal,
   releaseWebTerminal,
@@ -386,5 +387,18 @@ describe('TerminalPanel', () => {
 
     expect(terminal.blur).toHaveBeenCalledOnce();
     expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it('passes a visible selection background to xterm in the light theme', () => {
+    // xterm falls back to white rgba(255,255,255,0.3) for an unset
+    // selectionBackground, which blends into the white terminal background
+    // and leaves text selection invisible in the light theme.
+    render();
+
+    expect(Terminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        theme: expect.objectContaining({ selectionBackground: '#bdd8fe' }),
+      }),
+    );
   });
 });

--- a/packages/web-shell/client/components/terminal/TerminalPanel.tsx
+++ b/packages/web-shell/client/components/terminal/TerminalPanel.tsx
@@ -92,6 +92,11 @@ function xtermTheme(theme: WebShellTheme) {
         background: '#ffffff',
         foreground: '#1a1a1a',
         cursor: '#1a1a1a',
+        // An unset selectionBackground defaults to white in xterm and blends
+        // into the white terminal background, leaving text selection with no
+        // visible highlight in the light theme. Pin the light-theme selection
+        // blue instead so selected terminal text stays visible.
+        selectionBackground: '#bdd8fe',
       }
     : {
         background: '#0a0a0a',


### PR DESCRIPTION
## What this PR does

Text selection inside the web-shell terminal now paints a visible highlight in the light theme. Dragging to select terminal output previously produced no visual change because the xterm theme passed by the terminal panel did not set `selectionBackground`, so xterm fell back to its default of white at 30% opacity — which blends into the white terminal background used by the light theme and makes the selection rectangle invisible. The fix pins an explicit light-theme selection background (`#bdd8fe`) in the xterm theme and adds a regression test asserting the light-theme terminal is constructed with a visible selection color. Dark theme rendering is unchanged.

## Why it's needed

In the light theme, users who drag to select text in the terminal in order to copy it saw no highlight at all, so the selection looked as if it had not taken effect even though the text was actually selected. The dark theme was unaffected because xterm's default white selection stays visible against the dark background.

## Reviewer Test Plan

### How to verify

1. Switch web-shell to the light theme.
2. Open the terminal tab and drag across some output text with the mouse.
3. Expected: the selected range is highlighted with a light blue (`#bdd8fe`), and copying still works. Repeat the drag in the dark theme: the selection highlight there is unchanged (gray).

### Evidence (Before & After)

N/A — behavior is covered by the unit test suite; no terminal capture attached.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ terminal panel unit suite (19 tests) passed, ESLint + Prettier clean |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Unit tests only. `npm run typecheck` on the package still reports pre-existing errors in session-catalog code (a `DaemonSessionSummary.activeWorkState` type gap) that reproduce on a clean baseline and are unrelated to this change.

## Risk & Scope

- Main risk or tradeoff: none — the change only adds one theme field for the light theme; the dark theme and all other terminal behavior are untouched.
- Not validated / out of scope: no live-browser visual re-check of the selection color; package-wide typecheck has the pre-existing session-catalog errors noted above.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 内容

修复 web-shell 终端在浅色主题下选中文本没有可见高亮的问题。此前在浅色主题下用鼠标拖选终端输出没有任何视觉变化，原因是传入 xterm 的 theme 没有设置 `selectionBackground`，xterm 便回退到默认的「白色 30% 透明度」，而该颜色与浅色主题使用的白色终端背景混合后完全不可见。本 PR 在浅色主题的 xterm theme 中显式指定选区背景色（`#bdd8fe`），并新增回归测试，断言浅色主题下创建的终端带有可见的选区颜色。暗色主题行为不变。

## 背景

浅色主题下，用户拖选终端文本准备复制时看不到任何高亮，看起来像选中没有生效（实际上文本已被选中）。暗色主题不受影响，因为 xterm 默认的白色选区在深色背景上依然可见。

## 评审验证计划

### 如何验证

1. 将 web-shell 切换到浅色主题。
2. 打开终端页签，用鼠标拖选一段输出文本。
3. 预期：选中区域显示浅蓝色（`#bdd8fe`）高亮，复制仍然可用；在暗色主题下重复拖选，选区高亮保持原样（灰色）。

### 前后对比

不适用 —— 该行为由单元测试覆盖，未附终端截图。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 终端面板单元套件（19 个用例）通过，ESLint + Prettier 通过 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境说明（可选）

仅运行单元测试。包级 `npm run typecheck` 仍会报告 session-catalog 代码中与本次改动无关的既有错误（`DaemonSessionSummary.activeWorkState` 类型缺失），该错误在干净基线上同样复现。

## 风险与范围

- 主要风险或取舍：无 —— 改动仅为浅色主题增加一个 theme 字段，暗色主题及终端其余行为均未触碰。
- 未验证 / 超出范围：未在真实浏览器中目视复核选区颜色；包级 typecheck 存在上文提到的 session-catalog 既有错误。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。
</details>
