### PR TITLE
refactor(core): stop routing Goal turns through the legacy Stop hook

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -118,7 +118,6 @@ import type { SkillConfig } from '../skills/types.js';
 import { createSkillScopedAgentConfig } from '../memory/skillReviewAgentPlanner.js';
 import { maybeRunAutoSkillCurator } from '../skills/skill-curator.js';
 import { HookSystem } from '../hooks/index.js';
-import { GOAL_HOOK_ID_OUTPUT_KEY } from '../goals/goalHook.js';
 import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
 import type {
   ChatRecord,
@@ -13089,78 +13088,6 @@ describe('Model Switching and Config Updates', () => {
       );
       expect(response.success).toBe(true);
     });
-  });
-
-  describe('Stop dispatch through the hook execution bridge', () => {
-    it.each([
-      {
-        name: 'ignores non-blocking outputs',
-        otherOutput: { continue: true },
-        expected: false,
-        expectedReason: undefined,
-      },
-      {
-        name: 'detects another blocking output',
-        otherOutput: {
-          decision: 'block',
-          reason: 'Policy review is still required',
-        },
-        expected: true,
-        expectedReason: 'Policy review is still required',
-      },
-      {
-        name: 'preserves a stop reason',
-        otherOutput: {
-          continue: false,
-          stopReason: 'External stop hook feedback',
-        },
-        expected: true,
-        expectedReason: 'External stop hook feedback',
-      },
-    ])(
-      '$name when a goal hook blocks',
-      async ({ otherOutput, expected, expectedReason }) => {
-        const config = new Config({ ...baseParams });
-        await config.initialize();
-        const goalOutput = {
-          decision: 'block' as const,
-          reason: 'Keep working',
-          hookSpecificOutput: {
-            [GOAL_HOOK_ID_OUTPUT_KEY]: 'goal-hook-id',
-          },
-        };
-        const fireStopEvent = vi.fn().mockResolvedValue({
-          finalOutput: {
-            ...goalOutput,
-            ...otherOutput,
-          },
-          allOutputs: [goalOutput, otherOutput],
-        });
-        // @ts-expect-error - accessing private for testing
-        config['hookSystem'] = { fireStopEvent };
-
-        const response = await config
-          .getMessageBus()!
-          .request<HookExecutionRequest, HookExecutionResponse>(
-            {
-              type: MessageBusType.HOOK_EXECUTION_REQUEST,
-              eventName: 'Stop',
-              input: {
-                stop_hook_active: true,
-                last_assistant_message: 'last response',
-              },
-            },
-            MessageBusType.HOOK_EXECUTION_RESPONSE,
-          );
-
-        expect(response.error).toBeUndefined();
-        expect(response).toMatchObject({
-          success: true,
-          hasNonGoalBlockingStopHook: expected,
-        });
-        expect(response.nonGoalBlockingStopReason).toBe(expectedReason);
-      },
-    );
   });
 
   describe('MessageDisplay dispatch through the hook execution bridge', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -117,7 +117,7 @@ import { SkillManager } from '../skills/skill-manager.js';
 import type { SkillConfig } from '../skills/types.js';
 import { createSkillScopedAgentConfig } from '../memory/skillReviewAgentPlanner.js';
 import { maybeRunAutoSkillCurator } from '../skills/skill-curator.js';
-import { HookSystem } from '../hooks/index.js';
+import { createHookOutput, HookSystem } from '../hooks/index.js';
 import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
 import type {
   ChatRecord,
@@ -13087,6 +13087,110 @@ describe('Model Switching and Config Updates', () => {
         expected,
       );
       expect(response.success).toBe(true);
+    });
+  });
+
+  describe('Stop dispatch through the hook execution bridge', () => {
+    // The goal-specific half of this suite went with the two response fields
+    // it asserted. What remains is the only exercise of the surviving
+    // `case 'Stop':` branch: without it, deleting that branch or throwing
+    // inside it leaves the whole package green while every configured Stop
+    // hook silently stops blocking.
+    it('forwards the request input positionally, wraps the output, and counts the hooks that ran', async () => {
+      const config = new Config({ ...baseParams });
+      await config.initialize();
+
+      const blockingOutput = {
+        decision: 'block' as const,
+        reason: 'Policy review is still required',
+      };
+      const secondOutput = { continue: true };
+      const fireStopEvent = vi.fn().mockResolvedValue({
+        finalOutput: blockingOutput,
+        allOutputs: [blockingOutput, secondOutput],
+      });
+      // @ts-expect-error - accessing private for testing
+      config['hookSystem'] = { fireStopEvent };
+
+      const controller = new AbortController();
+      const response = await config
+        .getMessageBus()!
+        .request<HookExecutionRequest, HookExecutionResponse>(
+          {
+            type: MessageBusType.HOOK_EXECUTION_REQUEST,
+            eventName: 'Stop',
+            input: {
+              stop_hook_active: true,
+              last_assistant_message: 'last response',
+              context_limit: 1_000,
+              input_tokens: 250,
+            },
+            signal: controller.signal,
+          },
+          MessageBusType.HOOK_EXECUTION_RESPONSE,
+        );
+
+      expect(response.error).toBeUndefined();
+      expect(response.success).toBe(true);
+      // Positional, so swapping the two strings is caught here rather than by
+      // a consumer that happens to read only one of them.
+      expect(fireStopEvent).toHaveBeenCalledWith(
+        true,
+        'last response',
+        { context_usage: 0.25, context_limit: 1_000, input_tokens: 250 },
+        controller.signal,
+      );
+      // Read off the bridge response rather than through a consumer: both
+      // consumers mask a missing value with `?? 1`, so an assertion made
+      // through them would still pass if the producer stopped setting it.
+      expect(response.stopHookCount).toBe(2);
+      // The `createHookOutput('Stop', ...)` wrap. A plain object would carry
+      // the same fields but none of the methods every consumer calls.
+      // The `createHookOutput('Stop', ...)` wrap, asserted on the call rather
+      // than the result: this file replaces the hooks module with a bare mock,
+      // so the wrap returns undefined here. The call is what matters -- without
+      // it no consumer can ask the output whether it blocks.
+      expect(vi.mocked(createHookOutput)).toHaveBeenCalledWith(
+        'Stop',
+        blockingOutput,
+      );
+    });
+
+    it('reports no output when every Stop hook declines to act', async () => {
+      const config = new Config({ ...baseParams });
+      await config.initialize();
+
+      const fireStopEvent = vi.fn().mockResolvedValue({
+        finalOutput: undefined,
+        allOutputs: [],
+      });
+      // @ts-expect-error - accessing private for testing
+      config['hookSystem'] = { fireStopEvent };
+
+      const response = await config
+        .getMessageBus()!
+        .request<HookExecutionRequest, HookExecutionResponse>(
+          {
+            type: MessageBusType.HOOK_EXECUTION_REQUEST,
+            eventName: 'Stop',
+            input: { stop_hook_active: false },
+          },
+          MessageBusType.HOOK_EXECUTION_RESPONSE,
+        );
+
+      expect(response.success).toBe(true);
+      expect(response.output).toBeUndefined();
+      expect(response.stopHookCount).toBe(0);
+      // No final output means nothing to wrap.
+      expect(vi.mocked(createHookOutput)).not.toHaveBeenCalled();
+      // An absent last message is forwarded as the empty string, and usage
+      // figures that cannot be computed are forwarded as undefined.
+      expect(fireStopEvent).toHaveBeenCalledWith(
+        false,
+        '',
+        undefined,
+        undefined,
+      );
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -172,7 +172,6 @@ import {
   type PostToolBatchToolCall,
 } from '../hooks/types.js';
 import { fireNotificationHook } from '../core/toolHookTriggers.js';
-import { GOAL_HOOK_ID_OUTPUT_KEY } from '../goals/goalHook.js';
 import {
   createGoalRuntime,
   GoalPersistenceUnavailableError,
@@ -3277,8 +3276,6 @@ export class Config {
             // Execute the appropriate hook based on eventName
             let result;
             let stopHookCount: number | undefined;
-            let hasNonGoalBlockingStopHook: boolean | undefined;
-            let nonGoalBlockingStopReason: string | undefined;
             const input = request.input || {};
             const signal = request.signal;
             switch (request.eventName) {
@@ -3317,32 +3314,6 @@ export class Config {
                   ? createHookOutput('Stop', stopResult.finalOutput)
                   : undefined;
                 stopHookCount = stopResult.allOutputs.length;
-                const goalHookId =
-                  stopResult.finalOutput?.hookSpecificOutput?.[
-                    GOAL_HOOK_ID_OUTPUT_KEY
-                  ];
-                if (typeof goalHookId === 'string') {
-                  const nonGoalBlockingOutputs = stopResult.allOutputs.filter(
-                    (output) =>
-                      output.hookSpecificOutput?.[GOAL_HOOK_ID_OUTPUT_KEY] !==
-                        goalHookId &&
-                      (output.decision === 'block' ||
-                        output.decision === 'deny' ||
-                        output.continue === false),
-                  );
-                  hasNonGoalBlockingStopHook =
-                    nonGoalBlockingOutputs.length > 0;
-                  if (hasNonGoalBlockingStopHook) {
-                    nonGoalBlockingStopReason = nonGoalBlockingOutputs
-                      .map(
-                        (output) =>
-                          output.stopReason ||
-                          output.reason ||
-                          'No reason provided',
-                      )
-                      .join('\n');
-                  }
-                }
                 break;
               }
               case 'MessageDisplay': {
@@ -3471,8 +3442,6 @@ export class Config {
               output: result,
               // Include stop hook count for Stop events
               stopHookCount,
-              hasNonGoalBlockingStopHook,
-              nonGoalBlockingStopReason,
             } as HookExecutionResponse);
           } catch (error) {
             this.debugLogger.warn(`Hook execution failed: ${error}`);

--- a/packages/core/src/confirmation-bus/types.ts
+++ b/packages/core/src/confirmation-bus/types.ts
@@ -121,10 +121,6 @@ export interface HookExecutionResponse {
   error?: Error;
   /** Number of stop hooks that were executed */
   stopHookCount?: number;
-  /** Whether a blocking Stop output came from outside the active goal hook. */
-  hasNonGoalBlockingStopHook?: boolean;
-  /** Continuation reason from blocking Stop outputs outside the active goal. */
-  nonGoalBlockingStopReason?: string;
 }
 
 export type Message =

--- a/packages/core/src/core/client-goal.test.ts
+++ b/packages/core/src/core/client-goal.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 import type { LlmChat } from './llm-chat.js';
 import {
@@ -27,12 +27,6 @@ import {
 } from '../goals/goal-protocol.js';
 import type { ChatRecord } from '../services/chatRecordingService.js';
 import { ApprovalMode } from '../config/config.js';
-import {
-  __resetActiveGoalStoreForTests,
-  clearActiveGoal,
-  setActiveGoal,
-} from '../goals/activeGoalStore.js';
-import { GOAL_HOOK_ID_OUTPUT_KEY } from '../goals/goalHook.js';
 import type { PendingGoalProposal } from '../goals/goal-tools.js';
 
 const turnMocks = vi.hoisted(() => ({
@@ -291,17 +285,12 @@ function setupGoalClient() {
 
 describe('LlmClient Goal admission', () => {
   beforeEach(() => {
-    __resetActiveGoalStoreForTests();
     turnMocks.constructors.length = 0;
     turnMocks.pendingToolCalls.length = 0;
     turnMocks.run.mockReset().mockImplementation(emptyStream);
     nextSpeakerMocks.check.mockReset().mockResolvedValue({
       next_speaker: 'model',
     });
-  });
-
-  afterEach(() => {
-    __resetActiveGoalStoreForTests();
   });
 
   it('sets an approved propose_goal proposal once the turn ends without tool calls', async () => {
@@ -416,76 +405,6 @@ describe('LlmClient Goal admission', () => {
       ),
     );
 
-    expect(runtime.dispatch).toHaveBeenCalledWith({
-      action: 'create',
-      objective: 'ship it',
-    });
-  });
-
-  it('settles an approved proposal when a cleared Goal removes the Stop continuation', async () => {
-    const { client, config, runtime } = setupGoalClient();
-    vi.mocked(runtime.getSnapshot).mockReturnValue({
-      v: 2,
-      activity: 'idle',
-      goal: null,
-    });
-    setActiveGoal('goal-test-session', {
-      condition: 'finish the old goal',
-      iterations: 1,
-      setAt: 1,
-      tokensAtStart: 1,
-      hookId: 'old-goal-hook',
-    });
-    let pending: { objective: string; turnKey: string } | undefined;
-    const takePendingGoalProposal = vi.fn(() => {
-      const proposal = pending;
-      pending = undefined;
-      return proposal;
-    });
-    Object.assign(config, {
-      takePendingGoalProposal,
-      getDisableAllHooks: vi.fn(() => false),
-      hasHooksForEvent: vi.fn((event) => event === 'Stop'),
-      getMessageBus: vi.fn(() => ({
-        request: vi.fn(async () => ({
-          output: {
-            decision: 'block',
-            reason: 'Keep working',
-            hookSpecificOutput: {
-              [GOAL_HOOK_ID_OUTPUT_KEY]: 'old-goal-hook',
-            },
-          },
-          stopHookCount: 1,
-          hasNonGoalBlockingStopHook: false,
-        })),
-      })),
-      getMaxSessionTurns: vi.fn(() => 0),
-      getUsageStatisticsEnabled: vi.fn(() => false),
-    });
-    turnMocks.run.mockImplementationOnce(() => {
-      pending = { objective: 'ship it', turnKey: 'stop-clear-key' };
-      return emptyStream();
-    });
-    const getSteerInput = vi
-      .fn()
-      .mockResolvedValueOnce(undefined)
-      .mockImplementationOnce(async () => {
-        clearActiveGoal('goal-test-session');
-        return undefined;
-      });
-
-    await drain(
-      client.sendMessageStream(
-        [{ text: 'set a goal for this' }],
-        new AbortController().signal,
-        'stop-clear-key',
-        { type: SendMessageType.UserQuery, getSteerInput },
-      ),
-    );
-
-    expect(turnMocks.run).toHaveBeenCalledOnce();
-    expect(getSteerInput).toHaveBeenCalledTimes(2);
-    expect(takePendingGoalProposal).toHaveBeenCalledTimes(2);
     expect(runtime.dispatch).toHaveBeenCalledWith({
       action: 'create',
       objective: 'ship it',
@@ -2117,8 +2036,6 @@ describe('LlmClient Goal admission', () => {
     );
   });
 
-  afterEach(() => __resetActiveGoalStoreForTests());
-
   it('admits a runtime Goal turn to steer input at a hit session cap', async () => {
     // Second half of the session-cap exclusion: runtime Goal turns skip the
     // count increment (pinned by the 75-turn test above) and must also be
@@ -2142,59 +2059,5 @@ describe('LlmClient Goal admission', () => {
     );
 
     expect(getSteerInput).toHaveBeenCalled();
-  });
-
-  it('does not decrement the caller recursion budget inside a legacy hook Goal chain', async () => {
-    // A legacy /goal chain recurses inside one sendMessageStream call. With
-    // the caller budget of 2 preserved at every hop, two blocked stops still
-    // run three model turns; a decremented budget would refuse the third.
-    // Unsupported Goal runtime: the legacy hook chain owns the send, so the
-    // branch under test is the one that keys the budget on the active goal.
-    const { client, config } = setupGoalClient();
-    vi.mocked(config.getGoalRuntimeReady).mockRejectedValue(
-      new GoalPersistenceUnavailableError('legacy-only session'),
-    );
-    vi.mocked(config.getSkipNextSpeakerCheck).mockReturnValue(true);
-    vi.mocked(config.getDisableAllHooks).mockReturnValue(false);
-    vi.mocked(config.getMaxSessionTurns).mockReturnValue(0);
-    vi.mocked(config.hasHooksForEvent).mockImplementation(
-      (event) => event === 'Stop',
-    );
-    let stopRequestCount = 0;
-    const messageBus = {
-      request: vi.fn(async () => {
-        stopRequestCount += 1;
-        if (stopRequestCount <= 2) {
-          return {
-            output: { decision: 'block', reason: 'keep going' },
-            stopHookCount: 1,
-          };
-        }
-        return { output: undefined, stopHookCount: 1 };
-      }),
-    };
-    vi.mocked(config.getMessageBus).mockReturnValue(
-      messageBus as unknown as ReturnType<Config['getMessageBus']>,
-    );
-    setActiveGoal('goal-test-session', {
-      condition: 'ship',
-      iterations: 0,
-      setAt: 1,
-      tokensAtStart: 0,
-      hookId: 'goal-hook:test',
-    });
-
-    await drain(
-      client.sendMessageStream(
-        [{ text: 'start the chain' }],
-        new AbortController().signal,
-        'legacy-goal-chain',
-        undefined,
-        2,
-      ),
-    );
-
-    expect(messageBus.request).toHaveBeenCalledTimes(3);
-    expect(turnMocks.run).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -101,12 +101,6 @@ import {
 import { collectAvailableSkillEntries } from '../tools/skill-utils.js';
 import type { AvailableSkillEntry } from '../tools/skill-utils.js';
 import { ToolNames } from '../tools/tool-names.js';
-import {
-  __resetActiveGoalStoreForTests,
-  clearActiveGoal,
-  setActiveGoal,
-} from '../goals/activeGoalStore.js';
-import { GOAL_HOOK_ID_OUTPUT_KEY } from '../goals/goalHook.js';
 import { emptyGoalSnapshot } from '../goals/goal-protocol.js';
 import type { GoalRuntime } from '../goals/goal-runtime.js';
 import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
@@ -728,7 +722,6 @@ describe('Gemini Client (client.ts)', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-    __resetActiveGoalStoreForTests();
   });
 
   describe('initialize', () => {
@@ -11634,186 +11627,19 @@ Other open files:
         client['chat'] = mockChat as LlmChat;
       });
 
-      it('emits active_goal when a goal is active for the turn', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 2,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook-id',
-          lastReason: 'still missing verification',
-        });
-
-        const events = await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'Hi' }],
-            new AbortController().signal,
-            'prompt-active-goal',
-          ),
-        );
-
-        expect(events[0]).toEqual({
-          type: LlmEventType.ActiveGoal,
-          value: {
-            condition: 'finish the refactor',
-            iterations: 2,
-            setAt: 123,
-            tokensAtStart: 456,
-            hookId: 'goal-hook-id',
-            lastReason: 'still missing verification',
-          },
-        });
-      });
-
-      it('emits active_goal null when the Stop hook clears the goal', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 2,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook-id',
-          lastReason: 'still missing verification',
-        });
-        const mockMessageBus = {
-          request: vi.fn().mockImplementation(async () => {
-            clearActiveGoal('test-session-id');
-            return {};
-          }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        client['chat'] = {
-          addHistory: vi.fn(),
-          getHistory: vi.fn().mockReturnValue([
-            {
-              role: 'model',
-              parts: [{ text: 'done' }],
-            },
-          ]),
-        } as unknown as LlmChat;
-        mockTurnRunFn.mockReturnValue(
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'done' };
-          })(),
-        );
-
-        const events = await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'Hi' }],
-            new AbortController().signal,
-            'prompt-cleared-active-goal',
-          ),
-        );
-
-        expect(events).toContainEqual({
-          type: LlmEventType.ActiveGoal,
-          value: null,
-        });
-      });
-
-      it('emits active_goal null when the Stop hook clears the goal before aborting', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 2,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook-id',
-          lastReason: 'still missing verification',
-        });
+      it('does not start a Stop hook continuation when the blocking decision lands already aborted', async () => {
         const abortController = new AbortController();
         const mockMessageBus = {
-          request: vi.fn().mockImplementation(async () => {
-            clearActiveGoal('test-session-id');
-            abortController.abort();
-            return {};
-          }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        client['chat'] = {
-          addHistory: vi.fn(),
-          getHistory: vi.fn().mockReturnValue([
-            {
-              role: 'model',
-              parts: [{ text: 'done' }],
-            },
-          ]),
-        } as unknown as LlmChat;
-        mockTurnRunFn.mockReturnValue(
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'done' };
-          })(),
-        );
-
-        const events = await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'Hi' }],
-            abortController.signal,
-            'prompt-cleared-active-goal-then-aborted',
-          ),
-        );
-
-        const activeGoalEvents = events.filter(
-          (event) => event.type === LlmEventType.ActiveGoal,
-        );
-
-        expect(activeGoalEvents).toEqual([
-          {
-            type: LlmEventType.ActiveGoal,
-            value: expect.objectContaining({
-              condition: 'finish the refactor',
-            }),
-          },
-          {
-            type: LlmEventType.ActiveGoal,
-            value: null,
-          },
-        ]);
-      });
-
-      it('emits active_goal changes when aborting before Stop hook continuation', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 2,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook-id',
-          lastReason: 'still missing verification',
-        });
-        const abortController = new AbortController();
-        const mockMessageBus = {
-          request: vi.fn().mockImplementation(async () => {
-            setActiveGoal('test-session-id', {
-              condition: 'finish the refactor',
-              iterations: 3,
-              setAt: 123,
-              tokensAtStart: 456,
-              hookId: 'goal-hook-id',
-              lastReason: 'still missing validation',
-            });
-            return {
-              output: {
-                get decision() {
-                  abortController.abort();
-                  return 'block';
-                },
-                reason: 'Keep working',
+          request: vi.fn().mockImplementation(async () => ({
+            output: {
+              get decision() {
+                abortController.abort();
+                return 'block';
               },
-              stopHookCount: 1,
-            };
-          }),
+              reason: 'Keep working',
+            },
+            stopHookCount: 1,
+          })),
           response: vi.fn(),
         };
         vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
@@ -11845,27 +11671,10 @@ Other open files:
             'prompt-stop-hook-continuation-aborted',
           ),
         );
-        const activeGoalEvents = events.filter(
-          (event) => event.type === LlmEventType.ActiveGoal,
-        );
 
-        expect(activeGoalEvents).toEqual([
-          {
-            type: LlmEventType.ActiveGoal,
-            value: expect.objectContaining({
-              condition: 'finish the refactor',
-              iterations: 2,
-            }),
-          },
-          {
-            type: LlmEventType.ActiveGoal,
-            value: expect.objectContaining({
-              condition: 'finish the refactor',
-              iterations: 3,
-              lastReason: 'still missing validation',
-            }),
-          },
-        ]);
+        // The blocking decision arrives only after the signal aborted, so the
+        // continuation turn must not run and no StopHookLoop is announced.
+        expect(mockTurnRunFn).toHaveBeenCalledOnce();
         expect(events).not.toContainEqual(
           expect.objectContaining({
             type: LlmEventType.StopHookLoop,
@@ -12503,74 +12312,6 @@ Other open files:
         ).toHaveBeenCalledWith('ok', { promptId: 'prompt-stop-hook-budget' });
       });
 
-      it('emits one active_goal null when the blocking cap aborts an active goal', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 2,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook-id',
-          lastReason: 'still missing verification',
-        });
-        const mockMessageBus = {
-          request: vi.fn().mockResolvedValue({
-            output: {
-              decision: 'block',
-              reason: 'Keep working',
-            },
-            stopHookCount: 1,
-          }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        vi.mocked(mockConfig.getStopHookBlockingCap).mockReturnValue(1);
-
-        client['chat'] = {
-          addHistory: vi.fn(),
-          getHistory: vi.fn().mockReturnValue([
-            {
-              role: 'model',
-              parts: [{ text: 'not done' }],
-            },
-          ]),
-        } as unknown as LlmChat;
-        mockTurnRunFn.mockReturnValue(
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'not done' };
-          })(),
-        );
-
-        const events = await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'Hi' }],
-            new AbortController().signal,
-            'prompt-stop-cap-active-goal',
-          ),
-        );
-        const activeGoalEvents = events.filter(
-          (event) => event.type === LlmEventType.ActiveGoal,
-        );
-
-        expect(activeGoalEvents).toEqual([
-          {
-            type: LlmEventType.ActiveGoal,
-            value: expect.objectContaining({
-              condition: 'finish the refactor',
-            }),
-          },
-          {
-            type: LlmEventType.ActiveGoal,
-            value: null,
-          },
-        ]);
-      });
-
       it('should not skip hooks when hasHooksForEvent returns true', async () => {
         const mockMessageBus = {
           request: vi.fn().mockResolvedValue({ modifiedPrompt: undefined }),
@@ -13079,259 +12820,6 @@ Other open files:
         expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
         expect(getLastTurnRequestText()).toContain('Keep working');
         expect(getLastTurnRequestText()).toContain('also check the tests');
-      });
-
-      it('preserves goal feedback alongside an external stop reason', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 1,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'goal-hook',
-        });
-        const mockMessageBus = {
-          request: vi
-            .fn()
-            .mockResolvedValueOnce({
-              output: {
-                decision: 'block',
-                continue: false,
-                stopReason: 'External stop hook feedback',
-                reason: 'Keep working on the active goal',
-                hookSpecificOutput: {
-                  [GOAL_HOOK_ID_OUTPUT_KEY]: 'goal-hook',
-                },
-              },
-              stopHookCount: 2,
-              hasNonGoalBlockingStopHook: true,
-              nonGoalBlockingStopReason: 'External stop hook feedback',
-            })
-            .mockResolvedValue({ output: undefined }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        mockTurnRunFn.mockImplementation(() =>
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'response' };
-          })(),
-        );
-        const getSteerInput = vi
-          .fn<() => Promise<SteerInput | undefined>>()
-          .mockResolvedValue(undefined);
-
-        await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'start the goal' }],
-            new AbortController().signal,
-            'prompt-goal-with-external-stop-reason',
-            { type: SendMessageType.UserQuery, getSteerInput },
-          ),
-        );
-
-        expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
-        expect(getLastTurnRequestText()).toContain(
-          'External stop hook feedback',
-        );
-        expect(getLastTurnRequestText()).toContain(
-          'Keep working on the active goal',
-        );
-      });
-
-      it('stops a blocking goal when queued input clears it', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 1,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'old-goal-hook',
-        });
-        const mockMessageBus = {
-          request: vi.fn().mockResolvedValue({
-            output: {
-              decision: 'block',
-              reason: 'Keep working',
-              hookSpecificOutput: {
-                [GOAL_HOOK_ID_OUTPUT_KEY]: 'old-goal-hook',
-              },
-            },
-            stopHookCount: 2,
-            hasNonGoalBlockingStopHook: false,
-          }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        mockTurnRunFn.mockImplementation(() =>
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'response' };
-          })(),
-        );
-        const getSteerInput = vi
-          .fn<() => Promise<SteerInput | undefined>>()
-          .mockResolvedValueOnce(undefined)
-          .mockImplementationOnce(async () => {
-            clearActiveGoal('test-session-id');
-            return undefined;
-          });
-
-        const events = await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'start the goal' }],
-            new AbortController().signal,
-            'prompt-clear-during-stop',
-            { type: SendMessageType.UserQuery, getSteerInput },
-          ),
-        );
-
-        expect(mockTurnRunFn).toHaveBeenCalledOnce();
-        expect(events).toContainEqual({
-          type: LlmEventType.ActiveGoal,
-          value: null,
-        });
-      });
-
-      it('replaces a blocking goal without sending the old continuation', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 1,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'old-goal-hook',
-        });
-        const mockMessageBus = {
-          request: vi
-            .fn()
-            .mockResolvedValueOnce({
-              output: {
-                decision: 'block',
-                reason: 'Keep working',
-                hookSpecificOutput: {
-                  [GOAL_HOOK_ID_OUTPUT_KEY]: 'old-goal-hook',
-                },
-              },
-              stopHookCount: 1,
-              hasNonGoalBlockingStopHook: false,
-            })
-            .mockResolvedValue({ output: undefined }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        mockTurnRunFn.mockImplementation(() =>
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'response' };
-          })(),
-        );
-        const getSteerInput = vi
-          .fn<() => Promise<SteerInput | undefined>>()
-          .mockResolvedValueOnce(undefined)
-          .mockImplementationOnce(async () => {
-            setActiveGoal('test-session-id', {
-              condition: 'verify the tests',
-              iterations: 0,
-              setAt: 789,
-              tokensAtStart: 999,
-              hookId: 'new-goal-hook',
-            });
-            return {
-              parts: [{ text: 'new goal instruction' }],
-              accept: vi.fn(),
-              restore: vi.fn(),
-            };
-          })
-          .mockResolvedValue(undefined);
-
-        await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'start the goal' }],
-            new AbortController().signal,
-            'prompt-replace-during-stop',
-            { type: SendMessageType.UserQuery, getSteerInput },
-          ),
-        );
-
-        expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
-        expect(getLastTurnRequestText()).toContain('new goal instruction');
-        expect(getLastTurnRequestText()).not.toContain('Keep working');
-      });
-
-      it('preserves other blocking Stop hook output when a goal is cleared', async () => {
-        setActiveGoal('test-session-id', {
-          condition: 'finish the refactor',
-          iterations: 1,
-          setAt: 123,
-          tokensAtStart: 456,
-          hookId: 'old-goal-hook',
-        });
-        const mockMessageBus = {
-          request: vi
-            .fn()
-            .mockResolvedValueOnce({
-              output: {
-                decision: 'block',
-                reason: 'Keep working\nPolicy review is still required',
-                hookSpecificOutput: {
-                  [GOAL_HOOK_ID_OUTPUT_KEY]: 'old-goal-hook',
-                },
-              },
-              stopHookCount: 2,
-              hasNonGoalBlockingStopHook: true,
-              nonGoalBlockingStopReason: 'Policy review is still required',
-            })
-            .mockResolvedValue({ output: undefined }),
-          response: vi.fn(),
-        };
-        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
-        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
-          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
-        );
-        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
-          (event: string) => event === 'Stop',
-        );
-        mockTurnRunFn.mockImplementation(() =>
-          (async function* () {
-            yield { type: LlmEventType.Content, value: 'response' };
-          })(),
-        );
-        const getSteerInput = vi
-          .fn<() => Promise<SteerInput | undefined>>()
-          .mockResolvedValueOnce(undefined)
-          .mockImplementationOnce(async () => {
-            clearActiveGoal('test-session-id');
-            return undefined;
-          })
-          .mockResolvedValue(undefined);
-
-        await fromAsync(
-          client.sendMessageStream(
-            [{ text: 'start the goal' }],
-            new AbortController().signal,
-            'prompt-clear-with-other-stop-hook',
-            { type: SendMessageType.UserQuery, getSteerInput },
-          ),
-        );
-
-        expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
-        expect(getLastTurnRequestText()).toContain(
-          'Policy review is still required',
-        );
-        expect(getLastTurnRequestText()).not.toContain('Keep working');
       });
 
       it('uses input queued during next-speaker classification for the continuation', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -43,16 +43,6 @@ import {
   GoalPersistenceUnavailableError,
   type GoalRuntime,
 } from '../goals/goal-runtime.js';
-import {
-  activeGoalEquals,
-  getActiveGoal,
-  type ActiveGoal,
-} from '../goals/activeGoalStore.js';
-import {
-  abortGoalForStopHookCap,
-  getStopHookContinuationReason,
-  GOAL_HOOK_ID_OUTPUT_KEY,
-} from '../goals/goalHook.js';
 import { applyPendingGoalProposal } from '../goals/goal-tools.js';
 import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 import { buildContextUsage } from '../hooks/context-usage.js';
@@ -4012,31 +4002,6 @@ export class LlmClient {
         yield goalEvent;
       }
 
-      const activeGoalAtTurnStart = goalRuntime?.getSnapshot().goal
-        ? undefined
-        : getActiveGoal(this.config.getSessionId());
-      if (activeGoalAtTurnStart) {
-        yield {
-          type: LlmEventType.ActiveGoal,
-          value: activeGoalAtTurnStart,
-        };
-      }
-      let lastEmittedActiveGoal: ActiveGoal | undefined = activeGoalAtTurnStart;
-      // Tracks the last emitted goal value to suppress duplicate events.
-      // Mutates `lastEmittedActiveGoal` when an event is returned.
-      const maybeEmitActiveGoalChange = (
-        nextActiveGoal: ActiveGoal | undefined,
-      ): ServerLlmStreamEvent | undefined => {
-        if (activeGoalEquals(lastEmittedActiveGoal, nextActiveGoal)) {
-          return undefined;
-        }
-        lastEmittedActiveGoal = nextActiveGoal;
-        return {
-          type: LlmEventType.ActiveGoal,
-          value: nextActiveGoal ?? null,
-        };
-      };
-
       // MessageDisplay hook: fires repeatedly as this turn's reply streams
       // (before Stop, which fires once at the end). One dispatcher — one
       // message_id and one debounce accumulator — per turn.run() call;
@@ -4391,22 +4356,10 @@ export class LlmClient {
         for (const goalEvent of takePendingGoalEvents()) {
           yield goalEvent;
         }
-        // Stop hook callbacks can mutate active goal state during request().
-        // Capture it before cancellation returns so clear events are not lost.
-        const activeGoalAfterStopHook = goalPermit
-          ? undefined
-          : getActiveGoal(this.config.getSessionId());
-
         // Check if aborted after hook execution
         if (signal.aborted) {
           for (const goalEvent of await finalizeInterruptedGoalTurn()) {
             yield goalEvent;
-          }
-          const activeGoalEvent = maybeEmitActiveGoalChange(
-            activeGoalAfterStopHook,
-          );
-          if (activeGoalEvent) {
-            yield activeGoalEvent;
           }
           endCurrentInteraction('cancelled');
           return turn;
@@ -4528,17 +4481,12 @@ export class LlmClient {
         ) {
           // Check if aborted before continuing
           if (signal.aborted) {
-            const activeGoalEvent = maybeEmitActiveGoalChange(
-              activeGoalAfterStopHook,
-            );
-            if (activeGoalEvent) {
-              yield activeGoalEvent;
-            }
             endCurrentInteraction('cancelled');
             return turn;
           }
 
-          const continueReason = getStopHookContinuationReason(stopOutput);
+          const continueReason =
+            stopOutput.stopReason || stopOutput.reason || 'No reason provided';
 
           // Track stop hook iterations
           const currentIterationCount =
@@ -4558,19 +4506,6 @@ export class LlmClient {
               'Stop',
               stopHookBlockingCap,
             );
-            abortGoalForStopHookCap(
-              this.config,
-              this.config.getSessionId(),
-              warning,
-            );
-            const activeGoalAfterCap = getActiveGoal(
-              this.config.getSessionId(),
-            );
-            const activeGoalEvent =
-              maybeEmitActiveGoalChange(activeGoalAfterCap);
-            if (activeGoalEvent) {
-              yield activeGoalEvent;
-            }
             yield {
               type: LlmEventType.HookSystemMessage,
               value: warning,
@@ -4589,13 +4524,6 @@ export class LlmClient {
             return turn;
           }
 
-          const activeGoalEvent = maybeEmitActiveGoalChange(
-            activeGoalAfterStopHook,
-          );
-          if (activeGoalEvent) {
-            yield activeGoalEvent;
-          }
-
           yield {
             type: LlmEventType.StopHookLoop,
             value: {
@@ -4605,78 +4533,22 @@ export class LlmClient {
             },
           };
 
-          // A blocking Stop hook (e.g. /goal) feeds a fresh user-role prompt
-          // back to the model, starting a new logical turn — reset per-turn
-          // loop accounting so each continuation gets its own tool-call
-          // budget. Without this, a goal chain accumulates every iteration's
-          // tool calls into one "turn" and trips TURN_TOOL_CALL_CAP after a
-          // handful of healthy iterations. The ACP daemon path already has
-          // these semantics (fresh DaemonToolLoopState per continuation).
-          // Runaway protection is preserved: the cap still bounds each
-          // iteration, and the chain itself is bounded by
-          // stopHookBlockingCap / MAX_GOAL_ITERATIONS. Those are the only
-          // Goal-specific bounds on this path (a user-set maxSessionTurns
-          // still cuts the chain: each hook hop is a plain send with no
-          // Goal permit, so it counts as a session turn): the legacy hook
-          // Goal recurses inside one sendMessageStream call, so the
-          // runtime's token budget (which meters continuations the Goal
-          // runtime schedules) never sees it, and the recursion budget is
-          // not decremented below because a 50-iteration chain with steer
-          // and next-speaker continues would otherwise exhaust MAX_TURNS
-          // before its own iteration cap.
+          // A blocking Stop hook feeds a fresh user-role prompt back to the
+          // model, starting a new logical turn — reset per-turn loop
+          // accounting so each continuation gets its own tool-call budget.
+          // Without this, a hook chain accumulates every iteration's tool
+          // calls into one "turn" and trips TURN_TOOL_CALL_CAP after a handful
+          // of healthy iterations. The ACP daemon path already has these
+          // semantics (fresh DaemonToolLoopState per continuation). Runaway
+          // protection is preserved: the cap still bounds each iteration, and
+          // the chain itself is bounded by stopHookBlockingCap.
           this.loopDetector.reset(prompt_id);
 
-          const activeGoal = getActiveGoal(this.config.getSessionId());
-          const hookTurnBudget = activeGoal ? boundedTurns : boundedTurns - 1;
+          const hookTurnBudget = boundedTurns - 1;
           const pendingSteer = await takeSteerInput(hookTurnBudget);
-          const activeGoalAfterSteer = getActiveGoal(
-            this.config.getSessionId(),
-          );
-          const activeGoalChanged =
-            activeGoal !== undefined &&
-            activeGoalAfterSteer?.hookId !== activeGoal.hookId;
-          const goalContinuationChanged =
-            activeGoalChanged &&
-            stopOutput.hookSpecificOutput?.[GOAL_HOOK_ID_OUTPUT_KEY] ===
-              activeGoal.hookId;
-          if (activeGoalChanged) {
-            const activeGoalEvent =
-              maybeEmitActiveGoalChange(activeGoalAfterSteer);
-            if (activeGoalEvent) {
-              yield activeGoalEvent;
-            }
-          }
-          const discardGoalContinuation =
-            goalContinuationChanged &&
-            response.hasNonGoalBlockingStopHook === false;
-          const continuationReasonAfterSteer = discardGoalContinuation
-            ? undefined
-            : goalContinuationChanged &&
-                response.hasNonGoalBlockingStopHook === true
-              ? response.nonGoalBlockingStopReason || 'No reason provided'
-              : continueReason;
-          if (!continuationReasonAfterSteer && !pendingSteer) {
-            await this.settlePendingGoalProposal(
-              true,
-              signal,
-              loadGoalRuntime,
-              prompt_id,
-            );
-            for (const goalEvent of takePendingGoalEvents()) {
-              yield goalEvent;
-            }
-            endCurrentInteraction('ok');
-            normalCompletion = true;
-            return turn;
-          }
-          const continueRequest: Part[] = continuationReasonAfterSteer
-            ? [{ text: continuationReasonAfterSteer }]
-            : [];
+          const continueRequest: Part[] = [{ text: continueReason }];
           if (pendingSteer) {
-            if (continueRequest.length > 0) {
-              continueRequest.push({ text: '\n\n' });
-            }
-            continueRequest.push(...pendingSteer.parts);
+            continueRequest.push({ text: '\n\n' }, ...pendingSteer.parts);
           }
           const pushCountBefore = currentPushCount();
           let hookTurn: Turn;
@@ -4690,19 +4562,10 @@ export class LlmClient {
                 modelOverride: options?.modelOverride,
                 getSteerInput: options?.getSteerInput,
                 steerInput: pendingSteer,
-                stopHookState: discardGoalContinuation
-                  ? undefined
-                  : {
-                      iterationCount: currentIterationCount,
-                      reasons:
-                        continuationReasonAfterSteer &&
-                        continuationReasonAfterSteer !== continueReason
-                          ? [
-                              ...currentReasons.slice(0, -1),
-                              continuationReasonAfterSteer,
-                            ]
-                          : currentReasons,
-                    },
+                stopHookState: {
+                  iterationCount: currentIterationCount,
+                  reasons: currentReasons,
+                },
               },
               hookTurnBudget,
             );
@@ -4729,12 +4592,6 @@ export class LlmClient {
           return hookTurn;
         }
 
-        const activeGoalEvent = maybeEmitActiveGoalChange(
-          activeGoalAfterStopHook,
-        );
-        if (activeGoalEvent) {
-          yield activeGoalEvent;
-        }
         for (const goalEvent of takePendingGoalEvents()) {
           yield goalEvent;
         }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -4485,8 +4485,7 @@ export class LlmClient {
             return turn;
           }
 
-          const continueReason =
-            stopOutput.stopReason || stopOutput.reason || 'No reason provided';
+          const continueReason = stopOutput.getEffectiveReason();
 
           // Track stop hook iterations
           const currentIterationCount =

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -37,7 +37,7 @@ import {
   type ThoughtSummary,
 } from '../utils/thoughtUtils.js';
 import type { LoopType } from '../telemetry/types.js';
-import type { ActiveGoal } from '../goals/activeGoalStore.js';
+import type { ActiveGoal } from '../goals/goal-legacy-projection.js';
 import type {
   GoalSnapshotV2,
   GoalStateCause,

--- a/packages/core/src/goals/activeGoalStore.test.ts
+++ b/packages/core/src/goals/activeGoalStore.test.ts
@@ -12,8 +12,8 @@ import {
   getActiveGoal,
   recordGoalIteration,
   setActiveGoal,
-  type ActiveGoal,
 } from './activeGoalStore.js';
+import type { ActiveGoal } from './goal-legacy-projection.js';
 
 const makeGoal = (overrides: Partial<ActiveGoal> = {}): ActiveGoal => ({
   condition: 'write a hello world script',

--- a/packages/core/src/goals/activeGoalStore.ts
+++ b/packages/core/src/goals/activeGoalStore.ts
@@ -4,21 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * The runtime state of a `/goal` registered in a session. Lives only in memory:
- * the source of truth for restore-after-resume is the conversation history
- * `goal_status` attachments, not this store.
- */
-export interface ActiveGoal {
-  condition: string;
-  iterations: number;
-  deferredEvaluations?: number;
-  setAt: number;
-  tokensAtStart: number;
-  lastReason?: string;
-  hookId: string;
-}
+import type { ActiveGoal } from './goal-legacy-projection.js';
 
+/**
+ * Holds the runtime state of a `/goal` registered in a session. Lives only in
+ * memory: the source of truth for restore-after-resume is the conversation
+ * history `goal_status` attachments, not this store.
+ */
 const store = new Map<string, ActiveGoal>();
 
 export function activeGoalEquals(

--- a/packages/core/src/goals/goal-legacy-projection.ts
+++ b/packages/core/src/goals/goal-legacy-projection.ts
@@ -30,6 +30,22 @@ export interface LegacyGoalStatus {
   lastReason?: string;
 }
 
+/**
+ * The shape carried by the `active_goal` stream event and produced by
+ * `projectActiveGoal` from a Goal v3 snapshot. Deliberately kept separate from
+ * `LegacyActiveGoal` below: the two differ in which fields are optional, so
+ * merging them would silently change a wire type.
+ */
+export interface ActiveGoal {
+  condition: string;
+  iterations: number;
+  deferredEvaluations?: number;
+  setAt: number;
+  tokensAtStart: number;
+  lastReason?: string;
+  hookId: string;
+}
+
 export interface LegacyActiveGoal {
   readonly condition: string;
   readonly iterations: number;

--- a/packages/core/src/goals/goalHook.ts
+++ b/packages/core/src/goals/goalHook.ts
@@ -21,8 +21,8 @@ import {
   recordGoalIteration,
   resetGoalDeferrals,
   setActiveGoal,
-  type ActiveGoal,
 } from './activeGoalStore.js';
+import type { ActiveGoal } from './goal-legacy-projection.js';
 import { judgeGoal } from './goalJudge.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -5,7 +5,6 @@
  */
 
 export type {
-  ActiveGoal,
   GoalTerminalEvent,
   GoalTerminalKind,
   GoalTerminalObserver,
@@ -57,6 +56,7 @@ export {
   projectGoalStateToLegacy,
 } from './goal-legacy-projection.js';
 export type {
+  ActiveGoal,
   LegacyActiveGoal,
   LegacyGoalProjection,
   LegacyGoalStatus,


### PR DESCRIPTION
## What this PR does

Core no longer routes any Goal through the first-generation Stop-hook implementation. The `LlmClient` turn loop drops the fallback that read a Goal out of the in-memory legacy store whenever a turn arrived without a v3 permit, along with everything that fallback fed: the duplicate-suppressing `active_goal` emitter, the blocking-cap abort that reached into the store, the recursion-budget exception a legacy Goal used to get, and the Stop-hook continuation rewrite that compared hook ids to decide whether a Goal had been cleared mid-continuation. The hook execution bridge drops the two response fields that existed only so that rewrite could tell a Goal's blocking Stop output from anyone else's.

The `ActiveGoal` interface moves out of the legacy store module into `goal-legacy-projection.ts`, because it is still the shape of a live compatibility surface: the headless `active_goal` stream event and the `ServerLlmActiveGoalEvent` that carries it. It sits beside the existing `LegacyActiveGoal` rather than merging with it — the two differ in which fields are required, so merging would change a wire type — and the core barrel keeps exporting the same name.

The legacy modules themselves (`goalHook.ts`, `goalJudge.ts`, `activeGoalStore.ts`) are untouched and still compile. Two CLI call sites keep them referenced, so deleting them needs a CLI-side change first; that is the next PR in this sequence.

## Why it's needed

The two generations have coexisted for a while, and the duplication is the main thing that makes the Goal code hard to read: a reader cannot tell which judge is authoritative without tracing call graphs. It is also not a live/live split. `registerGoalHook`'s only production caller is `restoreGoalFromHistory`, and that function has no callers of its own, so the legacy store is never populated in a real session and the legacy judge never runs. What remained was cost: dead branches in the hottest function in core, two response fields nothing else could use, and a comment block explaining a recursion hazard that can no longer occur.

Removing core's use of the dead generation is also the prerequisite for deleting it. The files stay referenced from the CLI until the sibling PR lands, so this one is deliberately scoped to "stop calling it" rather than "delete it".

## Reviewer Test Plan

### How to verify

```
cd packages/core && npx vitest run src/core/client-goal.test.ts src/core/client.test.ts src/config/config.test.ts src/goals/goal-legacy-projection.test.ts
cd packages/core && npx vitest run src/goals src/hooks
cd packages/core && npx tsc --noEmit -p tsconfig.json
```

The claim worth checking rather than taking on trust is that nothing live was cut. Three things had to survive, and all three are still there: `projectActiveGoal` and `sameActiveGoalProjection`, the `takePendingGoalEvents` projection that turns a **v3 snapshot** into the `active_goal` event, and the `ActiveGoal` type itself under its original exported name. The removed emitter was a second, separate suppressor that only ever saw store-sourced Goals; the v3 one is untouched.

Also worth confirming: with the legacy branch gone the Stop-hook recursion budget is unconditionally `boundedTurns - 1`, which is the arm every non-legacy turn already took.

### Evidence (Before & After)

Non–user-visible refactor: N/A for screenshots. The observable evidence is that the legacy path is unreachable from core and the suites are unchanged in intent:

```
$ git grep -n "goalHook\|activeGoalStore" -- packages/core/src \
    | grep -v "goals/goalHook.ts\|goals/activeGoalStore.ts\|goals/index.ts\|\.test\."
(no matches)

$ cd packages/core && npx vitest run src/core/client-goal.test.ts src/core/client.test.ts src/config/config.test.ts src/goals/goal-legacy-projection.test.ts
 Test Files  4 passed (4)
      Tests  1089 passed (1089)

$ cd packages/core && npx vitest run src/goals src/hooks
 Test Files  43 passed (43)
      Tests  1338 passed (1338)

$ cd packages/core && npx tsc --noEmit -p tsconfig.json
(no output)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, package-local vitest and `tsc --noEmit` for `packages/core`.

## Risk & Scope

- Main risk or tradeoff: this is deletion inside `LlmClient`'s Stop-hook handling, which is dense and shared with non-Goal hooks. The mitigation is that every removed branch was guarded by a legacy-store lookup that can only return `undefined` in a real session, and the tests that covered those branches were removed rather than weakened — nine in `client.test.ts`, two in `client-goal.test.ts`, and one `describe` in `config.test.ts`, each because the mechanism it asserted no longer exists. One test was rewritten instead of deleted (the abort-before-continuation case), because its surviving assertion is about Stop hooks generally rather than about Goals.
- Not validated / out of scope: the legacy modules are still compiled and still tested by their own suites; deleting them, and the CLI call sites that keep them alive, is the next PR. `projectLegacyActiveGoal`, the `active_goal` stream event, `_meta.goalStatus`, `BridgeSessionGoal.active` and the pre-v3 `goal_status` transcript migration are all deliberately untouched.
- Breaking changes / migration notes: `HookExecutionResponse` loses two optional fields, `hasNonGoalBlockingStopHook` and `nonGoalBlockingStopReason`. Nothing in the repository writes them except the code removed here, and nothing reads them at all. No wire format, persisted record, or user-visible behaviour changes.

## Linked Issues

Part of #10795. Part of #4228.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

core 不再让任何 Goal 走第一代 Stop-hook 实现。`LlmClient` 的轮次循环去掉了那条兜底逻辑——每当一个轮次没有带 v3 permit 时，就从内存里的 legacy store 读出一个 Goal——以及这条兜底所喂养的一切：做重复抑制的 `active_goal` 发射器、伸手进 store 的阻塞上限中止逻辑、legacy Goal 曾经享有的递归预算例外，以及那段通过比对 hook id 来判断 Goal 是否在续跑中途被清除的 Stop-hook 续跑重写。hook 执行桥同时去掉了两个响应字段——它们存在的唯一目的就是让那段重写能把 Goal 的阻塞 Stop 输出与别人的区分开。

`ActiveGoal` 接口从 legacy store 模块搬到了 `goal-legacy-projection.ts`，因为它仍然是一个存活的兼容面的形状：headless 的 `active_goal` 流事件，以及承载它的 `ServerLlmActiveGoalEvent`。它与已有的 `LegacyActiveGoal` 并列而不是合并——两者在哪些字段必填上不同，合并会改变一个线协议类型——而 core 的 barrel 继续导出同一个名字。

legacy 模块本身（`goalHook.ts`、`goalJudge.ts`、`activeGoalStore.ts`）未被触及，仍然参与编译。有两处 CLI 调用点让它们保持被引用，所以删除它们需要先做一次 CLI 侧改动；那是本序列的下一个 PR。

## 为什么需要

两代实现已经共存了一段时间，而这份重复正是让 Goal 代码难读的主要原因：读者不追调用图就分不清哪个判定者才是权威。它也不是"两个都活着"的分裂。`registerGoalHook` 在生产代码里唯一的调用者是 `restoreGoalFromHistory`，而后者自己没有任何调用者，所以 legacy store 在真实会话里从不被写入，legacy judge 也从不运行。剩下的只有代价：core 里最热的那个函数中的死分支、两个别处无法使用的响应字段，以及一段解释一种已经不可能发生的递归风险的注释。

移除 core 对这代死代码的使用，也是删除它的前提。在姊妹 PR 落地之前，这些文件仍被 CLI 引用，所以本 PR 刻意把范围收在"不再调用它"而不是"删除它"。

## 评审验证方式

### 如何验证

```
cd packages/core && npx vitest run src/core/client-goal.test.ts src/core/client.test.ts src/config/config.test.ts src/goals/goal-legacy-projection.test.ts
cd packages/core && npx vitest run src/goals src/hooks
cd packages/core && npx tsc --noEmit -p tsconfig.json
```

值得亲自核对而不是照单接受的论断是：没有任何存活的东西被砍掉。有三样必须存活，而它们都还在：`projectActiveGoal` 与 `sameActiveGoalProjection`；把 **v3 快照**转成 `active_goal` 事件的 `takePendingGoalEvents` 投影；以及 `ActiveGoal` 类型本身，仍以原来导出的名字存在。被删掉的那个发射器是第二个、独立的抑制器，它只见过来自 store 的 Goal；v3 那个未被触及。

同样值得确认：legacy 分支移除后，Stop-hook 的递归预算无条件为 `boundedTurns - 1`，而这正是每一个非 legacy 轮次本来就走的那一支。

### 证据（前后对比）

不面向用户的重构：截图部分为 N/A。可观察的证据是 legacy 路径从 core 已不可达，且测试套的意图未变：

```
$ git grep -n "goalHook\|activeGoalStore" -- packages/core/src \
    | grep -v "goals/goalHook.ts\|goals/activeGoalStore.ts\|goals/index.ts\|\.test\."
(no matches)

$ cd packages/core && npx vitest run src/core/client-goal.test.ts src/core/client.test.ts src/config/config.test.ts src/goals/goal-legacy-projection.test.ts
 Test Files  4 passed (4)
      Tests  1089 passed (1089)

$ cd packages/core && npx vitest run src/goals src/hooks
 Test Files  43 passed (43)
      Tests  1338 passed (1338)

$ cd packages/core && npx tsc --noEmit -p tsconfig.json
(no output)
```

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

Linux，`packages/core` 的包内 vitest 与 `tsc --noEmit`。

## 风险与范围

- 主要风险或权衡：这是在 `LlmClient` 的 Stop-hook 处理里做删除，那段代码很密，而且与非 Goal 的 hook 共用。缓解在于：每一个被删掉的分支都由一次 legacy store 查询把门，而这个查询在真实会话里只可能返回 `undefined`；覆盖那些分支的测试是被删除而不是被弱化——`client.test.ts` 里九个、`client-goal.test.ts` 里两个、`config.test.ts` 里一个 `describe`，各自都是因为它断言的机制已不存在。只有一个测试是被改写而不是删除（中止先于续跑那个用例），因为它仍然成立的那条断言讲的是 Stop hook 的通用行为，而不是 Goal。
- 未验证 / 不在范围内：legacy 模块仍在编译，仍由它们自己的测试套覆盖；删除它们以及让它们存活的那些 CLI 调用点，是下一个 PR。`projectLegacyActiveGoal`、`active_goal` 流事件、`_meta.goalStatus`、`BridgeSessionGoal.active` 与 pre-v3 的 `goal_status` transcript 迁移都刻意未动。
- 破坏性变更 / 迁移说明：`HookExecutionResponse` 少了两个可选字段，`hasNonGoalBlockingStopHook` 与 `nonGoalBlockingStopReason`。仓库里除了本次被删掉的代码之外没有任何地方写入它们，也没有任何地方读取它们。线协议格式、持久化记录与用户可见行为均未改变。

## 关联 Issue

Part of #10795. Part of #4228.

</details>
