### PR TITLE
fix(dws): forward Aone sandbox identifier

### DIFF
--- a/packages/channels/dws/src/dws-environment.test.ts
+++ b/packages/channels/dws/src/dws-environment.test.ts
@@ -18,7 +18,7 @@ describe('DWS process environment', () => {
         NODE_EXTRA_CA_CERTS: '/etc/ssl/corp.pem',
         DWS_DISABLE_KEYCHAIN: '1',
         DWS_AGENT_PRODUCT: 'openclaw',
-        AONE_SANDBOX_ID: 'sandbox-secret',
+        AONE_SANDBOX_ID: 'sandbox-id',
         XDG_DATA_HOME: '/srv/qwen/data',
         OPENAI_API_KEY: 'model-secret',
         QWEN_SERVER_TOKEN: 'daemon-secret',
@@ -32,6 +32,7 @@ describe('DWS process environment', () => {
       NODE_EXTRA_CA_CERTS: '/etc/ssl/corp.pem',
       DWS_DISABLE_KEYCHAIN: '1',
       DWS_AGENT_PRODUCT: 'qwen-code',
+      AONE_SANDBOX_ID: 'sandbox-id',
       XDG_DATA_HOME: '/srv/qwen/data',
       NO_COLOR: '1',
     });

--- a/packages/channels/dws/src/dws-environment.ts
+++ b/packages/channels/dws/src/dws-environment.ts
@@ -7,6 +7,7 @@
 import process from 'node:process';
 
 const SAFE_KEYS = new Set([
+  'AONE_SANDBOX_ID',
   'APPDATA',
   'COMSPEC',
   'HOME',


### PR DESCRIPTION
## What this PR does

Preserves the Aone sandbox routing identifier when Qwen Code launches DWS CLI subprocesses through its sanitized environment.

## Why it's needed

In sandboxed Aone environments, DWS commands need the routing identifier inherited from the parent process. The DWS environment sanitizer currently drops it, so authentication can succeed while event and message operations fail to reach the configured sandbox.

## Reviewer Test Plan

### How to verify

Set a placeholder sandbox identifier alongside representative runtime, DWS, XDG, and unrelated secret variables. Confirm the sanitized DWS subprocess environment keeps the sandbox identifier and expected runtime settings while continuing to exclude model, daemon, and channel secrets.

### Evidence (Before & After)

N/A — subprocess environment handling only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.23.2; targeted DWS unit test and package build.

## Risk & Scope

- Main risk or tradeoff: The sandbox identifier is now available to DWS child processes; unrelated credentials remain excluded by the existing allowlist.
- Not validated / out of scope: Real DingTalk end-to-end delivery and non-macOS execution were not tested locally. The repository-wide build currently stops at the unchanged document-export bundle size budget on `main` (4,212,198 bytes versus 4,200,000 bytes), and the subsequent repository-wide typecheck lacks that unbuilt package.
- Breaking changes / migration notes: None.

## Linked Issues

N/A
