### PR TITLE
refactor(cli): drop the legacy Goal Stop-hook plumbing

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -599,13 +599,6 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
   applyProviderInstallPlan: vi.fn().mockResolvedValue({
     updatedModelProviders: {},
   }),
-  unregisterGoalHook: vi.fn(),
-  getActiveGoal: vi.fn(),
-  getLastGoalTerminal: vi.fn(),
-  // Reached through the real `ui/utils/restoreGoal.js` on the resume path.
-  registerGoalHook: vi.fn(),
-  setGoalTerminalObserver: vi.fn(),
-  setLastGoalTerminal: vi.fn(),
   uiTelemetryService: {
     removeSession: vi.fn(),
     getMetricsForSession: vi.fn(),
@@ -1076,9 +1069,6 @@ import {
   SessionTranscriptTooLargeError,
   SessionTranscriptPageTooLargeError,
   encodeSessionTranscriptCursor,
-  unregisterGoalHook,
-  getActiveGoal,
-  registerGoalHook,
   findBoundaryAtOrBefore,
   isReplayTurnStartType,
   startEventLoopLagMonitor,
@@ -3644,7 +3634,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           replayHistory: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -4354,7 +4343,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           replayHistory: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
     );
@@ -4560,7 +4548,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           replayHistory: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -4760,7 +4747,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           replayHistory: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           beginClose: vi.fn().mockReturnValue(vi.fn()),
           beginCloseIfAvailable: vi.fn().mockReturnValue(vi.fn()),
@@ -15288,7 +15274,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionGoalGet, params),
       ).rejects.toThrow(/sessionId/i);
     }
-    expect(getActiveGoal).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -15316,7 +15301,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         sessionId: 'not-a-live-session',
       }),
     ).rejects.toThrow();
-    expect(getActiveGoal).not.toHaveBeenCalledWith('not-a-live-session');
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -19526,7 +19510,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         replayHistory: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       } as unknown as InstanceType<typeof Session>;
@@ -21070,7 +21053,6 @@ describe('QwenAgent session-management routing (rename / delete / list / branch 
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           replayHistory: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -22751,7 +22733,6 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
           apiTimeMs: number;
         };
         installRewriter: ReturnType<typeof vi.fn>;
-        installGoalTerminalObserver: ReturnType<typeof vi.fn>;
         installManagedConversationActivation: ReturnType<typeof vi.fn>;
         startCronScheduler: ReturnType<typeof vi.fn>;
         enableLiveScreenContext: ReturnType<typeof vi.fn>;
@@ -23142,7 +23123,6 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
           apiTimeMs: 11,
         },
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         installManagedConversationActivation: vi.fn(
           (activate: () => Promise<void>) => {
             lastManagedConversationActivation = activate;
@@ -24196,44 +24176,6 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       await agentPromise;
     },
   );
-
-  it('leaves canonical Goal recovery to Config initialization', async () => {
-    bindRestoreMocks({
-      sessionExists: true,
-      resumedConversation: {
-        messages: [
-          {
-            uuid: 'goal-state',
-            parentUuid: null,
-            sessionId: 'persisted-1',
-            timestamp: new Date(0).toISOString(),
-            type: 'system',
-            subtype: 'goal_state',
-            cwd: '/tmp',
-            version: '1.0.0',
-            systemPayload: {
-              v: 2,
-              cause: 'create',
-              snapshot: goalSnapshot(),
-            },
-          },
-        ],
-      },
-    });
-    const { agent, agentPromise } = await spawnAgent();
-
-    await agent.loadSession({
-      cwd: '/tmp',
-      sessionId: 'persisted-1',
-      mcpServers: [],
-    });
-
-    expect(registerGoalHook).not.toHaveBeenCalled();
-    expect(unregisterGoalHook).not.toHaveBeenCalled();
-
-    mockConnectionState.resolve();
-    await agentPromise;
-  });
 
   it('loadSession returns LoadSessionResponse and replays history on the session', async () => {
     const messages = [{ role: 'user', parts: [{ text: 'hi' }] }];
@@ -27292,7 +27234,6 @@ describe('sessionLanguage multi-session propagation', () => {
         getConfig: vi.fn().mockReturnValue(cfg),
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       };
@@ -27484,7 +27425,6 @@ describe('sessionLanguage multi-session propagation', () => {
         getConfig: vi.fn().mockReturnValue(cfg),
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       } as unknown as InstanceType<typeof Session>;
@@ -27595,7 +27535,6 @@ describe('sessionLanguage multi-session propagation', () => {
         reloadModelProvidersFromDisk: index === 0 ? reload1 : reload2,
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       } as unknown as InstanceType<typeof Session>;
@@ -27724,7 +27663,6 @@ describe('sessionLanguage multi-session propagation', () => {
           getSessionReasoningSelection,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -27812,7 +27750,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -27917,7 +27854,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust: vi.fn(),
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28031,7 +27967,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust: vi.fn(),
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28138,7 +28073,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust: vi.fn(),
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28236,7 +28170,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28350,7 +28283,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28465,7 +28397,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28585,7 +28516,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28699,7 +28629,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28791,7 +28720,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -28885,7 +28813,6 @@ describe('sessionLanguage multi-session propagation', () => {
         clearTodoStopGuardTrust,
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       } as unknown as InstanceType<typeof Session>;
@@ -29019,7 +28946,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29103,7 +29029,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29184,7 +29109,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29272,7 +29196,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearTodoStopGuardTrust,
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29365,7 +29288,6 @@ describe('sessionLanguage multi-session propagation', () => {
           clearActiveTodoPlanRevision: vi.fn(),
           clearTodoStopGuardTrust: vi.fn(),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29876,7 +29798,6 @@ describe('sessionLanguage multi-session propagation', () => {
           getConfig: vi.fn().mockReturnValue(cfg),
           sendAvailableCommandsUpdate,
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -29954,7 +29875,6 @@ describe('sessionLanguage multi-session propagation', () => {
           getConfig: vi.fn().mockReturnValue(cfg),
           sendAvailableCommandsUpdate,
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,
@@ -30102,7 +30022,6 @@ describe('sessionLanguage multi-session propagation', () => {
         getConfig: vi.fn().mockReturnValue(cfg),
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
       } as unknown as InstanceType<typeof Session>;
@@ -30172,7 +30091,6 @@ describe('sessionLanguage multi-session propagation', () => {
           getConfig: vi.fn().mockReturnValue(cfgA),
           sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
           installRewriter: vi.fn(),
-          installGoalTerminalObserver: vi.fn(),
           startCronScheduler: vi.fn(),
           dispose: vi.fn(),
         }) as unknown as InstanceType<typeof Session>,

--- a/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
@@ -480,7 +480,6 @@ describe('QwenAgent loadSession — Phase C worktree context restore', () => {
         sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
         replayHistory: vi.fn().mockResolvedValue(undefined),
         installRewriter: vi.fn(),
-        installGoalTerminalObserver: vi.fn(),
         startCronScheduler: vi.fn(),
         dispose: vi.fn(),
         pendingWorktreeNotice: null as string | null,

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
@@ -143,6 +143,32 @@ describe('MessageEmitter', () => {
     });
   });
 
+  describe('emitStopHookLoop', () => {
+    it('sends loop metadata and no legacy goal projection', async () => {
+      // Exact equality, not `objectContaining`: the three assertions that
+      // observe this payload through the real emitter in `Session.test.ts` all
+      // match on a subset, so re-attaching the first-generation `goal`
+      // sub-object -- a partial revert, or a badly resolved merge -- would put
+      // a second, stale Goal projection back on the ACP wire beside
+      // `_meta.goalState` and leave the whole suite green. A surplus key fails
+      // this assertion.
+      await emitter.emitStopHookLoop(2, ['first reason', 'second reason'], 3);
+
+      expect(sendUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: '' },
+        _meta: {
+          stopHookLoop: {
+            iterationCount: 2,
+            reasons: ['first reason', 'second reason'],
+            stopHookCount: 3,
+          },
+        },
+      });
+    });
+  });
+
   describe('emitGoalState', () => {
     it('sends canonical state with the legacy projection used by replay', async () => {
       const snapshot: GoalSnapshotV2 = {

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -12,7 +12,6 @@ import {
 } from '@qwen-code/acp-bridge/transcriptReplay';
 import {
   apiActivityTracker,
-  getActiveGoal,
   projectGoalStateToLegacy,
   type GoalRecord,
   type GoalSnapshotV2,
@@ -96,7 +95,6 @@ export class MessageEmitter extends BaseEmitter {
     reasons: string[],
     stopHookCount: number,
   ): Promise<void> {
-    const activeGoal = getActiveGoal(this.sessionId);
     await this.sendUpdate({
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text: '' },
@@ -105,16 +103,6 @@ export class MessageEmitter extends BaseEmitter {
           iterationCount,
           reasons,
           stopHookCount,
-          ...(activeGoal
-            ? {
-                goal: {
-                  condition: activeGoal.condition,
-                  iterations: activeGoal.iterations,
-                  setAt: activeGoal.setAt,
-                  lastReason: activeGoal.lastReason,
-                },
-              }
-            : {}),
         },
       },
     });

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -1316,8 +1316,6 @@ describe('HistoryReplayer', () => {
     it('refuses to replay a goal card whose condition is empty', async () => {
       // A transcript is a file: a corrupted or hand-edited condition would
       // otherwise ride out to every client inside `_meta.goalStatus`.
-      // `restoreGoalFromHistory` refuses the same card, so neither the card nor
-      // the hook survives — they stay consistent.
       await replayer.replay([
         goalRecord({ type: 'goal_status', kind: 'set', condition: '' }),
       ]);

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -10,7 +10,6 @@ import {
   handleSlashCommand,
 } from './nonInteractiveCliCommands.js';
 import {
-  __resetActiveGoalStoreForTests,
   createGoalRuntime,
   type ChatRecord,
   type Config,
@@ -81,7 +80,6 @@ describe('handleSlashCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     uiTelemetryService.reset();
-    __resetActiveGoalStoreForTests();
     const goalRuntime = createGoalRuntime({ journal: createJournal() });
     // getCommandsForMode applies real mode filtering on top of getCommands()
     mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
@@ -135,7 +133,6 @@ describe('handleSlashCommand', () => {
 
   afterEach(() => {
     uiTelemetryService.reset();
-    __resetActiveGoalStoreForTests();
   });
 
   it('should return no_command for non-slash input', async () => {

--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   Config,
   GoalRuntime,
@@ -18,23 +18,6 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { goalCommand, parseGoalCommand } from './goalCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
-
-const mockRegisterGoalHook = vi.hoisted(() => vi.fn());
-const mockGetActiveGoal = vi.hoisted(() => vi.fn());
-const mockGetLastGoalTerminal = vi.hoisted(() => vi.fn());
-const mockUnregisterGoalHook = vi.hoisted(() => vi.fn());
-
-vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
-  return {
-    ...actual,
-    registerGoalHook: mockRegisterGoalHook,
-    getActiveGoal: mockGetActiveGoal,
-    getLastGoalTerminal: mockGetLastGoalTerminal,
-    unregisterGoalHook: mockUnregisterGoalHook,
-  };
-});
 
 function goalSnapshot(
   overrides: Partial<NonNullable<GoalSnapshotV2['goal']>> = {},
@@ -143,13 +126,6 @@ describe('parseGoalCommand', () => {
 });
 
 describe('goalCommand', () => {
-  beforeEach(() => {
-    mockRegisterGoalHook.mockReset();
-    mockGetActiveGoal.mockReset();
-    mockGetLastGoalTerminal.mockReset();
-    mockUnregisterGoalHook.mockReset();
-  });
-
   it('is available in interactive, non-interactive, and ACP modes', () => {
     expect(goalCommand.supportedModes).toEqual([
       'interactive',
@@ -197,7 +173,6 @@ describe('goalCommand', () => {
 
       expect(dispatch).toHaveBeenCalledWith(expectedRequest);
       expect(result).toMatchObject({ type: 'goal_control' });
-      expect(mockRegisterGoalHook).not.toHaveBeenCalled();
     },
   );
 
@@ -242,8 +217,6 @@ describe('goalCommand', () => {
         cause: request.action,
       });
       expect(getGoalRuntimeReady).toHaveBeenCalledTimes(1);
-      expect(mockRegisterGoalHook).not.toHaveBeenCalled();
-      expect(mockUnregisterGoalHook).not.toHaveBeenCalled();
     },
   );
 

--- a/packages/cli/src/ui/hooks/use-llm-stream.test.tsx
+++ b/packages/cli/src/ui/hooks/use-llm-stream.test.tsx
@@ -113,10 +113,6 @@ const mockParseAndFormatApiError = vi.hoisted(() =>
   ),
 );
 const mockLogApiCancel = vi.hoisted(() => vi.fn());
-const mockGetActiveGoal = vi.hoisted(() => vi.fn());
-const mockActiveGoalEquals = vi.hoisted(() => vi.fn());
-const mockSetActiveGoal = vi.hoisted(() => vi.fn());
-const mockClearActiveGoal = vi.hoisted(() => vi.fn());
 const mockRefreshMemoryAfterManagedWrite = vi.hoisted(() => vi.fn());
 const mockRefreshMemoryInstruction = vi.hoisted(() => vi.fn());
 const mockCleanupReviewWorktreeLeases = vi.hoisted(() => vi.fn());
@@ -154,10 +150,6 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     ApiCancelEvent: MockedApiCancelEvent,
     parseAndFormatApiError: mockParseAndFormatApiError,
     logApiCancel: mockLogApiCancel,
-    getActiveGoal: mockGetActiveGoal,
-    activeGoalEquals: mockActiveGoalEquals,
-    setActiveGoal: mockSetActiveGoal,
-    clearActiveGoal: mockClearActiveGoal,
     runVisionBridge: mockRunVisionBridge,
     refreshMemoryAfterManagedWrite: mockRefreshMemoryAfterManagedWrite,
     refreshMemoryInstruction: mockRefreshMemoryInstruction,
@@ -249,8 +241,6 @@ describe('useLlmStream', () => {
     mockGetActiveInteractionSpan.mockReturnValue(mockInteractionSpan);
     mockRefreshMemoryAfterManagedWrite.mockResolvedValue(false);
     mockRefreshMemoryInstruction.mockResolvedValue(undefined);
-    mockGetActiveGoal.mockReturnValue(undefined);
-    mockActiveGoalEquals.mockReturnValue(false);
     vi.mocked(findLastSafeSplitPoint).mockImplementation(
       (s: string) => s.length,
     );
@@ -7279,18 +7269,6 @@ describe('useLlmStream', () => {
   });
 
   it('drops a queued replacement prompt when a later goal command clears it', async () => {
-    const activeGoal = {
-      condition: 'first',
-      iterations: 0,
-      setAt: 123,
-      tokensAtStart: 0,
-      hookId: 'first-goal-hook',
-    };
-    mockGetActiveGoal
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(activeGoal)
-      .mockReturnValueOnce(activeGoal)
-      .mockReturnValueOnce(undefined);
     mockHandleSlashCommand
       .mockResolvedValueOnce({
         type: 'submit_prompt',
@@ -19845,55 +19823,16 @@ describe('useLlmStream', () => {
           };
         })(),
       );
-      mockGetActiveGoal
-        .mockReturnValueOnce(undefined)
-        .mockReturnValueOnce(activeGoal);
-      mockActiveGoalEquals.mockReturnValue(false);
-
       const { result } = renderTestHook();
 
       await act(async () => {
         await result.current.submitQuery('continue goal');
       });
 
-      expect(mockSetActiveGoal).not.toHaveBeenCalled();
-      expect(mockClearActiveGoal).not.toHaveBeenCalled();
-    });
-
-    it('skips redundant active_goal store updates', async () => {
-      const activeGoal = {
-        condition: 'finish the refactor',
-        iterations: 1,
-        setAt: 123,
-        tokensAtStart: 456,
-        hookId: 'goal-hook-id',
-        lastReason: 'still missing verification',
-      };
-      mockSendMessageStream.mockReturnValue(
-        (async function* () {
-          yield {
-            type: ServerLlmEventType.ActiveGoal,
-            value: activeGoal,
-          };
-          yield {
-            type: ServerLlmEventType.ActiveGoal,
-            value: null,
-          };
-        })(),
+      expect(mockAddItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'goal_status' }),
+        expect.any(Number),
       );
-      mockGetActiveGoal
-        .mockReturnValueOnce(activeGoal)
-        .mockReturnValueOnce(undefined);
-      mockActiveGoalEquals.mockReturnValue(true);
-
-      const { result } = renderTestHook();
-
-      await act(async () => {
-        await result.current.submitQuery('continue goal');
-      });
-
-      expect(mockSetActiveGoal).not.toHaveBeenCalled();
-      expect(mockClearActiveGoal).not.toHaveBeenCalled();
     });
 
     it('should handle StopHookLoop event and add stop hook loop history item', async () => {
@@ -19943,14 +19882,6 @@ describe('useLlmStream', () => {
       const recordSlashCommand = vi.fn();
       mockConfig.getChatRecordingService = vi.fn().mockReturnValue({
         recordSlashCommand,
-      });
-      mockGetActiveGoal.mockReturnValue({
-        condition: 'finish the refactor',
-        iterations: 7,
-        setAt: 100,
-        tokensAtStart: 0,
-        hookId: 'goal-hook',
-        lastReason: 'not enough evidence yet',
       });
       mockSendMessageStream.mockReturnValue(
         (async function* () {

--- a/packages/cli/src/ui/utils/restoreGoal.test.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.test.ts
@@ -4,28 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MockInstance } from 'vitest';
-import {
-  __resetActiveGoalStoreForTests,
-  getActiveGoal,
-  getLastGoalTerminal,
-  notifyGoalTerminal,
-  setActiveGoal,
-  setGoalTerminalObserver,
-  type ChatRecord,
-  type Config,
-} from '@qwen-code/qwen-code-core';
+import { describe, expect, it } from 'vitest';
+import type { ChatRecord } from '@qwen-code/qwen-code-core';
 import type { HistoryItem } from '../types.js';
 import {
   collectGoalStatusItemsFromRecords,
   findGoalToRestore,
-  findLastTerminalGoal,
-  goalTerminalEventToHistoryItem,
   parseGoalStatusItem,
-  recordGoalStatusItem,
-  restoreGoalFromHistory,
-  type GoalStatusItem,
 } from './restoreGoal.js';
 
 const goalItem = (
@@ -41,18 +26,6 @@ const goalItem = (
 
 const userItem = (text = 'hi'): HistoryItem =>
   ({ id: 2, type: 'user', text }) as HistoryItem;
-
-const makeConfig = (overrides: Partial<Config> = {}): Config =>
-  ({
-    getSessionId: vi.fn().mockReturnValue('sess-1'),
-    isTrustedFolder: vi.fn().mockReturnValue(true),
-    getDisableAllHooks: vi.fn().mockReturnValue(false),
-    getHookSystem: vi.fn().mockReturnValue({
-      addFunctionHook: vi.fn().mockReturnValue('hook-1'),
-      removeFunctionHook: vi.fn().mockReturnValue(true),
-    }),
-    ...overrides,
-  }) as unknown as Config;
 
 describe('findGoalToRestore', () => {
   it('returns null on empty history', () => {
@@ -124,244 +97,6 @@ describe('findGoalToRestore', () => {
         goalItem({ kind: 'failed', condition: 'do x' }),
       ]),
     ).toBeNull();
-  });
-});
-
-describe('restoreGoalFromHistory', () => {
-  beforeEach(() => __resetActiveGoalStoreForTests());
-  afterEach(() => __resetActiveGoalStoreForTests());
-
-  it('restores an active goal and re-registers the hook', () => {
-    const cfg = makeConfig();
-    const result = restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'write hello' })],
-      cfg,
-    );
-    expect(result).toEqual({ restored: true, condition: 'write hello' });
-    expect(getActiveGoal('sess-1')).toMatchObject({ condition: 'write hello' });
-  });
-
-  it('resumes the iteration count so the MAX cap is not reset on resume', () => {
-    const cfg = makeConfig();
-    const result = restoreGoalFromHistory(
-      [
-        goalItem({ kind: 'set', condition: 'write hello' }),
-        userItem(),
-        goalItem({ kind: 'checking', condition: 'write hello', iterations: 7 }),
-      ],
-      cfg,
-    );
-    expect(result).toEqual({ restored: true, condition: 'write hello' });
-    expect(getActiveGoal('sess-1')).toMatchObject({
-      condition: 'write hello',
-      iterations: 7,
-    });
-  });
-
-  it('does nothing when no goal_status item exists', () => {
-    const cfg = makeConfig();
-    const result = restoreGoalFromHistory([userItem()], cfg);
-    expect(result).toEqual({ restored: false });
-    expect(getActiveGoal('sess-1')).toBeUndefined();
-  });
-
-  it('skips restore when workspace is no longer trusted and clears stale in-memory goal', () => {
-    setActiveGoal('sess-1', {
-      condition: 'stale goal',
-      iterations: 0,
-      setAt: 100,
-      tokensAtStart: 0,
-      hookId: 'stale-hook',
-    });
-    const cfg = makeConfig({
-      isTrustedFolder: vi.fn().mockReturnValue(false),
-    } as unknown as Partial<Config>);
-    const result = restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'do x' })],
-      cfg,
-    );
-    expect(result).toEqual({
-      restored: false,
-      blockedBy: 'untrusted-folder',
-    });
-    expect(getActiveGoal('sess-1')).toBeUndefined();
-  });
-
-  it('skips restore when hooks are disabled by policy', () => {
-    const cfg = makeConfig({
-      getDisableAllHooks: vi.fn().mockReturnValue(true),
-    } as unknown as Partial<Config>);
-    const result = restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'do x' })],
-      cfg,
-    );
-    expect(result).toEqual({ restored: false, blockedBy: 'hooks-disabled' });
-  });
-
-  it('skips restore when hook system is unavailable', () => {
-    const cfg = makeConfig({
-      getHookSystem: vi.fn().mockReturnValue(undefined),
-    } as unknown as Partial<Config>);
-    const result = restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'do x' })],
-      cfg,
-    );
-    expect(result).toEqual({ restored: false, blockedBy: 'no-hook-system' });
-  });
-
-  it('rehydrates the last completed goal cache from history on resume', () => {
-    const cfg = makeConfig();
-    restoreGoalFromHistory(
-      [
-        goalItem({ kind: 'set', condition: 'goal A' }),
-        goalItem({
-          kind: 'achieved',
-          condition: 'goal A',
-          iterations: 4,
-          durationMs: 30_000,
-          lastReason: 'evidence in transcript',
-        }),
-      ],
-      cfg,
-    );
-    expect(getLastGoalTerminal('sess-1')).toMatchObject({
-      kind: 'achieved',
-      condition: 'goal A',
-      iterations: 4,
-      durationMs: 30_000,
-      lastReason: 'evidence in transcript',
-    });
-  });
-
-  it('restores the terminal observer when an active goal is restored', () => {
-    const recordSlashCommand = vi.fn();
-    const cfg = makeConfig({
-      getChatRecordingService: vi.fn().mockReturnValue({ recordSlashCommand }),
-    } as unknown as Partial<Config>);
-    const addItem = vi.fn();
-
-    const result = restoreGoalFromHistory(
-      [goalItem({ kind: 'checking', condition: 'do x' })],
-      cfg,
-      addItem,
-    );
-
-    expect(result).toEqual({ restored: true, condition: 'do x' });
-
-    notifyGoalTerminal('sess-1', {
-      kind: 'achieved',
-      condition: 'do x',
-      iterations: 2,
-      durationMs: 12_000,
-      lastReason: 'done',
-    });
-
-    expect(addItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'goal_status',
-        kind: 'achieved',
-        condition: 'do x',
-        iterations: 2,
-        durationMs: 12_000,
-        lastReason: 'done',
-      }),
-      expect.any(Number),
-    );
-    expect(recordSlashCommand).toHaveBeenCalledWith({
-      phase: 'result',
-      rawCommand: '/goal',
-      outputHistoryItems: [
-        expect.objectContaining({
-          type: 'goal_status',
-          kind: 'achieved',
-          condition: 'do x',
-          iterations: 2,
-          durationMs: 12_000,
-          lastReason: 'done',
-        }),
-      ],
-    });
-  });
-
-  it.each([
-    ['an active goal is restored', 'checking' as const],
-    ['there is no goal to restore', 'achieved' as const],
-  ])(
-    'tears down an existing terminal observer when %s and no addItem is given',
-    (_label, kind) => {
-      // The ACP path calls restore without `addItem` and relies on this: every
-      // exit re-enters `unregisterGoalHook`, which clears the observer table.
-      // `acpAgent.#restoreGoalOnResume` reinstalls the Session's observer
-      // afterwards. If that ever stops being true, a restored goal reaches its
-      // terminal state with nobody listening — this pins the reason why.
-      const observer = vi.fn();
-      setGoalTerminalObserver('sess-1', observer);
-
-      restoreGoalFromHistory(
-        [goalItem({ kind, condition: 'do x' })],
-        makeConfig(),
-      );
-
-      notifyGoalTerminal('sess-1', {
-        kind: 'achieved',
-        condition: 'do x',
-        iterations: 1,
-        durationMs: 10,
-      });
-      expect(observer).not.toHaveBeenCalled();
-    },
-  );
-});
-
-describe('findLastTerminalGoal', () => {
-  it('returns null when transcript has no terminal goal_status', () => {
-    expect(findLastTerminalGoal([])).toBeNull();
-    expect(
-      findLastTerminalGoal([
-        goalItem({ kind: 'set', condition: 'x' }),
-        userItem(),
-      ]),
-    ).toBeNull();
-  });
-
-  it('returns the most recent achieved, skipping `set` and `cleared`', () => {
-    // Aligned with Claude Code's `yjK`: sentinel-style entries (set / cleared)
-    // are skipped, so a trailing `cleared` does NOT dismiss an earlier
-    // achievement — subsequent empty `/goal` still surfaces it.
-    const result = findLastTerminalGoal([
-      goalItem({ kind: 'set', condition: 'goal A' }),
-      goalItem({ kind: 'achieved', condition: 'goal A', iterations: 2 }),
-      goalItem({ kind: 'set', condition: 'goal B' }),
-      goalItem({ kind: 'cleared', condition: 'goal B' }),
-    ]);
-    expect(result).toMatchObject({ kind: 'achieved', condition: 'goal A' });
-  });
-
-  it('returns aborted when it is the most recent terminal', () => {
-    const result = findLastTerminalGoal([
-      goalItem({ kind: 'achieved', condition: 'goal A' }),
-      goalItem({ kind: 'set', condition: 'goal B' }),
-      goalItem({ kind: 'aborted', condition: 'goal B' }),
-    ]);
-    expect(result?.kind).toBe('aborted');
-    expect(result?.condition).toBe('goal B');
-  });
-
-  it('returns failed when it is the most recent terminal', () => {
-    const result = findLastTerminalGoal([
-      goalItem({ kind: 'achieved', condition: 'goal A' }),
-      goalItem({ kind: 'set', condition: 'goal B' }),
-      goalItem({
-        kind: 'failed',
-        condition: 'goal B',
-        lastReason: 'external service unavailable',
-      }),
-    ]);
-    expect(result).toMatchObject({
-      kind: 'failed',
-      condition: 'goal B',
-      lastReason: 'external service unavailable',
-    });
   });
 });
 
@@ -530,92 +265,23 @@ describe('collectGoalStatusItemsFromRecords', () => {
       ]),
     ]);
     expect(findGoalToRestore(items)).toBeNull();
-    expect(findLastTerminalGoal(items)).toMatchObject({
-      kind: 'achieved',
-      condition: 'goal A',
-    });
   });
 });
 
-describe('restoreGoalFromHistory has no condition cap', () => {
-  beforeEach(() => __resetActiveGoalStoreForTests());
-  afterEach(() => __resetActiveGoalStoreForTests());
-
-  it('restores a condition far longer than the old 4,000-char cap', () => {
+describe('findGoalToRestore has no condition cap', () => {
+  it('returns a condition far longer than the old 4,000-char cap', () => {
     // `/goal` accepts a condition of any length (#6665). A cap here would
     // refuse, on reload, a goal the user legitimately set — and the replay
     // drops the card too, so they would never see why it vanished.
-    const cfg = makeConfig();
     const condition = 'x'.repeat(10_000);
-    expect(restoreGoalFromHistory([goalItem({ condition })], cfg)).toEqual({
-      restored: true,
+    expect(findGoalToRestore([goalItem({ condition })])).toEqual({
       condition,
-    });
-    expect(getActiveGoal('sess-1')).toMatchObject({ condition });
-  });
-
-  it('drops a stale in-memory goal when the transcript condition is empty', () => {
-    setActiveGoal('sess-1', {
-      condition: 'stale goal',
       iterations: 0,
-      setAt: 100,
-      tokensAtStart: 0,
-      hookId: 'stale-hook',
     });
-    const cfg = makeConfig();
-    restoreGoalFromHistory([goalItem({ condition: '' })], cfg);
-    expect(getActiveGoal('sess-1')).toBeUndefined();
-  });
-});
-
-describe('goalTerminalEventToHistoryItem', () => {
-  it('keeps lastReason when the judge produced one', () => {
-    expect(
-      goalTerminalEventToHistoryItem({
-        kind: 'achieved',
-        condition: 'ship it',
-        iterations: 2,
-        durationMs: 900,
-        lastReason: 'tests pass',
-      }),
-    ).toMatchObject({ kind: 'achieved', lastReason: 'tests pass' });
-  });
-
-  it('falls back to systemMessage when the judge never ran', () => {
-    // `aborted` events carry the cap message in systemMessage, not lastReason.
-    expect(
-      goalTerminalEventToHistoryItem({
-        kind: 'aborted',
-        condition: 'ship it',
-        iterations: 50,
-        durationMs: 900,
-        systemMessage: 'Goal max iterations reached; cleared.',
-      }),
-    ).toMatchObject({
-      kind: 'aborted',
-      lastReason: 'Goal max iterations reached; cleared.',
-    });
-  });
-
-  it('prefers lastReason over systemMessage when both are present', () => {
-    // Known lossy collapse: HistoryItemGoalStatus has no systemMessage field.
-    expect(
-      goalTerminalEventToHistoryItem({
-        kind: 'aborted',
-        condition: 'ship it',
-        iterations: 50,
-        durationMs: 900,
-        lastReason: 'two tests still fail',
-        systemMessage: 'Goal max iterations reached; cleared.',
-      }).lastReason,
-    ).toBe('two tests still fail');
   });
 });
 
 describe('parseGoalStatusItem keeps refusable cards so ordering survives', () => {
-  beforeEach(() => __resetActiveGoalStoreForTests());
-  afterEach(() => __resetActiveGoalStoreForTests());
-
   it('parses a card whose condition is empty rather than dropping it', () => {
     // Rejecting at parse time looks like a tidy shared gate, but the scanners
     // below decide on the LAST goal card. Dropping one silently promotes the
@@ -643,10 +309,6 @@ describe('parseGoalStatusItem keeps refusable cards so ordering survives', () =>
     ]);
 
     expect(findGoalToRestore(items)).toBeNull();
-    expect(restoreGoalFromHistory(items, makeConfig())).toEqual({
-      restored: false,
-    });
-    expect(getActiveGoal('sess-1')).toBeUndefined();
   });
 
   it('fails closed on an empty set card instead of restoring an older goal', () => {
@@ -657,14 +319,9 @@ describe('parseGoalStatusItem keeps refusable cards so ordering survives', () =>
       slashCommandRecord([{ type: 'goal_status', kind: 'set', condition: '' }]),
     ]);
 
-    // The newest card wins the scan, and the empty gate then refuses it. Goal
-    // A must NOT come back to life.
+    // The newest card wins the scan, so goal A must NOT come back to life;
+    // the empty condition is reported as-is for the caller to refuse.
     expect(findGoalToRestore(items)?.condition).toBe('');
-    expect(restoreGoalFromHistory(items, makeConfig())).toEqual({
-      restored: false,
-      blockedBy: 'condition-invalid',
-    });
-    expect(getActiveGoal('sess-1')).toBeUndefined();
   });
 });
 
@@ -716,53 +373,36 @@ describe('transcript payloads are untrusted', () => {
   });
 });
 
-describe('restoreGoalFromHistory carries the original start time', () => {
-  beforeEach(() => __resetActiveGoalStoreForTests());
-  afterEach(() => __resetActiveGoalStoreForTests());
-
-  it('restores setAt from the set card rather than restarting the clock', () => {
-    const cfg = makeConfig();
-    restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'do x', setAt: 1000 })],
-      cfg,
-    );
-    expect(getActiveGoal('sess-1')).toMatchObject({ setAt: 1000 });
+describe('findGoalToRestore carries the original start time', () => {
+  it('reads setAt off the set card rather than restarting the clock', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'set', condition: 'do x', setAt: 1000 }),
+      ]),
+    ).toMatchObject({ setAt: 1000 });
   });
 
   it('finds setAt on the set card when the newest card is a checking card', () => {
     // `checking` cards written before this change carry no setAt at all, so the
     // scan has to walk back to the `set` card that opened the run.
-    const cfg = makeConfig();
-    restoreGoalFromHistory(
-      [
+    expect(
+      findGoalToRestore([
         goalItem({ kind: 'set', condition: 'do x', setAt: 1000 }),
         userItem(),
         goalItem({ kind: 'checking', condition: 'do x', iterations: 3 }),
-      ],
-      cfg,
-    );
-    expect(getActiveGoal('sess-1')).toMatchObject({
-      setAt: 1000,
-      iterations: 3,
-    });
+      ]),
+    ).toEqual({ condition: 'do x', iterations: 3, setAt: 1000 });
   });
 
   it('does not borrow setAt from a previous, already-finished goal', () => {
-    const cfg = makeConfig();
-    const now = Date.now();
-    restoreGoalFromHistory(
-      [
-        goalItem({ kind: 'set', condition: 'goal A', setAt: 1000 }),
-        goalItem({ kind: 'achieved', condition: 'goal A', durationMs: 5 }),
-        // Goal B's own `set` card is gone (truncated transcript).
-        goalItem({ kind: 'checking', condition: 'goal B', iterations: 1 }),
-      ],
-      cfg,
-    );
-    const goal = getActiveGoal('sess-1');
-    expect(goal).toMatchObject({ condition: 'goal B' });
-    expect(goal!.setAt).not.toBe(1000);
-    expect(goal!.setAt).toBeGreaterThanOrEqual(now);
+    const goal = findGoalToRestore([
+      goalItem({ kind: 'set', condition: 'goal A', setAt: 1000 }),
+      goalItem({ kind: 'achieved', condition: 'goal A', durationMs: 5 }),
+      // Goal B's own `set` card is gone (truncated transcript).
+      goalItem({ kind: 'checking', condition: 'goal B', iterations: 1 }),
+    ]);
+    expect(goal).toEqual({ condition: 'goal B', iterations: 1 });
+    expect(goal).not.toHaveProperty('setAt');
   });
 
   it('does not borrow setAt from a previous goal that has no terminal card', () => {
@@ -770,92 +410,15 @@ describe('restoreGoalFromHistory carries the original start time', () => {
     // truncated or hand-edited transcript can put two goals back to back. The
     // condition is what identifies the run, so goal B must not inherit goal A's
     // clock just because nothing separates them.
-    const cfg = makeConfig();
-    const now = Date.now();
-    restoreGoalFromHistory(
-      [
-        goalItem({ kind: 'set', condition: 'goal A', setAt: 1000 }),
-        goalItem({ kind: 'checking', condition: 'goal A', iterations: 2 }),
-        // Goal B's own `set` card survived but lost its setAt, and no terminal
-        // card was ever written for goal A.
-        goalItem({ kind: 'set', condition: 'goal B' }),
-        goalItem({ kind: 'checking', condition: 'goal B', iterations: 1 }),
-      ],
-      cfg,
-    );
-    const goal = getActiveGoal('sess-1');
-    expect(goal).toMatchObject({ condition: 'goal B' });
-    expect(goal!.setAt).not.toBe(1000);
-    expect(goal!.setAt).toBeGreaterThanOrEqual(now);
-  });
-
-  it('ignores a non-positive setAt from a corrupted transcript', () => {
-    const cfg = makeConfig();
-    const now = Date.now();
-    restoreGoalFromHistory(
-      [goalItem({ kind: 'set', condition: 'do x', setAt: 0 })],
-      cfg,
-    );
-    expect(getActiveGoal('sess-1')!.setAt).toBeGreaterThanOrEqual(now);
-  });
-});
-
-describe('restoreGoalFromHistory refuses an empty condition', () => {
-  beforeEach(() => __resetActiveGoalStoreForTests());
-  afterEach(() => __resetActiveGoalStoreForTests());
-
-  it('does not register a hook for a blank condition', () => {
-    // `/goal` never sets one — a bare `/goal` reports status. Only a corrupted
-    // transcript gets here, and a blank condition makes every judge call ask
-    // the model to check nothing.
-    const cfg = makeConfig();
-    expect(
-      restoreGoalFromHistory([goalItem({ kind: 'set', condition: '' })], cfg),
-    ).toEqual({ restored: false, blockedBy: 'condition-invalid' });
-    expect(getActiveGoal('sess-1')).toBeUndefined();
-  });
-});
-
-describe('recordGoalStatusItem', () => {
-  let stderr: MockInstance<typeof process.stderr.write>;
-  beforeEach(() => {
-    stderr = vi
-      .spyOn(process.stderr, 'write')
-      .mockReturnValue(true) as MockInstance<typeof process.stderr.write>;
-  });
-  afterEach(() => stderr.mockRestore());
-
-  const item = {
-    type: 'goal_status',
-    kind: 'set',
-    condition: 'do x',
-  } as GoalStatusItem;
-
-  it('warns when there is no chat recording service to persist the card', () => {
-    // Optional chaining used to swallow this: the goal then works for the rest
-    // of the session and silently fails to come back on resume.
-    recordGoalStatusItem(
-      makeConfig({
-        getChatRecordingService: vi.fn().mockReturnValue(undefined),
-      } as unknown as Partial<Config>),
-      item,
-    );
-    expect(stderr).toHaveBeenCalledWith(
-      expect.stringContaining('no chat recording service'),
-    );
-  });
-
-  it('warns but does not throw when the recording write fails', () => {
-    const cfg = makeConfig({
-      getChatRecordingService: vi.fn().mockReturnValue({
-        recordSlashCommand: vi.fn().mockImplementation(() => {
-          throw new Error('disk full');
-        }),
-      }),
-    } as unknown as Partial<Config>);
-    expect(() => recordGoalStatusItem(cfg, item)).not.toThrow();
-    expect(stderr).toHaveBeenCalledWith(
-      expect.stringContaining('failed to record goal_status'),
-    );
+    const goal = findGoalToRestore([
+      goalItem({ kind: 'set', condition: 'goal A', setAt: 1000 }),
+      goalItem({ kind: 'checking', condition: 'goal A', iterations: 2 }),
+      // Goal B's own `set` card survived but lost its setAt, and no terminal
+      // card was ever written for goal A.
+      goalItem({ kind: 'set', condition: 'goal B' }),
+      goalItem({ kind: 'checking', condition: 'goal B', iterations: 1 }),
+    ]);
+    expect(goal).toEqual({ condition: 'goal B', iterations: 1 });
+    expect(goal).not.toHaveProperty('setAt');
   });
 });

--- a/packages/cli/src/ui/utils/restoreGoal.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.ts
@@ -4,25 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  registerGoalHook,
-  setGoalTerminalObserver,
-  setLastGoalTerminal,
-  unregisterGoalHook,
-  type Config,
-  type GoalRecoveryRecord,
-  type GoalTerminalEvent,
-  type GoalTerminalKind,
-  type SlashCommandRecordPayload,
+import type {
+  GoalRecoveryRecord,
+  SlashCommandRecordPayload,
 } from '@qwen-code/qwen-code-core';
 import {
   isGoalStatusKind,
-  isTerminalGoalStatusKind,
   MessageType,
   type HistoryItemGoalStatus,
   type HistoryItemWithoutId,
 } from '../types.js';
-import { writeStderrLineSafe } from '../../utils/stdioHelpers.js';
 
 export interface RestorableGoal {
   condition: string;
@@ -93,35 +84,7 @@ function findSetAtOfRun(
   return undefined;
 }
 
-/**
- * Finds the most recent terminal (achieved / failed / aborted) goal_status item in
- * the transcript. Sentinel-style entries (`set`, `cleared`, `checking`) are
- * SKIPPED — `/goal clear` after an achievement is intentionally a no-op on
- * this scan, matching Claude Code's `yjK` behavior (`if (!K.met || K.sentinel)
- * continue;`). Used on resume to repopulate the in-memory "last completed
- * goal" cache so empty `/goal` after a reload still shows the summary card.
- */
-export function findLastTerminalGoal(
-  history: readonly HistoryItemWithoutId[],
-): GoalTerminalEvent | null {
-  for (let i = history.length - 1; i >= 0; i--) {
-    const item = history[i];
-    if (item?.type !== MessageType.GOAL_STATUS) continue;
-    const goal = item as HistoryItemGoalStatus;
-    if (!isTerminalGoalStatusKind(goal.kind)) continue;
-    return {
-      kind: goal.kind as GoalTerminalKind,
-      condition: goal.condition,
-      iterations: goal.iterations ?? 0,
-      durationMs: goal.durationMs ?? 0,
-      lastReason: goal.lastReason,
-    };
-  }
-  return null;
-}
-
 export type GoalStatusItem = Omit<HistoryItemGoalStatus, 'id'>;
-type AddGoalStatusItem = (item: GoalStatusItem, timestamp: number) => void;
 
 function finiteNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
@@ -175,7 +138,7 @@ export function parseGoalStatusItem(item: unknown): GoalStatusItem | null {
  * Extracts the goal cards a transcript persisted inside its `system` /
  * `slash_command` records, oldest first. This is the daemon-side counterpart to
  * the TUI's in-memory `HistoryItem[]`: on the ACP path no `HistoryItem[]` ever
- * exists, so `findGoalToRestore` / `findLastTerminalGoal` are fed from here.
+ * exists, so `findGoalToRestore` is fed from here.
  */
 export function collectGoalStatusItemsFromRecords(
   records: readonly GoalRecoveryRecord[],
@@ -201,187 +164,4 @@ export function collectGoalStatusItemsFromRecords(
     }
   }
   return items;
-}
-
-export function goalTerminalEventToHistoryItem(
-  event: GoalTerminalEvent,
-): GoalStatusItem {
-  return {
-    type: MessageType.GOAL_STATUS,
-    kind: event.kind,
-    condition: event.condition,
-    iterations: event.iterations,
-    durationMs: event.durationMs,
-    lastReason: event.lastReason ?? event.systemMessage,
-  };
-}
-
-export function recordGoalStatusItem(
-  config: Config,
-  item: GoalStatusItem,
-  rawCommand = '/goal',
-): void {
-  try {
-    const recording = config.getChatRecordingService?.();
-    if (!recording) {
-      // Optional chaining used to swallow this. A goal set without a recording
-      // service works for the rest of the session and then vanishes on resume,
-      // which is indistinguishable from the restore bug this module fixes.
-      writeStderrLineSafe(
-        `qwen: no chat recording service; goal_status (kind=${item.kind}) will not survive a resume.`,
-      );
-      return;
-    }
-    recording.recordSlashCommand({
-      phase: 'result',
-      rawCommand,
-      outputHistoryItems: [{ ...item } as Record<string, unknown>],
-    });
-  } catch (error) {
-    // Recording is best-effort; the live goal loop must not fail because the
-    // session transcript could not be appended. But swallowing it silently is
-    // how a goal ends up unrecoverable on resume — the failure mode this
-    // recording exists to prevent — so leave a trace.
-    // Not debugLogger: that no-ops unless a debug session is active, and a
-    // lost write here is invisible until the goal fails to survive a resume.
-    writeStderrLineSafe(
-      `qwen: failed to record goal_status (kind=${item.kind}): ${error}`,
-    );
-  }
-}
-
-export function installGoalTerminalObserver(args: {
-  sessionId: string;
-  config: Config;
-  addItem: AddGoalStatusItem;
-}): void {
-  const { sessionId, config, addItem } = args;
-  setGoalTerminalObserver(sessionId, (event: GoalTerminalEvent) => {
-    const item = goalTerminalEventToHistoryItem(event);
-    addItem(item, Date.now());
-    recordGoalStatusItem(config, item);
-  });
-}
-
-/**
- * Why a transcript's active goal could not be put back under a live Stop hook.
- * `condition-invalid` covers a transcript that no longer describes a goal
- * `/goal` itself would accept.
- */
-export type GoalRestoreBlockedReason =
-  | 'untrusted-folder'
-  | 'hooks-disabled'
-  | 'no-hook-system'
-  | 'condition-invalid';
-
-/**
- * The environment half of `/goal`'s gates, as a pure function of `config`.
- *
- * Split out so the history replay can ask the question *before* restore runs:
- * a client derives "there is an active goal" from the newest replayed goal
- * card, so a card that is about to be refused must not be replayed as active.
- */
-export function goalRestoreBlockedBy(
-  config: Config,
-): Exclude<GoalRestoreBlockedReason, 'condition-invalid'> | null {
-  if (!config.isTrustedFolder()) return 'untrusted-folder';
-  if (config.getDisableAllHooks()) return 'hooks-disabled';
-  if (!config.getHookSystem()) return 'no-hook-system';
-  return null;
-}
-
-/**
- * Mirrors the gates `/goal` applies to a condition at set time.
- *
- * There is deliberately no length cap: #6665 removed the one `/goal` had, so
- * capping here would silently destroy a long goal the user legitimately set —
- * refused on restore, and dropped from the replay so they never see why.
- */
-export function goalConditionBlockedBy(
-  condition: string,
-): 'condition-invalid' | null {
-  if (condition.length === 0) return 'condition-invalid';
-  return null;
-}
-
-export type RestoreGoalResult =
-  | { restored: true; condition: string }
-  | { restored: false; blockedBy?: GoalRestoreBlockedReason };
-
-/**
- * On session resume, restores the active /goal hook if the transcript ended
- * with an unsatisfied goal. Idempotent — safe to call on a fresh session.
- *
- * Re-runs the same trust/policy/length gates as `/goal`; if a gate now fails,
- * we skip restoration rather than re-register a goal the user can no longer
- * cancel. That case reports `blockedBy`, which callers must not confuse with
- * "the transcript had no goal": the transcript still shows one as active, so
- * something has to say otherwise.
- *
- * Note that every `{ restored: false }` path unregisters, which clears the
- * session's goal-terminal observer as a side effect. ACP callers reinstall it.
- */
-export function restoreGoalFromHistory(
-  history: readonly HistoryItemWithoutId[],
-  config: Config,
-  addItem?: AddGoalStatusItem,
-): RestoreGoalResult {
-  const sessionId = config.getSessionId();
-  // Always rehydrate the "last completed goal" cache from transcript so empty
-  // `/goal` after resume can render the most recent achievement summary.
-  // Independent of whether an active goal is being restored: a session may
-  // have completed Goal A, started Goal B (still active), or completed
-  // multiple goals — only the latest terminal one is surfaced.
-  const lastTerminal = findLastTerminalGoal(history);
-  setLastGoalTerminal(sessionId, lastTerminal ?? undefined);
-
-  const restorable = findGoalToRestore(history);
-
-  if (restorable === null) {
-    unregisterGoalHook(config, sessionId);
-    return { restored: false };
-  }
-
-  const blockedBy = goalRestoreBlockedBy(config);
-  if (blockedBy) {
-    unregisterGoalHook(config, sessionId);
-    return { restored: false, blockedBy };
-  }
-  // `/goal` gates the condition at set time, but a transcript is a file: a
-  // corrupted or hand-edited `condition` would otherwise be re-registered —
-  // empty and meaningless — and then embedded verbatim in every judge call and
-  // continuation prompt for the rest of the session.
-  //
-  // This is the only blocked path that reports itself. The env gates above stay
-  // silent because their caller knows the policy and says so; a malformed
-  // condition is known only here, and three of the four callers (the TUI ones)
-  // discard the result entirely, so saying nothing would lose it completely.
-  // ACP's `#restoreGoalOnResume` skips its own line for this reason, so exactly
-  // one line is written either way.
-  if (goalConditionBlockedBy(restorable.condition)) {
-    writeStderrLineSafe(
-      `qwen: refusing to restore a goal for session ${sessionId}: the condition is empty.`,
-    );
-    unregisterGoalHook(config, sessionId);
-    return { restored: false, blockedBy: 'condition-invalid' };
-  }
-
-  registerGoalHook({
-    config,
-    sessionId,
-    condition: restorable.condition,
-    tokensAtStart: 0,
-    // Resume the iteration count so MAX_GOAL_ITERATIONS is a cross-resume cap,
-    // not a per-resume one.
-    initialIterations: restorable.iterations,
-    // Likewise the start time: without it every reload restarts the clock, and
-    // `GET /goals` reports a long-running goal as freshly started.
-    ...(restorable.setAt !== undefined
-      ? { initialSetAt: restorable.setAt }
-      : {}),
-  });
-  if (addItem) {
-    installGoalTerminalObserver({ sessionId, config, addItem });
-  }
-  return { restored: true, condition: restorable.condition };
 }

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
@@ -5297,8 +5297,12 @@ function normalizeGoalStatusEvent(event: DaemonEvent): DaemonUiEvent | null {
 
   // Per-iteration "checking" events are deliberately not turned into
   // transcript cards: one card per stop-hook turn floods the transcript, and
-  // the active goal state is already visible in the status bar. Only terminal
-  // events and the initial "set" event above become cards.
+  // the active goal state is already visible in the status bar. Which kinds do
+  // become cards is decided by `normalizeGoalStatus` below, not here -- it
+  // admits `paused`, `cleared` and `usage_limited` as well as the terminal
+  // kinds, and dropping any of them regresses the bug recorded beside its
+  // `paused` entry. This return is only the fallthrough for an event that
+  // carried neither a status nor a terminal.
   return null;
 }
 

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
@@ -5295,17 +5295,10 @@ function normalizeGoalStatusEvent(event: DaemonEvent): DaemonUiEvent | null {
     return createGoalStatusUiEvent(event, terminal);
   }
 
-  const loop = meta['stopHookLoop'];
-  if (!isRecord(loop)) return null;
-  const goal = loop['goal'];
-  if (!isRecord(goal)) return null;
-  const condition = getString(goal, 'condition');
-  if (!condition) return null;
-
-  // Suppress per-iteration "checking" events from the transcript to avoid
-  // flooding with one card per stop-hook turn. The active goal state is
-  // already visible in the status bar; only terminal events and the initial
-  // "set" event are shown as transcript cards.
+  // Per-iteration "checking" events are deliberately not turned into
+  // transcript cards: one card per stop-hook turn floods the transcript, and
+  // the active goal state is already visible in the status bar. Only terminal
+  // events and the initial "set" event above become cards.
   return null;
 }
 


### PR DESCRIPTION
## What this PR does

The CLI stops calling the first-generation Goal Stop-hook implementation. `restoreGoal.ts` loses the seven exports that drove it — the history restorer that registered the hook, the terminal-event observer and recorder, the two blocked-reason gates, and the terminal-goal finder — none of which had a single production caller. What stays is the part three live call sites actually use: the transcript scanner that finds a Goal worth offering to restore, and the card parsing around it.

The ACP message emitter stops attaching a `goal` sub-object to `_meta.stopHookLoop`. That object could only ever be populated from the legacy in-memory store, which nothing writes in a real session. One consumer did read it — the Web Shell's session provider — but that branch returned `null` unconditionally, deliberately suppressing per-iteration "checking" events, so it produced no UI. The branch goes with it and the explanation stays as a comment.

The rest is dead test scaffolding: mocks of legacy core exports in five suites, and thirty-two mocks of a `Session.installGoalTerminalObserver` method that does not exist on `Session` in this revision.

The legacy core modules themselves are untouched. This PR removes the CLI's references so they can be deleted next.

## Why it's needed

Goal v3 owns every surface. The legacy generation is not a second live path — `registerGoalHook`'s only production caller was `restoreGoalFromHistory` in this file, and that function had no callers of its own — so what remained was cost: a 387-line module where two thirds was unreachable, a wire field nothing could populate, and test files that mocked functions the code under test never calls, which is the kind of scaffolding that makes a reader think a path is live when it is not.

Together with the core-side sibling, this is what makes deleting `goalHook.ts`, `goalJudge.ts` and `activeGoalStore.ts` a mechanical follow-up rather than a large-scope refactor.

## Reviewer Test Plan

### How to verify

The CLI's vitest config aliases `@qwen-code/qwen-code-core` straight to source, so no build is needed:

```
cd packages/cli && npx vitest run src/ui/utils/restoreGoal.test.ts
cd packages/cli && npx vitest run src/ui/commands/goalCommand.test.ts
cd packages/cli && npx vitest run src/nonInteractiveCliCommands.test.ts
cd packages/cli && npx vitest run src/acp-integration/session/emitters
cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
cd packages/cli && npx vitest run src/ui/hooks/use-llm-stream.test.tsx
```

Run them one file per invocation on a small host; a single combined invocation gets OOM-killed here.

The claim worth checking is that the retained half of `restoreGoal.ts` is exactly what its three importers need. `acpAgent.ts`, `session/Session.ts` and `session/recovered-goal-update.ts` import only `findGoalToRestore`, `collectGoalStatusItemsFromRecords`, `parseGoalStatusItem`, `isTranscriptItemRecord` and the two types — all kept.

Two tests were retargeted rather than deleted, and those are the ones to read: the 10,000-character objective pin from #6665 now asserts against the live transcript scanner instead of the deleted restorer, and the start-time cases assert the `setAt` the scanner returns instead of the default clock the deleted hook registration applied.

### Evidence (Before & After)

Non–user-visible refactor: N/A for screenshots. The evidence is that no legacy symbol is reachable from the CLI, and every suite still passes:

```
$ git grep -nE "registerGoalHook|unregisterGoalHook|getActiveGoal|setActiveGoal|clearActiveGoal|activeGoalEquals|getLastGoalTerminal|setLastGoalTerminal|setGoalTerminalObserver|__resetActiveGoalStoreForTests|GoalTerminalEvent|GoalTerminalKind" -- packages/cli/src
(no matches)

restoreGoal.test.ts                                    34 passed
goalCommand.test.ts                                    65 passed
nonInteractiveCliCommands.test.ts                      52 passed
acp-integration/session/emitters (3 files)            115 passed
acpAgent.test.ts                                      622 passed
use-llm-stream.test.tsx                               279 passed
acpAgent.worktree.test.ts + history-replayer.test.ts   55 passed
```

`prettier --check` and `eslint` are clean on all ten changed files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, package-local vitest for `packages/cli`, one test file per invocation.

## Risk & Scope

- Main risk or tradeoff: one wire field goes away, `_meta.stopHookLoop.goal`. Its only reader was a Web Shell branch that returned `null` on every path, so removing both is byte-identical in behaviour, but it is a wire surface and worth a reviewer's eye. Everything else removed was unreachable: seven exports with no production caller, and mocks of functions the code under test never calls.
- Not validated / out of scope: the legacy core modules still compile and keep their own suites; deleting them is the next PR. `projectLegacyActiveGoal`, the headless `active_goal` event, `_meta.goalStatus`, `_meta.goalTerminal`, `BridgeSessionGoal.active` and the `goal_status` history card are all deliberately untouched. `packages/cli/tsconfig.json` reports type errors in seven files this PR never touches (`activeWorkState`, `ChannelBaseOptions.locale`, `agentsRespawned`) — those come from unbuilt sibling package dists on this host, and a worktree with a complete `npm run build` type-checks the CLI with zero errors.
- Breaking changes / migration notes: none beyond the `stopHookLoop.goal` field above. No settings, persisted records, or user-visible behaviour change.

One follow-up found while doing this and left out on purpose: `session/Session.ts` still imports and calls core's `abortGoalForStopHookCap`. Its own comment explains the legacy store has no writer for daemon sessions, so the call always returns false and the canonical-runtime branch always runs. Dropping that guard is behaviour-bearing enough to deserve its own commit.

## Linked Issues

Part of #10795. Part of #4228.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

CLI 不再调用第一代 Goal Stop-hook 实现。`restoreGoal.ts` 去掉了驱动它的七个导出——注册该 hook 的历史恢复器、终态事件观察者与记录器、两个"被阻止原因"的判断门，以及终态 Goal 查找器——它们在生产代码里一个调用者都没有。留下的是三处存活调用点真正在用的部分：从 transcript 里找出值得提议恢复的 Goal 的扫描器，以及围绕它的卡片解析。

ACP 的消息发射器不再往 `_meta.stopHookLoop` 上挂 `goal` 子对象。那个对象只可能由内存里的 legacy store 填充，而真实会话里没有任何东西写它。确实有一个消费者读过它——Web Shell 的 session provider——但那个分支在所有路径上都无条件 `return null`，刻意抑制逐轮的"checking"事件，所以它不产生任何 UI。该分支随之移除，解释以注释形式保留。

其余是死掉的测试脚手架：五个测试套里对 legacy core 导出的 mock，以及三十二处对 `Session.installGoalTerminalObserver` 的 mock——这个方法在当前版本的 `Session` 上并不存在。

legacy core 模块本身未被触及。本 PR 移除 CLI 侧的引用，以便下一个 PR 删除它们。

## 为什么需要

Goal v3 拥有所有界面。legacy 那一代并不是第二条存活路径——`registerGoalHook` 在生产代码里唯一的调用者就是本文件里的 `restoreGoalFromHistory`，而它自己没有任何调用者——所以剩下的只有代价：一个 387 行的模块里三分之二不可达、一个没有东西能填充的线协议字段，以及一批 mock 了被测代码从不调用的函数的测试文件——而这类脚手架正是让读者误以为某条路径还活着的原因。

与 core 侧的姊妹 PR 合起来，这就是让删除 `goalHook.ts`、`goalJudge.ts` 与 `activeGoalStore.ts` 变成一次机械跟进、而不是一次大范围重构的前提。

## 评审验证方式

### 如何验证

CLI 的 vitest 配置把 `@qwen-code/qwen-code-core` 直接别名到源码，所以不需要构建：

```
cd packages/cli && npx vitest run src/ui/utils/restoreGoal.test.ts
cd packages/cli && npx vitest run src/ui/commands/goalCommand.test.ts
cd packages/cli && npx vitest run src/nonInteractiveCliCommands.test.ts
cd packages/cli && npx vitest run src/acp-integration/session/emitters
cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
cd packages/cli && npx vitest run src/ui/hooks/use-llm-stream.test.tsx
```

在内存较小的机器上请一个文件一次调用；把它们合成一次调用会被 OOM 杀掉。

值得核对的论断是：`restoreGoal.ts` 保留下来的那一半，恰好就是它三个引入方需要的东西。`acpAgent.ts`、`session/Session.ts` 与 `session/recovered-goal-update.ts` 只引入 `findGoalToRestore`、`collectGoalStatusItemsFromRecords`、`parseGoalStatusItem`、`isTranscriptItemRecord` 与两个类型——全部保留。

有两个测试是被改指对象而不是删除，那两个值得读：来自 #6665 的一万字符目标长度固定断言，现在针对存活的 transcript 扫描器而不是被删掉的恢复器；起始时间那几个用例现在断言扫描器返回的 `setAt`，而不是被删掉的 hook 注册所应用的默认时钟。

### 证据（前后对比）

不面向用户的重构：截图部分为 N/A。证据是 CLI 侧已无法到达任何 legacy 符号，且每个测试套仍然通过：

```
$ git grep -nE "registerGoalHook|unregisterGoalHook|getActiveGoal|setActiveGoal|clearActiveGoal|activeGoalEquals|getLastGoalTerminal|setLastGoalTerminal|setGoalTerminalObserver|__resetActiveGoalStoreForTests|GoalTerminalEvent|GoalTerminalKind" -- packages/cli/src
(no matches)

restoreGoal.test.ts                                    34 passed
goalCommand.test.ts                                    65 passed
nonInteractiveCliCommands.test.ts                      52 passed
acp-integration/session/emitters（3 个文件）           115 passed
acpAgent.test.ts                                      622 passed
use-llm-stream.test.tsx                               279 passed
acpAgent.worktree.test.ts + history-replayer.test.ts   55 passed
```

十个改动文件上的 `prettier --check` 与 `eslint` 均干净。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

Linux，`packages/cli` 的包内 vitest，一个测试文件一次调用。

## 风险与范围

- 主要风险或权衡：有一个线协议字段消失了，`_meta.stopHookLoop.goal`。它唯一的读者是 Web Shell 里一个在所有路径上都 `return null` 的分支，所以两者一起移除在行为上逐字节相同；但它毕竟是线协议面，值得评审者过一眼。其余被移除的都是不可达的：七个没有生产调用者的导出，以及对被测代码从不调用的函数的 mock。
- 未验证 / 不在范围内：legacy core 模块仍在编译，仍保有它们自己的测试套；删除它们是下一个 PR。`projectLegacyActiveGoal`、headless 的 `active_goal` 事件、`_meta.goalStatus`、`_meta.goalTerminal`、`BridgeSessionGoal.active` 与 `goal_status` 历史卡片都刻意未动。`packages/cli/tsconfig.json` 在本 PR 从未触及的七个文件里报出类型错误（`activeWorkState`、`ChannelBaseOptions.locale`、`agentsRespawned`）——它们来自本机上未构建的兄弟包 dist；在一个完成了 `npm run build` 的 worktree 里，CLI 的类型检查零报错。
- 破坏性变更 / 迁移说明：除上述 `stopHookLoop.goal` 字段外没有。设置、持久化记录与用户可见行为均未改变。

顺手发现但刻意留在范围外的一项跟进：`session/Session.ts` 仍然引入并调用 core 的 `abortGoalForStopHookCap`。它自己的注释说明 legacy store 对 daemon 会话没有写入方，所以该调用永远返回 false，规范运行时那一支永远执行。移除这道保护有行为含义，值得单独一次提交。

## 关联 Issue

Part of #10795. Part of #4228.

</details>
