### PR TITLE
docs(serve): state what --no-web actually removes

### DIFF
--- a/docs/developers/daemon/00-index.md
+++ b/docs/developers/daemon/00-index.md
@@ -58,7 +58,7 @@ Pick the path that matches your goal:
 - [`17-configuration.md`](./17-configuration.md) - env vars, CLI flags, `settings.json` keys that affect the daemon.
 - [`18-error-taxonomy.md`](./18-error-taxonomy.md) - typed errors per layer with remediation.
 - [`19-observability.md`](./19-observability.md) - `QWEN_SERVE_DEBUG`, debugging recipes, telemetry gaps.
-- [`20-quickstart-operations.md`](./20-quickstart-operations.md) - shortest startup path, curl checks, route map, and embedded invocation recipes.
+- [`20-quickstart-operations.md`](./20-quickstart-operations.md) - shortest startup path, curl checks, route map, and the embedding boundary (in-process hosting is internal; external integrations use `qwen serve --no-web` plus the HTTP/SSE protocol). The internal `createServeApp` lifecycle recipe lives in [`02-serve-runtime.md`](./02-serve-runtime.md).
 
 ## Glossary
 
@@ -141,12 +141,12 @@ Use these anchors when moving from the docs into the latest `main` code:
 
 ### Reference and operations
 
-| Area                    | Current state                                                                                                                                             | Primary docs                          |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| Configuration           | Full `qwen serve` flags, env vars, `settings.json`, `ServeOptions`, `BridgeOptions`, and important constants are collected in one page.                   | [`17`](./17-configuration.md)         |
-| Quickstart / operations | Shortest startup path, launch recipes, curl checks, Web Shell auth behavior, route split, shutdown behavior, and embedded invocation recipes are covered. | [`20`](./20-quickstart-operations.md) |
-| Errors                  | Boot-time explicit failures, route errors, bridge errors, EventBus errors, filesystem errors, and mediator errors are summarized with remediation.        | [`18`](./18-error-taxonomy.md)        |
-| Observability           | `QWEN_SERVE_DEBUG`, curl recipes, useful events, telemetry gaps, and investigation checklists are documented.                                             | [`19`](./19-observability.md)         |
+| Area                    | Current state                                                                                                                                                                                                                               | Primary docs                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Configuration           | Full `qwen serve` flags, env vars, `settings.json`, `ServeOptions`, `BridgeOptions`, and important constants are collected in one page.                                                                                                     | [`17`](./17-configuration.md)         |
+| Quickstart / operations | Shortest startup path, launch recipes, curl checks, Web Shell auth behavior, route split, shutdown behavior, and the embedding boundary are covered. The internal `createServeApp` lifecycle recipe lives in [`02`](./02-serve-runtime.md). | [`20`](./20-quickstart-operations.md) |
+| Errors                  | Boot-time explicit failures, route errors, bridge errors, EventBus errors, filesystem errors, and mediator errors are summarized with remediation.                                                                                          | [`18`](./18-error-taxonomy.md)        |
+| Observability           | `QWEN_SERVE_DEBUG`, curl recipes, useful events, telemetry gaps, and investigation checklists are documented.                                                                                                                               | [`19`](./19-observability.md)         |
 
 ### Historical or deprecated surfaces
 

--- a/docs/developers/examples/daemon-client-quickstart.md
+++ b/docs/developers/examples/daemon-client-quickstart.md
@@ -13,7 +13,7 @@ qwen serve --no-web --port 4170 \
 # → qwen serve listening on http://127.0.0.1:4170 (mode=http-bridge, workspace=/path/to/project-a)
 ```
 
-`--no-web` removes the Web Shell assets; it does not select a smaller REST/SSE API profile. Each `--workspace` value must be an absolute directory. The first startup workspace is primary and remains the compatibility default for requests that omit `cwd`; `/capabilities.workspaces[]` is the catalog clients should use when selecting any runtime explicitly.
+`--no-web` removes the Web Shell assets and the surfaces bound to them: `POST /workspace/local-control/enable` then fails closed with `409 local_control_web_shell_unavailable` on every platform, and on macOS the `/live/*` routes, the `/live/host` WebSocket and the `experimental.liveVoice.*` settings keys are not registered — so an integration that drives the SDK's Live methods must run without `--no-web`. It is not a feature-profile switch: the session, prompt, workspace, permission and SSE routes are unchanged. Each `--workspace` value must be an absolute directory. The first startup workspace is primary and remains the compatibility default for requests that omit `cwd`; `/capabilities.workspaces[]` is the catalog clients should use when selecting any runtime explicitly.
 
 The token-less loopback default is intended for a single-user workstation. On a shared host, set `QWEN_SERVER_TOKEN` and add `--require-auth`; non-loopback binds require a token.
 

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -66,7 +66,7 @@ qwen serve
 
 The default bind is `127.0.0.1:4170`. Bearer auth is **off** and the primary listener is trusted, so any local process that can reach the port can use the full operator API, including executing code as the daemon user. Route-specific workspace trust, session ownership, `X-Qwen-Client-Id`, permission, feature, validation, and resource checks still apply. The daemon registers the current working directory as its primary workspace; use an absolute `--workspace /path/to/dir` to override it, and repeat the flag to register additional isolated runtimes.
 
-For an API-only daemon, disable the Web Shell without narrowing the daemon's REST or SSE API:
+For an API-only daemon, disable the Web Shell. The session, prompt, workspace, permission and SSE routes are unchanged; the surfaces bound to the Web Shell go with it — Local Control enablement fails closed on every platform, and on macOS the `/live/*` routes and the `/live/host` WebSocket are not registered:
 
 ```bash
 qwen serve --no-web


### PR DESCRIPTION
## What this PR does

Three sentences in the API-only daemon docs claim that `--no-web` leaves the REST/SSE surface intact. This PR replaces those claims with what the flag actually removes, and updates the daemon documentation index, which still advertises the embedded-invocation recipes that #11314 deleted from page 20. Documentation only — no code, test or configuration changes.

## Why it's needed

#11314 added `--no-web` to the API-only quickstart and to the user guide together with an absolute negative: "it does not select a smaller REST/SSE API profile" and "disable the Web Shell without narrowing the daemon's REST or SSE API". Both are falsifiable, and both are false.

`POST /workspace/local-control/enable` is registered unconditionally (`packages/cli/src/serve/server.ts:3432`) but receives `webShellAvailable: Boolean(webShellDir)` (`server.ts:3437`), and `--no-web` forces `webShellDir` to `undefined` (`server.ts:2032-2033`, `run-qwen-serve.ts:4236-4237`), so a call that reaches the LAN-interface check on a default daemon instead fails closed with `409 local_control_web_shell_unavailable` (`packages/cli/src/serve/routes/workspace-local-control.ts:126-133`) — on Linux as well as macOS, so this half is not a Live Voice scoping question. On macOS, `liveVoiceSurfaceAvailable` additionally requires `opts.serveWebShell !== false` (`server.ts:977-981`), which gates the whole block registering `/live/status`, `/live/start`, `/live/new`, `/live/stop`, `/live/mute`, `/live/shortcut` and `/live/setup*` (`server.ts:2268-2323`), the `/live/host` WebSocket (`server.ts:3357-3370`), and `includeLiveVoice` for the `experimental.liveVoice.*` settings keys (`server.ts:2748`, `routes/workspace-settings.ts:142-155`).

The repository's own suite already pins this narrowing, under a case named for the exact configuration the docs recommend: `packages/cli/src/serve/server.test.ts` → `does not expose Live in 'API-only mode'` (`serveWebShell: false`, `runtimePlatform: 'darwin'`, `webShellDir` present) asserts `GET /live/status` → 404 and no `experimental.liveVoice.*` setting key.

The cost is concrete for the reader these pages are written for. An integrator follows the quickstart's own Setup command, reads that nothing was narrowed, and then drives the SDK's Live methods — `liveStatus()`, `liveSetupStatus()`, `updateLiveSetup()`, `retryLiveHostInstall()`, `liveSetupInstall()`, `liveSetupLaunch()`, `startLive()`, `stopLive()`, `setLiveMute()`, `setLiveShortcut()` (`packages/sdk-typescript/src/daemon/DaemonClient.ts:4588-4672`), which issue plain `jsonRequest`s with no capability pre-flight, unlike the guarded calls at `DaemonClient.ts:1234-1241`. Every one 404s, enabling the feature throws `Live Voice is available only in WebShell on macOS.` (`server.ts:1850-1852`), and the sentence attached to the command they just copied points them away from the launch flag and toward their client, their token and their SDK version.

Separately, `docs/developers/daemon/00-index.md` still describes page 20 as covering "embedded invocation recipes" in two places (`:61` and the `:147` coverage table), although #11314 replaced that section with `## 12. Embedding boundary`, which says the opposite — that `runQwenServe` and `createServeApp` are internal implementation APIs and that those imports are not a supported integration contract. A repo-wide `git grep` for that phrase returns exactly those two index hits and none in page 20. The index is the routing surface for the whole daemon doc set, and nothing validates its per-page summaries, so it now sends a reader looking for an embedding recipe to a page that forbids embedding, while the real recipe sits unpointed-at at `docs/developers/daemon/02-serve-runtime.md:106`.

## Reviewer Test Plan

### How to verify

Confirm the stale wording is gone: `git grep -n -E "does not select a smaller REST/SSE API profile|without narrowing the daemon|embedded invocation recipes" -- docs` returns three hits on `main` and none after this PR. Confirm the behaviour the new wording states, without taking this description's word for it: run the existing case `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SHELL="$SHELL" npx vitest run packages/cli/src/serve/server.test.ts -t "does not expose Live in"` (expected: `/live/status` → 404 and no `experimental.liveVoice.*` key when `serveWebShell: false` on darwin), and read `routes/workspace-local-control.ts:126-133` together with its `webShellAvailable` input at `server.ts:3437` for the platform-independent 409. Confirm the index now matches page 20 by reading `docs/developers/daemon/20-quickstart-operations.md` §12 next to the two changed `00-index.md` lines, and that the pointer added for the internal recipe resolves to `02-serve-runtime.md:106`. Confirm formatting with `npx prettier --check docs/developers/examples/daemon-client-quickstart.md docs/users/qwen-serve.md docs/developers/daemon/00-index.md`.

### Evidence (Before & After)

N/A — documentation only; no user-visible or TUI surface changes. The measured behaviour behind the wording is quoted in Why it's needed from the existing test case and the cited source lines, and was additionally observed on a three-arm probe (`serveWebShell` default vs `false`, darwin vs linux) during the review of #11314: `GET /live/status` 200 → 404, `experimental.liveVoice.*` keys `["…enabled","…shortcut"]` → `[]`, and `POST /workspace/local-control/enable` `409 no_lan_interface` → `409 local_control_web_shell_unavailable`, where the first code is raised inside `service.#enable` after the `webShellAvailable` gate (`local-control/service.ts:169`) and so shows the default arm passing that gate.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: `prettier --check` clean on all three files, the `git grep` before/after comparison above, and `git diff --check` clean. Windows and Linux: N/A — this PR changes no code, so there is nothing platform-specific to run; the Linux row of the probe evidence was produced by injecting `runtimePlatform` on a macOS host, not on a Linux host, and is reported as such rather than claimed as platform testing.

### Environment (optional)

N/A — no daemon or runtime was exercised by this PR's own changes. The worktree was installed with `QWEN_SKIP_PREPARE=1 npm ci` so that the repository's `pre-commit` hook (`npm run pre-commit` → lint-staged → Prettier) could run normally; the commit was made with the hook enabled, not bypassed.

## Risk & Scope

- Main risk or tradeoff: the replacement wording names four specific surfaces (`POST /workspace/local-control/enable`, `/live/*`, the `/live/host` WebSocket, the `experimental.liveVoice.*` settings keys), so it is longer and more likely to need updating if those surfaces move than the shorter sentence it replaces. That is the intended trade: the short sentence was false, and a reader can only act on a specific one. The macOS-only half is explicitly conditioned in the text, because `server.ts:977-981` also requires `runtimePlatform === 'darwin'`, a resolved `deps.webShellDir` and `acpHttpEnabledAtBoot` (`acp-http-enabled.ts:20`), so on Linux or with `QWEN_SERVE_ACP_HTTP=0` those routes are absent with or without `--no-web`; only the Local Control 409 is unconditional.
- Not validated / out of scope: no code changes, so no test was added, and nothing beyond the existing case named above was run. Two items raised in the #11314 review are deliberately left out. (1) Nothing pins `packages/cli/package.json`'s `exports` map, so the `./serve` boundary that page 20 §12 declares could be dissolved later with the whole suite green — fixing that means adding a test file, which is not a documentation correction and belongs in its own change. (2) The §12 redirect sentence itself ("External integrations should start `qwen serve --no-web` and use … `@qwen-code/sdk`") is left as written, because the quickstart page an SDK integrator actually follows now states the withholding; adding the same clause to §12 as well would duplicate it. Also out of scope: two pre-existing inaccuracies noticed while verifying, neither introduced by #11314 and neither in a file this PR touches — `docs/developers/daemon/00-index.md:116` says `qwen serve` "calls `app.listen`" where the bootstrap is `createServer(app)` (`run-qwen-serve.ts:9592`) then `server.listen(...)` (`:9678`), and the `expect(capabilities.body.features).not.toContain('realtime_voice')` assertion inside `server.test.ts`'s `does not expose Live in 'API-only mode'` case cannot fail in either `it.each` arm because that tag requires `realtimeVoiceEnabled === true` (`capabilities.ts:769`), which neither arm sets.
- Breaking changes / migration notes: none — documentation only.

## Linked Issues

Refs #11314 (merged as `59163a3ad0`; this PR corrects three sentences it added and one index entry it left stale, and follows up the five review comments posted on it after the merge). No issue is closed by this PR.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

API-only daemon 文档里有三句话声称 `--no-web` 不影响 REST/SSE 接口面。本 PR 把这些说法换成该 flag 实际移除的内容，并更新 daemon 文档索引——索引仍在宣传 #11314 已从 page 20 删掉的 embedded-invocation 示例。纯文档改动，不涉及任何代码、测试或配置。

## 为什么需要

#11314 把 `--no-web` 加进 API-only quickstart 和用户指南时，配了一个绝对否定式表述："it does not select a smaller REST/SSE API profile" 与 "disable the Web Shell without narrowing the daemon's REST or SSE API"。两句都可证伪，而且都是假的。

`POST /workspace/local-control/enable` 是无条件注册的（`packages/cli/src/serve/server.ts:3432`），但它收到的是 `webShellAvailable: Boolean(webShellDir)`（`server.ts:3437`），而 `--no-web` 会把 `webShellDir` 强制置为 `undefined`（`server.ts:2032-2033`、`run-qwen-serve.ts:4236-4237`）；于是在默认 daemon 上能走到 LAN 网卡检查的同一个调用，在这里会以 `409 local_control_web_shell_unavailable` 失败关闭（`packages/cli/src/serve/routes/workspace-local-control.ts:126-133`）——Linux 和 macOS 都一样，所以这一半不是 Live Voice 的平台范围问题。在 macOS 上，`liveVoiceSurfaceAvailable` 还额外要求 `opts.serveWebShell !== false`（`server.ts:977-981`），它把关了注册 `/live/status`、`/live/start`、`/live/new`、`/live/stop`、`/live/mute`、`/live/shortcut`、`/live/setup*` 的整个代码块（`server.ts:2268-2323`）、`/live/host` WebSocket（`server.ts:3357-3370`），以及 `experimental.liveVoice.*` 设置键所依赖的 `includeLiveVoice`（`server.ts:2748`、`routes/workspace-settings.ts:142-155`）。

仓库自己的测试套件已经钉住了这个收窄，而且用例名正好就是文档所推荐的这个配置：`packages/cli/src/serve/server.test.ts` → `does not expose Live in 'API-only mode'`（`serveWebShell: false`、`runtimePlatform: 'darwin'`、`webShellDir` 存在）断言 `GET /live/status` → 404，且没有 `experimental.liveVoice.*` 设置键。

对这两页文档的目标读者来说代价是具体的。集成方照着 quickstart 自己的 Setup 命令启动，读到"接口面没有收窄"，然后去驱动 SDK 的 Live 方法——`liveStatus()`、`liveSetupStatus()`、`updateLiveSetup()`、`retryLiveHostInstall()`、`liveSetupInstall()`、`liveSetupLaunch()`、`startLive()`、`stopLive()`、`setLiveMute()`、`setLiveShortcut()`（`packages/sdk-typescript/src/daemon/DaemonClient.ts:4588-4672`），这些都是不带能力预检的普通 `jsonRequest`，与 `DaemonClient.ts:1234-1241` 那些有门控的调用不同。于是全部 404；想开启该功能又会抛 `Live Voice is available only in WebShell on macOS.`（`server.ts:1850-1852`）；而贴在他刚复制的那条命令旁边的这句话，把他的注意力从启动参数引开，转向自己的客户端、token 和 SDK 版本。

另一方面，`docs/developers/daemon/00-index.md` 仍有两处（`:61` 与 `:147` 的覆盖度表格）把 page 20 描述为涵盖 "embedded invocation recipes"，而 #11314 已把那一节换成 `## 12. Embedding boundary`，说的正是相反的事——`runQwenServe` 与 `createServeApp` 是内部实现 API，这些 import 不是受支持的集成契约。全仓 `git grep` 该短语恰好命中这两处索引、page 20 内零命中。索引是整个 daemon 文档集的导流面，而它的每页摘要没有任何校验，所以现在它会把想找嵌入示例的读者送到一个禁止嵌入的页面，而真正的示例就在 `docs/developers/daemon/02-serve-runtime.md:106`，没有任何索引行指向它。

## Reviewer 测试计划

### 如何验证

确认过时措辞已消失：`git grep -n -E "does not select a smaller REST/SSE API profile|without narrowing the daemon|embedded invocation recipes" -- docs` 在 `main` 上返回 3 处命中，本 PR 之后为 0。确认新措辞所描述的行为——不要只信本描述：跑既有用例 `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SHELL="$SHELL" npx vitest run packages/cli/src/serve/server.test.ts -t "does not expose Live in"`（预期：darwin 下 `serveWebShell: false` 时 `/live/status` → 404 且无 `experimental.liveVoice.*` 键），并阅读 `routes/workspace-local-control.ts:126-133` 与其 `webShellAvailable` 输入 `server.ts:3437`，确认那个与平台无关的 409。确认索引与 page 20 一致：把 `docs/developers/daemon/20-quickstart-operations.md` §12 与改动后的两行 `00-index.md` 对照阅读，并确认新增的内部示例指针能解析到 `02-serve-runtime.md:106`。用 `npx prettier --check docs/developers/examples/daemon-client-quickstart.md docs/users/qwen-serve.md docs/developers/daemon/00-index.md` 确认格式。

### Before & After 证据

N/A——纯文档改动，没有用户可见或 TUI 层面的变化。措辞背后的实测行为已在"为什么需要"中引用既有测试用例与被引源码行；此外在 #11314 的评审过程中用三臂探针（`serveWebShell` 默认 vs `false`，darwin vs linux）观测到：`GET /live/status` 200 → 404，`experimental.liveVoice.*` 键从 `["…enabled","…shortcut"]` 变为 `[]`，`POST /workspace/local-control/enable` 从 `409 no_lan_interface` 变为 `409 local_control_web_shell_unavailable`——前一个错误码是在 `webShellAvailable` 闸门之后由 `service.#enable` 内部抛出的（`local-control/service.ts:169`），因此说明默认臂通过了该闸门。

### 测试环境

macOS：三个文件 `prettier --check` 全部通过、上述 `git grep` 前后对比、`git diff --check` 干净。Windows 与 Linux：N/A——本 PR 不改代码，没有平台相关可运行项；探针证据里的 Linux 那一臂是在 macOS 主机上通过注入 `runtimePlatform` 得到的，并非真实 Linux 主机，此处如实说明而不当作平台测试声称。

### 环境（可选）

N/A——本 PR 自身的改动没有启动任何 daemon 或运行时。worktree 用 `QWEN_SKIP_PREPARE=1 npm ci` 安装，以便仓库的 `pre-commit` 钩子（`npm run pre-commit` → lint-staged → Prettier）能正常运行；提交是在钩子启用的状态下完成的，没有绕过。

## 风险与范围

- 主要风险或取舍：替换后的措辞点名了四个具体接口面（`POST /workspace/local-control/enable`、`/live/*`、`/live/host` WebSocket、`experimental.liveVoice.*` 设置键），因此比它所替换的那句更长，将来这些接口面变动时也更可能需要更新。这是有意的取舍：原来那句短但是假的，而读者只能对具体的表述采取行动。macOS 专属的那一半在文中已明确加了条件限定，因为 `server.ts:977-981` 还要求 `runtimePlatform === 'darwin'`、已解析的 `deps.webShellDir` 与 `acpHttpEnabledAtBoot`（`acp-http-enabled.ts:20`）；所以在 Linux 上、或设了 `QWEN_SERVE_ACP_HTTP=0` 时，这些路由无论加不加 `--no-web` 都不存在，只有 Local Control 的 409 是无条件的。
- 未验证 / 超出范围：不改代码，因此没有新增测试，除上面点名的既有用例外没有运行其他测试。#11314 评审中提出的两项被有意排除。（1）没有任何测试钉住 `packages/cli/package.json` 的 `exports` 映射，所以 page 20 §12 声明的 `./serve` 边界将来可能在整套测试全绿的情况下被解除——修它意味着新增测试文件，那不是文档修正，应放在独立改动里。（2）§12 的重定向句本身（"External integrations should start `qwen serve --no-web` and use … `@qwen-code/sdk`"）保持原样，因为 SDK 集成方真正会跟着走的那一页 quickstart 现在已经说明了会被拿掉的能力；在 §12 再加同样的从句是重复。同样超出范围：验证过程中注意到的两处既有不准确表述，都不是 #11314 引入的，也都不在本 PR 触碰的文件里——`docs/developers/daemon/00-index.md:116` 说 `qwen serve` "calls `app.listen`"，而真实引导是 `createServer(app)`（`run-qwen-serve.ts:9592`）再 `server.listen(...)`（`:9678`）；以及 `server.test.ts` 的 `does not expose Live in 'API-only mode'` 用例里那条 `expect(capabilities.body.features).not.toContain('realtime_voice')` 在两个 `it.each` 臂中都不可能失败，因为该 tag 需要 `realtimeVoiceEnabled === true`（`capabilities.ts:769`），而两臂都没有设置它。
- 破坏性变更 / 迁移说明：无——纯文档改动。

## 关联 Issue

Refs #11314（已以 `59163a3ad0` 合并；本 PR 修正它新增的三句话与它遗留的一处过时索引，并跟进合并后才发布在它上面的五条评审评论）。本 PR 不关闭任何 issue。

</details>
