### PR TITLE
fix(core): use qwen3.8-flash for automatic web search

### DIFF
--- a/packages/core/src/tools/web-search.test.ts
+++ b/packages/core/src/tools/web-search.test.ts
@@ -651,7 +651,7 @@ describe('evaluateWebSearchGate auto derivation', () => {
       expect(gate.backend).toEqual({
         // Not the primary model id: the search runs on the documented
         // search model at the same endpoint.
-        modelId: 'qwen3.6-plus',
+        modelId: 'qwen3.8-flash',
         apiKeyEnvKey: STANDARD.envKey,
         baseUrl: STANDARD.baseUrl,
         webExtractor: true,
@@ -668,7 +668,7 @@ describe('evaluateWebSearchGate auto derivation', () => {
     expect(gate.ok).toBe(true);
     if (gate.ok) {
       expect(gate.backend.baseUrl).toBe(TOKEN_PLAN.baseUrl);
-      expect(gate.backend.modelId).toBe('qwen3.6-plus');
+      expect(gate.backend.modelId).toBe('qwen3.8-flash');
     }
   });
 
@@ -1240,7 +1240,7 @@ describe('evaluateWebSearchGate auto derivation', () => {
       }),
     );
     expect(gate.ok).toBe(true);
-    if (gate.ok) expect(gate.backend.modelId).toBe('qwen3.6-plus');
+    if (gate.ok) expect(gate.backend.modelId).toBe('qwen3.8-flash');
   });
 
   it('stays silently off instead of throwing when the config surface is incomplete', () => {

--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -71,7 +71,7 @@ const NO_SEARCH_RETRY_JITTER_MS = 500;
  * guaranteed to serve the Responses API search tools, while this one is the
  * documented recommendation.
  */
-export const DEFAULT_WEB_SEARCH_MODEL = 'qwen3.6-plus';
+export const DEFAULT_WEB_SEARCH_MODEL = 'qwen3.8-flash';
 
 /**
  * Parameters for the WebSearch tool. Deliberately just the query: the
@@ -494,18 +494,18 @@ export function evaluateWebSearchGate(config: Config): WebSearchGateResult {
       ok: false,
       notice:
         'WebSearch is enabled but no search model is configured.\n' +
-        'Add a search model to settings.json (recommended: qwen3.6-plus):\n' +
+        'Add a search model to settings.json (recommended: qwen3.8-flash):\n' +
         '  {\n' +
-        '    "tools": { "webSearch": { "enabled": true, "model": "qwen3.6-plus" } },\n' +
+        '    "tools": { "webSearch": { "enabled": true, "model": "qwen3.8-flash" } },\n' +
         '    "modelProviders": {\n' +
-        '      "openai": [{ "id": "qwen3.6-plus",\n' +
+        '      "openai": [{ "id": "qwen3.8-flash",\n' +
         '        "baseUrl": "' +
         DEFAULT_DASHSCOPE_BASE_URL +
         '",\n' +
         '        "envKey": "DASHSCOPE_API_KEY" }]\n' +
         '    }\n' +
         '  }\n' +
-        'Or via env: ENABLE_WEB_SEARCH=true WEB_SEARCH_MODEL=qwen3.6-plus\n' +
+        'Or via env: ENABLE_WEB_SEARCH=true WEB_SEARCH_MODEL=qwen3.8-flash\n' +
         'WEB_SEARCH_BASE_URL=' +
         DEFAULT_DASHSCOPE_BASE_URL +
         ' (plus WEB_SEARCH_API_KEY).',


### PR DESCRIPTION
## What this PR does

Changes the automatically derived ModelStudio Web Search side model from `qwen3.6-plus` to `qwen3.8-flash` for both Standard API Key and Token Plan providers. Explicit `tools.webSearch.model` configuration continues to take precedence, and the setup guidance now recommends the same default.

## Why it's needed

The live Token Plan model catalog no longer exposes `qwen3.6-plus` for the affected subscription, and Responses API requests fail with an access-denied model error. This made the zero-configuration Web Search path added by #11348 register successfully but fail every search request. `qwen3.8-flash` is available on the current Token Plan endpoint and is documented to support Responses API Web Search across ModelStudio regions.

## Reviewer Test Plan

### How to verify

With either a ModelStudio Standard API Key or Token Plan provider selected, leave `tools.webSearch` unset and start Qwen Code. Confirm that Web Search is registered automatically and that the derived side request uses `qwen3.8-flash` at the selected provider's existing endpoint. Also confirm that an explicit `tools.webSearch.model` value still overrides the default.

### Evidence (Before & After)

Before: the automatically derived request used `qwen3.6-plus`; on the affected Token Plan subscription the endpoint returned `response.failed` with `Access to model denied`.

After: the Standard API Key and Token Plan auto-derivation tests both resolve the side request to `qwen3.8-flash`; the complete Web Search unit file passes 103/103. A live Token Plan request using `qwen3.8-flash` completed successfully.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS, Node.js 22, local bundle against the ModelStudio Token Plan China (Beijing) endpoint.

## Risk & Scope

- Main risk or tradeoff: Model availability remains controlled by each ModelStudio account and region; users can still select another supported search model explicitly.
- Not validated / out of scope: No live Standard API Key request was made; that path is covered by the same auto-derivation unit test and the documented ModelStudio Responses API capability.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #11348.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

将 ModelStudio Web Search 自动派生路径使用的旁路模型从 `qwen3.6-plus` 调整为 `qwen3.8-flash`，同时覆盖 Standard API Key 和 Token Plan provider。用户显式配置的 `tools.webSearch.model` 仍然优先，配置提示也同步推荐新的默认模型。

## 为什么需要此改动

受影响订阅的 Token Plan 实时模型目录已不再返回 `qwen3.6-plus`，Responses API 请求会以模型无访问权限失败。这导致 #11348 新增的零配置 Web Search 虽然能够正常注册工具，但每次搜索请求都会失败。当前 Token Plan endpoint 可使用 `qwen3.8-flash`，并且官方文档明确它在 ModelStudio 各地域支持 Responses API Web Search。

## Reviewer 测试计划

### 如何验证

选择 ModelStudio Standard API Key 或 Token Plan provider，不配置 `tools.webSearch` 并启动 Qwen Code。确认 Web Search 会自动注册，且派生出的旁路请求使用所选 provider 原有 endpoint 上的 `qwen3.8-flash`。同时确认显式配置 `tools.webSearch.model` 时仍会覆盖默认值。

### 前后证据

改动前：自动派生请求使用 `qwen3.6-plus`；在受影响的 Token Plan 订阅上，endpoint 返回 `response.failed`，错误为 `Access to model denied`。

改动后：Standard API Key 和 Token Plan 的自动派生测试都会将旁路请求解析为 `qwen3.8-flash`；完整 Web Search 单测 103/103 通过。使用 `qwen3.8-flash` 的 Token Plan 真实请求也已成功完成。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

macOS、Node.js 22、本地 bundle，连接 ModelStudio Token Plan 华北 2（北京）endpoint。

## 风险与范围

- 主要风险或权衡：模型可用性仍由各 ModelStudio 账号和地域控制；用户仍可显式选择其他受支持的搜索模型。
- 未验证或不在范围内：未执行 Standard API Key 真实网络请求；该路径由相同的自动派生单测以及 ModelStudio Responses API 官方能力说明覆盖。
- 破坏性变更或迁移说明：无。

## 关联事项

#11348 的后续修复。

</details>
