### PR TITLE
feat(sessions): record what kind of session registered, and document the registry and wire contract

### DIFF
--- a/docs/users/features/_meta.ts
+++ b/docs/users/features/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   commands: 'Commands',
+  'cross-session-protocol': 'Cross-Session Protocol',
   'code-review': 'Code Review',
   'followup-suggestions': 'Followup Suggestions',
   'tool-use-summaries': 'Tool-Use Summaries',

--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -757,12 +757,11 @@ qwen sessions list --json | jq .
 
 #### `qwen sessions ps`
 
-Lists the interactive Qwen Code sessions running on this machine right
-now. `sessions list` walks saved transcripts ("what have I worked on");
-this walks the live-process registry ("what is running at this moment").
-Records left behind by a killed session are swept as they are found.
-Headless sessions (`qwen -p`) do not register with the live-process
-registry, so they are not shown.
+Lists the Qwen Code sessions registered on this machine right now.
+`sessions list` walks saved transcripts ("what have I worked on"); this
+walks the live-process registry ("what is running at this moment").
+Records left behind by a killed session are swept as they are found. A
+one-shot `qwen -p` run never registers, so it is never shown.
 
 **Flags:**
 
@@ -772,7 +771,16 @@ registry, so they are not shown.
 
 **Human-readable output (default):**
 
-A table with columns: NAME, PID, AGE, DIRECTORY.
+A table with columns: NAME, KIND, PID, AGE, DIRECTORY.
+
+KIND says what registered the session — `tui` for someone at a terminal,
+`external` for a program that is not a Qwen Code session at all (a voice
+front-end, a relay), and `headless` or `serve` for a session another
+program drives. It is a self-report, like NAME and DIRECTORY: every field
+here was written by the process it describes, and nothing about what a
+session is allowed to do depends on it. See
+[Cross-Session Protocol](./cross-session-protocol.md) for the record
+format and for how to register a program of your own.
 
 **JSON output (`--json`):**
 
@@ -781,7 +789,7 @@ object with fields:
 
 ```
 schemaVersion, pid, procStart, pidNs, sessionId, cwd, name, startedAt,
-qwenVersion, ipcPath (when peer messaging is available)
+qwenVersion, kind, ipcPath (when peer messaging is available)
 ```
 
 Nothing else is written to stdout — an empty listing prints nothing at
@@ -1018,3 +1026,18 @@ on your behalf.
 Anyone who holds the token can send as that controller, so treat it like
 any other credential: give it to one program, keep it out of shared
 config, and revoke it when that program is done.
+
+### Programs that are not Qwen Code sessions
+
+Everything above works between sessions, but nothing in it is specific to
+one. A program that writes a registry record for itself and binds an
+inbox the same way is listed by `qwen sessions ps` and by `list_agents`,
+can be addressed by name from `send_message`, and receives delivery
+receipts for what it sends — a voice front-end, a relay, a build watcher.
+It should record `kind: "external"` so a listing can say what it is.
+
+[Cross-Session Protocol](./cross-session-protocol.md) is the contract for
+writing one: the record schema and how liveness is judged, the socket
+paths and framing, the auth line, every frame field, the receipt states
+and their transitions, and what a receiver does with a message before its
+model sees it.

--- a/docs/users/features/cross-session-protocol.md
+++ b/docs/users/features/cross-session-protocol.md
@@ -1,0 +1,291 @@
+# Cross-Session Protocol
+
+This page is the contract for a program that wants to take part in
+cross-session messaging without being a Qwen Code session: a voice
+front-end, a relay daemon, a script that watches a build. It describes
+what a session writes to the registry, what its inbox reads off a
+connection, and what it sends back. Everything here is what the code
+does today at schema version 1 and frame version 1; the last section
+says what may change and how you will know.
+
+Every value that crosses a process boundary is untrusted on arrival and
+validated by the reader. Where this page says a field "must" have some
+shape, a value that does not is dropped, never rejected with an error.
+
+## 1. The session registry
+
+A running session publishes one record:
+
+```
+$QWEN_HOME/sessions/<pid>.json        (directory 0700, file 0600)
+```
+
+`$QWEN_HOME` defaults to `~/.qwen`. The file name is the writer's PID
+and nothing else; a record whose `pid` field disagrees with its file
+name is ignored.
+
+```json
+{
+  "schemaVersion": 1,
+  "pid": 41337,
+  "procStart": "a1b2c3d4-…-boot-uuid:8895124",
+  "pidNs": 4026531836,
+  "sessionId": "8e016be8-5b48-4c13-ad22-1f5326ae64ac",
+  "cwd": "/home/me/project",
+  "name": "project-3f",
+  "startedAt": 1788959000000,
+  "qwenVersion": "0.23.0",
+  "kind": "tui",
+  "ipcPath": "/run/user/1000/qwen-socks/41337.sock",
+  "ipcToken": "c0ffee…64 hex…"
+}
+```
+
+| Field           | Meaning                                                                                                                                                                                                                                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion` | Always `1`. A reader skips a record with a higher version and never deletes it.                                                                                                                                                                                                                       |
+| `pid`           | The writer's process id. Must equal the file name.                                                                                                                                                                                                                                                    |
+| `procStart`     | `<boot id>:<process start ticks>` on Linux (`/proc/sys/kernel/random/boot_id` and field 22 of `/proc/<pid>/stat`); `null` elsewhere. Guards against PID reuse, and against records written on another machine that shares this home directory.                                                        |
+| `pidNs`         | Inode number of `/proc/self/ns/pid` on Linux; `null` elsewhere. A reader only lists and sweeps records from its own namespace.                                                                                                                                                                        |
+| `sessionId`     | The session's id. `/clear` and `/resume` swap it under the same PID, so re-read the record before each send.                                                                                                                                                                                          |
+| `cwd`           | Working directory at registration.                                                                                                                                                                                                                                                                    |
+| `name`          | Display name. Derived from the cwd basename (Unicode letters, marks, digits, `.`, `_`, `-`; up to 32 code points) plus `-` and the first two hex characters of `sha256(sessionId)`, unless the writer chose one. Not unique.                                                                          |
+| `startedAt`     | Epoch milliseconds. Newest first is the listing order and the tie-break between twins.                                                                                                                                                                                                                |
+| `qwenVersion`   | Free text or `null`.                                                                                                                                                                                                                                                                                  |
+| `kind`          | What registered: `tui` (someone at a terminal), `headless`, `serve`, `external`. Lowercase ASCII, digits and dashes, at most 16 characters; anything else is dropped on read. Absent means a writer older than the field, which reads as `tui`. A label for listings — never a credential; see below. |
+| `ipcPath`       | The inbox socket, present only while it is bound. Absent means discoverable but not messageable.                                                                                                                                                                                                      |
+| `ipcToken`      | 64 hex characters. What a connection to `ipcPath` presents on its auth line. Absent means the inbox requires none (records from older builds).                                                                                                                                                        |
+
+**A record is a self-report.** Every field in it was written by the
+process it describes, so `name`, `cwd` and `kind` are claims, not facts a
+reader can lean on. Nothing that decides what a sender may do reads
+them — that is settled by what a connection presents (§3) and by the
+receiving session's own policy (§6). Set `kind` so a listing can group
+sessions honestly; do not expect it to buy you anything.
+
+**Writing your own record.** An external process that wants to be
+found — listed by `qwen sessions ps`, addressable from `send_message`,
+able to receive receipts — writes the same record for itself: its own
+`pid`, `procStart` and `pidNs` computed the same way, a `sessionId` it
+mints (any UUID), `kind: "external"`, a `name` (yours, or derived the
+same way; it is flattened to one line and bounded when displayed), and
+`ipcPath` + `ipcToken` for an inbox it binds itself (§2). Write to a
+temp file in the same directory and `rename` over the target; create the
+file 0600; refuse to write through a symlink. Remove the record on exit.
+A record whose process is gone is swept by the next session that lists,
+but only when `procStart` proves the PID is not merely reused.
+
+**Reading.** Anything that can read the directory can read every record,
+including tokens: being able to discover a session and being able to
+authenticate to it are one capability by design. Do not print
+`ipcToken` anywhere a model or a log can see it.
+
+**Liveness.** A record is live when all of these hold: the file name
+matches `pid`; `pidNs` equals the reader's; the boot id inside
+`procStart` equals the reader's (or `procStart` is `null`); and the PID
+is alive with the same start ticks. A live record with an `ipcPath`
+still has to be dialed before it is advertised as reachable — a socket
+file outlives a crash.
+
+**Refs.** Displayed handles use `ref = sha256(sessionId)[0:6]`. Two
+sessions may share a `name`; the address grammar a sender types is
+`name`, `name [ref]`, `[ref]` or the bare `ref`, and an ambiguous
+`name` is an error rather than a guess.
+
+## 2. The inbox socket
+
+One UNIX domain socket per session, at the first of these that binds:
+
+1. `$XDG_RUNTIME_DIR/qwen-socks/<pid>.sock`
+2. `$TMPDIR/qwen-socks-<16 hex>/<pid>.sock`
+3. `/tmp/qwen-socks-<16 hex>/<pid>.sock`
+
+The directory is 0700 and the socket 0600. A path longer than 103 bytes
+is skipped. When the PID-keyed name is already held by a live listener
+(two PID namespaces sharing a runtime directory), the session binds
+`<pid>-<8 hex>.sock` next to it instead. Peers never derive a socket
+path; they read `ipcPath` from the record.
+
+A connection carries newline-delimited JSON, one object per line, UTF-8.
+A single line longer than 1 MiB (measured in UTF-16 code units) drops
+the connection. A connection that goes 30 seconds without completing a
+line that parses is dropped; junk lines do not extend the deadline. The
+listener accepts at most 64 connections at once.
+
+The expected exchange is one message per connection: connect, write the
+auth line and the frame in one write, half-close, wait for the peer to
+close. The receiver never writes on the same connection; anything it
+has to say comes back as a separate connection to your own `ipcPath`.
+
+## 3. The auth line
+
+When the target record has an `ipcToken`, the first line must be:
+
+```json
+{ "msgV": 1, "type": "auth", "token": "<token>" }
+```
+
+Three kinds of token are accepted, and the inbox remembers which one it
+saw:
+
+| Presented                                                                     | The inbox concludes            | Effect                                                                           |
+| ----------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------- |
+| The `ipcToken` from the target's registry record                              | an ordinary peer               | subject to policy and mode parity (§6)                                           |
+| `QWEN_CODE_MESSAGING_TOKEN` from the target's own environment                 | a process that session started | delivered under the parity default; `origin="own-process"`                       |
+| A controller token `qpc_<64 hex>` minted with `qwen sessions controllers add` | a program the user trusts      | delivered under the parity default; `origin="controller"` with the grant's label |
+
+A first line that is not an auth line, or that presents a token matching
+none of the three, drops the connection silently. When the record has no
+`ipcToken`, do not send an auth line; an older inbox reads it as an
+unknown frame type and skips it, so leading with one is always safe.
+
+Nothing here authenticates the _sender_: a token proves the connection is
+allowed, not who opened it. `from`, `fromName`, `fromMode` and every
+field of the record are claims.
+
+This is also the whole of the trust model. A program the user wants
+driving their sessions gets a controller token, minted by hand and given
+to that one program; it is what makes the difference between a message
+that is delivered and one that waits for review. Writing
+`kind: "external"` or a familiar-looking `name` buys nothing.
+
+## 4. The user frame
+
+```json
+{
+  "msgV": 1,
+  "msgId": "5f1d0c9e-3b2a-4e8f-9c7d-1a2b3c4d5e6f",
+  "type": "user",
+  "from": "/run/user/1000/qwen-socks/40011.sock",
+  "replyToken": "<my own ipcToken>",
+  "fromName": "project-3f",
+  "fromMode": "prompting",
+  "toSessionId": "8e016be8-…",
+  "priority": "next",
+  "message": { "role": "user", "content": "build finished, 0 failures" }
+}
+```
+
+| Field         | Rule                                                                                                                                                                                                                          |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `msgV`        | Number. Must be ≤ 1; higher is dropped.                                                                                                                                                                                       |
+| `msgId`       | `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`, and must not canonicalize (dashes stripped, lower-cased) to `all`. Use a fresh UUID per message: the receiver remembers ids it has settled and repeats the old verdict for a re-sent one. |
+| `type`        | `"user"`.                                                                                                                                                                                                                     |
+| `from`        | Your `ipcPath`, if you have one. Where receipts go. Absent means no receipts.                                                                                                                                                 |
+| `replyToken`  | Your `ipcToken`, so the receiver can authenticate its receipts to you.                                                                                                                                                        |
+| `fromName`    | Display name; flattened to one line, at most 200 characters.                                                                                                                                                                  |
+| `fromMode`    | `"prompting"` (a person reviews each action) or `"bypass"` (some actions apply without review). Absent means "asserts nothing", which is held for review (§6).                                                                |
+| `toSessionId` | The `sessionId` you read from the record. A receiver holding a different id answers `misaddressed`. Always send it.                                                                                                           |
+| `priority`    | `"now"` or `"next"`; anything else reads as `"next"`. Carried for a future interrupt path; today the receiver queues both for the next turn.                                                                                  |
+| `message`     | `role` must be `"user"`; `content` a non-empty string.                                                                                                                                                                        |
+
+Unknown fields are ignored.
+
+## 5. The delivery-status frame
+
+The receiver reports what became of a message with one control frame per
+outcome, sent to the message's `from` and authenticated with its
+`replyToken`:
+
+```json
+{
+  "msgV": 1,
+  "msgId": "<fresh id>",
+  "type": "control",
+  "action": "delivery_status",
+  "status": "held",
+  "origMsgId": "5f1d0c9e-…",
+  "from": "/run/user/1000/qwen-socks/41337.sock",
+  "reason": "Your message is held for the recipient user to review …"
+}
+```
+
+| `status`       | When                                                                                                                                                      | What to do                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `held`         | Parked for the user to review. Repeated on a retry, and on a release that could not be queued.                                                            | Wait; a decision or an expiry follows.                                             |
+| `delivered`    | Queued for the model.                                                                                                                                     | Nothing. Not proof it was read.                                                    |
+| `denied`       | A person reviewed it and said no.                                                                                                                         | Do not re-send.                                                                    |
+| `refused`      | The session's policy turns peer messages away; nobody saw it. Only ever the first receipt.                                                                | Stop; reach that user another way.                                                 |
+| `expired`      | A held message ran out its wait, the session exited with it unread, or it arrived while that session was shutting down. Can follow `held` or `delivered`. | Re-send later if it still matters.                                                 |
+| `misaddressed` | `toSessionId` does not match the session at that address.                                                                                                 | Re-read the registry.                                                              |
+| `dropped`      | The inbox turned it away before any policy ran (§6).                                                                                                      | Treat as unsent. Do not retry in a loop; fold what matters into one later message. |
+
+A `dropped` receipt carries two more fields. `dropReason` is
+`rate-limited`, `duplicate` or `queue-full`. `droppedMsgIds` lists up to
+256 further ids the same receipt settles: a burst is answered with one
+receipt rather than one each, so a sender moves every message it lost to
+a terminal state from a single frame. Both are meaningless on any other
+status and are ignored there.
+
+`reason` is free text for a human. Order of receipts is not guaranteed
+across connections; apply them as state transitions:
+
+```
+pending   → held | delivered | denied | refused | expired | misaddressed | dropped
+held      → delivered | denied | expired | misaddressed
+delivered → expired | misaddressed
+```
+
+Anything else is a repeat and should be ignored. A receipt for an id you
+never sent is noise; ignore it. Receipts are best-effort on the
+receiver's side: a full outbound limit or a dead `from` loses them
+silently, so a sender must tolerate never hearing back.
+
+Your own inbox receives these frames from the sessions you messaged. If
+you only ever send, bind an inbox and give `from` anyway: without one you
+are blind to every outcome above.
+
+## 6. What the receiver does with a message
+
+In order:
+
+1. **Admission.** Per sender: a burst of 30, then one message every two seconds. All senders together: a burst of 32, then one a second — a sender names itself on the frame, so rotating that name buys a fresh allowance from the first limit but not the second. The same body from another session inside 30 seconds is a `duplicate`; a process the session started and a trusted controller are exempt from that check, and rate-limited like everyone else. A dropped message is never held, never delivered, and leaves no record, so a sender that waits out its burst and retries still lands.
+2. **Settled ids.** A `msgId` the gate already decided repeats its earlier verdict.
+3. **Policy.** `agents.crossSessionInbound` set to `accept`, `hold` or `refuse` wins. Unset: a process the session started or a trusted controller is accepted; otherwise a message is accepted only when `fromMode` names the same review class the receiver is in, and held in every other case, including when `fromMode` is absent.
+4. **Hold.** Up to 50 messages wait. A message arriving at a full buffer is `dropped` with `queue-full` rather than evicting one already parked. A held message expires after `agents.crossSessionHeldExpiry` (`1m`, `5m`, `10m`, `never`; default `5m`). The user releases or denies from `/peers`; a mode change re-evaluates the backlog.
+5. **Queue.** An accepted message joins the session's input queue, which holds at most 50 from peers. A full queue is `dropped` with `queue-full` too.
+
+A sender does not have to discover the limits the hard way: a Qwen Code
+session mirrors them per address and refuses its own send before writing
+it, telling its model to batch instead.
+
+The model sees a delivered message as:
+
+```
+<cross_session_message from="/run/user/1000/qwen-socks/40011.sock" name="project-3f">
+build finished, 0 failures
+</cross_session_message>
+```
+
+followed by a notice stating the sender's authority. `origin="own-process"`
+or `origin="controller" controller="<label>"` is added by the receiver
+from what the connection presented, never from the frame; a controller's
+label comes from the grant the user minted, not from `fromName`. Tags
+that look like the envelope are defanged inside `content`.
+
+## 7. Compatibility
+
+- A reader ignores fields it does not know. Adding a field to a record or
+  a frame is not a breaking change.
+- `schemaVersion` and `msgV` are bumped only for a change to the shape of
+  existing fields. A reader drops a frame or skips a record with a
+  version above what it knows, and never deletes such a record.
+- New `status` values may appear; treat an unknown one as "no transition"
+  and keep waiting. The same goes for a `kind` you do not recognize:
+  show it, do not correct it.
+- Constants that may change without notice: the burst and rate figures,
+  the hold ceiling and expiry choices, the 1 MiB line cap, the 30-second
+  line deadline, the 64-connection cap.
+
+## 8. Not settled yet
+
+- **Name yielding.** Two sessions in one directory can register the same
+  `name`; today they are told apart only by `ref`. A registration that
+  yields to a live name, and a control frame that tells peers a session
+  renamed itself, are both still to come.
+- **Same-name reporting.** `qwen sessions ps` and `list_agents` do not
+  flag records that still collide.
+- **Daemon-managed sessions.** Only the interactive UI registers today, so
+  a session `qwen serve` drives is not in the registry, cannot be
+  addressed, and cannot send. The `serve` and `headless` kinds are
+  reserved for it.

--- a/packages/cli/src/commands/sessions/ps.test.ts
+++ b/packages/cli/src/commands/sessions/ps.test.ts
@@ -12,6 +12,14 @@ const listLiveSessions = vi.fn();
 
 vi.mock('@qwen-code/qwen-code-core', () => ({
   listLiveSessions: (...args: unknown[]) => listLiveSessions(...args),
+  // Stated rather than imported: this suite mocks the whole package to
+  // stay a fast command test, and pulling the real barrel in for one pure
+  // function would undo that. What the function *means* — an absent kind
+  // is the interactive UI, an unknown one is shown as written — is pinned
+  // where it lives, in the registry's own suite; here it only has to be
+  // something to lay out in a column.
+  describeSessionKind: (kind: string | undefined) =>
+    kind === undefined || kind.length === 0 ? 'tui' : kind,
 }));
 
 const stdout: string[] = [];
@@ -22,9 +30,8 @@ vi.mock('../../utils/stdioHelpers.js', () => ({
   writeStderrLine: (line: string) => stderr.push(line),
 }));
 
-const { psCommand, formatAge, NAME_COL, PID_COL, AGE_COL } = await import(
-  './ps.js'
-);
+const { psCommand, formatAge, NAME_COL, KIND_COL, PID_COL, AGE_COL } =
+  await import('./ps.js');
 
 function record(
   over: Partial<SessionRegistryRecord> = {},
@@ -85,7 +92,7 @@ describe('qwen sessions ps', () => {
     listLiveSessions.mockResolvedValue([record()]);
     await run({ json: false });
 
-    expect(stdout[0]).toMatch(/^NAME\s+PID\s+AGE\s+DIRECTORY$/);
+    expect(stdout[0]).toMatch(/^NAME\s+KIND\s+PID\s+AGE\s+DIRECTORY$/);
     expect(stdout[1]).toContain('app-ab');
     expect(stdout[1]).toContain('4242');
     expect(stdout[1]).toContain('/w/app');
@@ -98,7 +105,7 @@ describe('qwen sessions ps', () => {
     try {
       vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
       listLiveSessions.mockResolvedValue([
-        record({ startedAt: Date.now() - 5_000 }),
+        record({ startedAt: Date.now() - 5_000, kind: 'serve' }),
       ]);
       await run({ json: false });
     } finally {
@@ -107,25 +114,48 @@ describe('qwen sessions ps', () => {
 
     expect(stdout[0]).toBe(
       'NAME'.padEnd(NAME_COL) +
+        'KIND'.padEnd(KIND_COL) +
         'PID'.padEnd(PID_COL) +
         'AGE'.padEnd(AGE_COL) +
         'DIRECTORY',
     );
     expect(stdout[1]).toBe(
       'app-ab'.padEnd(NAME_COL) +
+        'serve'.padEnd(KIND_COL) +
         '4242'.padEnd(PID_COL) +
         '5s'.padEnd(AGE_COL) +
         '/w/app',
     );
-    expect([NAME_COL, PID_COL, AGE_COL]).toEqual([22, 9, 10]);
+    expect([NAME_COL, KIND_COL, PID_COL, AGE_COL]).toEqual([22, 10, 9, 10]);
   });
 
-  it('says so plainly when nothing else is running', async () => {
+  it('shows a record with no kind as the interactive UI', async () => {
+    listLiveSessions.mockResolvedValue([record()]);
+    await run({ json: false });
+    expect(stdout[1].slice(NAME_COL, NAME_COL + KIND_COL)).toBe(
+      'tui'.padEnd(KIND_COL),
+    );
+  });
+
+  it('truncates an over-long kind instead of shifting the columns after it', async () => {
+    // A newer build can write a kind up to sixteen characters, which is
+    // wider than this column: without the truncation the PID, AGE and
+    // DIRECTORY cells of that one row would all slide right.
+    listLiveSessions.mockResolvedValue([record({ kind: 'abcdefghijklmnop' })]);
+    await run({ json: false });
+    expect(stringWidth(stdout[1].slice(0, NAME_COL + KIND_COL))).toBe(
+      NAME_COL + KIND_COL,
+    );
+    expect(stdout[1]).toContain('abcdefg…');
+    expect(stdout[1].slice(NAME_COL + KIND_COL)).toBe(
+      '4242'.padEnd(PID_COL) + formatAge(90_000).padEnd(AGE_COL) + '/w/app',
+    );
+  });
+
+  it('says so plainly when nothing is registered', async () => {
     listLiveSessions.mockResolvedValue([]);
     await run({ json: false });
-    expect(stdout).toEqual([
-      'No other interactive Qwen Code sessions are running.',
-    ]);
+    expect(stdout).toEqual(['No Qwen Code sessions are registered right now.']);
   });
 
   it('emits one JSON object per line with no header', async () => {
@@ -152,6 +182,15 @@ describe('qwen sessions ps', () => {
 
     expect(stdout).toEqual([expected]);
     expect(stdout[0]).not.toContain('\n');
+  });
+
+  it('carries the kind into the JSON output, unfiltered', async () => {
+    // This is the surface an aggregator reads to tell a user's own
+    // terminals from sessions something else is driving, so the field has
+    // to survive the projection the token strip does.
+    listLiveSessions.mockResolvedValue([record({ kind: 'external' })]);
+    await run({ json: true });
+    expect(JSON.parse(stdout[0]).kind).toBe('external');
   });
 
   it('strips the inbox auth token from the JSON output', async () => {
@@ -248,6 +287,8 @@ describe('qwen sessions ps', () => {
     // Padding is measured in terminal cells, not code units: a 2-cell CJK
     // character must not push the PID column one cell right per character.
     const row = stdout[1];
-    expect(stringWidth(row.slice(0, row.indexOf('4242')))).toBe(22);
+    expect(stringWidth(row.slice(0, row.indexOf('4242')))).toBe(
+      NAME_COL + KIND_COL,
+    );
   });
 });

--- a/packages/cli/src/commands/sessions/ps.ts
+++ b/packages/cli/src/commands/sessions/ps.ts
@@ -5,20 +5,22 @@
  */
 
 /**
- * `qwen sessions ps` — list the interactive Qwen Code sessions running
- * right now.
+ * `qwen sessions ps` — list the Qwen Code sessions running right now.
  *
  * The sibling `qwen sessions list` walks saved transcripts; this walks the
  * live-process registry, so the two answer different questions: "what have
  * I worked on" versus "what is running on this machine at this moment".
  *
- * "Interactive" is a registration fact, not a filter: only the
- * interactive UI registers sessions, so headless runs (`qwen -p`) never
- * appear here.
+ * KIND says what registered each one — an interactive terminal, a
+ * daemon-managed session, a program that is not Qwen Code at all. It is a
+ * self-report, like NAME and DIRECTORY: everything here was written by
+ * the process it describes. What does not appear at all is a one-shot
+ * `qwen -p` run, which never registers.
  */
 
 import type { CommandModule, Argv } from 'yargs';
 import {
+  describeSessionKind,
   listLiveSessions,
   type SessionRegistryRecord,
 } from '@qwen-code/qwen-code-core';
@@ -31,6 +33,8 @@ import { writeStdoutLine } from '../../utils/stdioHelpers.js';
 
 /** Fixed column widths for the human-readable table (exported for tests). */
 export const NAME_COL = 22;
+/** Wide enough for the longest kind this build writes (`headless`). */
+export const KIND_COL = 10;
 export const PID_COL = 9;
 export const AGE_COL = 10;
 
@@ -78,6 +82,7 @@ export function formatAge(ms: number): string {
 function outputHuman(records: SessionRegistryRecord[], now: number): void {
   writeStdoutLine(
     padDisplay('NAME', NAME_COL) +
+      padDisplay('KIND', KIND_COL) +
       padDisplay('PID', PID_COL) +
       padDisplay('AGE', AGE_COL) +
       'DIRECTORY',
@@ -88,6 +93,15 @@ function outputHuman(records: SessionRegistryRecord[], now: number): void {
         truncateToWidth(sanitize(record.name), NAME_COL - 2),
         NAME_COL,
       ) +
+        // Truncated for the same reason NAME is: a newer build may write
+        // a longer kind than any this one knows, and one over-wide cell
+        // would misalign every column after it. Not sanitized — unlike
+        // NAME and DIRECTORY, the read guard already bounds `kind` to
+        // lowercase ASCII, digits and dashes.
+        padDisplay(
+          truncateToWidth(describeSessionKind(record.kind), KIND_COL - 2),
+          KIND_COL,
+        ) +
         padDisplay(String(record.pid), PID_COL) +
         padDisplay(formatAge(now - record.startedAt), AGE_COL) +
         sanitize(record.cwd),
@@ -117,7 +131,7 @@ async function handlePs(argv: PsArgs): Promise<void> {
   }
 
   if (records.length === 0) {
-    writeStdoutLine('No other interactive Qwen Code sessions are running.');
+    writeStdoutLine('No Qwen Code sessions are registered right now.');
     return;
   }
 
@@ -126,7 +140,7 @@ async function handlePs(argv: PsArgs): Promise<void> {
 
 export const psCommand: CommandModule<unknown, PsArgs> = {
   command: 'ps',
-  describe: 'List interactive Qwen Code sessions running right now',
+  describe: 'List Qwen Code sessions running right now',
   builder: (yargs: Argv) =>
     yargs.option('json', {
       type: 'boolean',

--- a/packages/cli/src/ui/opentui/start-opentui-ui.tsx
+++ b/packages/cli/src/ui/opentui/start-opentui-ui.tsx
@@ -451,6 +451,7 @@ export async function startOpenTuiUI(
         sessionId: config.getSessionId(),
         cwd: config.getTargetDir(),
         qwenVersion: version,
+        kind: 'tui',
       }),
     );
     registerCleanup(() => config.unregisterSessionRegistry());

--- a/packages/cli/src/ui/startInteractiveUI.test.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.test.tsx
@@ -185,16 +185,20 @@ describe('startInteractiveUI session registration', () => {
     vi.clearAllMocks();
   });
 
-  it('registers the session with its id, target dir, and CLI version', async () => {
+  it('registers the session with its id, target dir, CLI version, and kind', async () => {
     registerSession.mockResolvedValue(true);
     const config = makeConfig();
 
     await start(config);
 
+    // `kind` is stated rather than left to the default: this is the one
+    // registrant a listing describes as someone sitting at a terminal,
+    // and it is the only place that claim is made.
     expect(registerSession).toHaveBeenCalledWith({
       sessionId: 'session-123',
       cwd: '/work/app',
       qwenVersion: '9.9.9',
+      kind: 'tui',
     });
     expect(config.trackSessionRegistration).toHaveBeenCalledTimes(1);
     await expect(

--- a/packages/cli/src/ui/startInteractiveUI.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.tsx
@@ -443,6 +443,7 @@ export async function startInteractiveUI(
       sessionId: config.getSessionId(),
       cwd: config.getTargetDir(),
       qwenVersion: version,
+      kind: 'tui',
     }),
   );
 

--- a/packages/core/src/ipc/peer-directory.test.ts
+++ b/packages/core/src/ipc/peer-directory.test.ts
@@ -9,7 +9,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 const listLiveSessions = vi.fn();
 const probePeerSocketVerdict = vi.fn();
 
-vi.mock('../services/session-registry.js', () => ({
+// Only the enumeration is stubbed; everything else this module reads from
+// the registry — how a `kind` reads back, above all — stays real, so a
+// projection test is checking the projection rather than a copy of it.
+vi.mock('../services/session-registry.js', async () => ({
+  ...(await vi.importActual<typeof import('../services/session-registry.js')>(
+    '../services/session-registry.js',
+  )),
   listLiveSessions: (...args: unknown[]) => listLiveSessions(...args),
 }));
 vi.mock('./uds-client.js', () => ({
@@ -106,9 +112,23 @@ describe('toPeerSessionInfo', () => {
       ref: peerRef('s1'),
       cwd: '/w/app',
       pid: 100,
+      kind: 'tui',
       ipcPath: '/tmp/s1.sock',
       startedAt: 1_000,
     });
+  });
+
+  it("carries the record's own kind, and reads a record without one as tui", () => {
+    expect(
+      toPeerSessionInfo(
+        record({ ipcPath: '/tmp/s1.sock', kind: 'serve' }) as never,
+      )?.kind,
+    ).toBe('serve');
+    // A record written before the field existed came from the interactive
+    // UI: nothing else registered then.
+    expect(
+      toPeerSessionInfo(record({ ipcPath: '/tmp/s1.sock' }) as never)?.kind,
+    ).toBe('tui');
   });
 });
 

--- a/packages/core/src/ipc/peer-directory.ts
+++ b/packages/core/src/ipc/peer-directory.ts
@@ -22,6 +22,7 @@
 
 import { createHash } from 'node:crypto';
 import {
+  describeSessionKind,
   listLiveSessions,
   type SessionRegistryRecord,
 } from '../services/session-registry.js';
@@ -36,6 +37,14 @@ export interface PeerSessionInfo {
   ref: string;
   cwd: string;
   pid: number;
+  /**
+   * What the peer says registered it — see `SessionKind`. A claim, like
+   * `name` and `cwd`: it tells a reader what to expect on the other end
+   * (a person at a terminal, a session a daemon drives), never what the
+   * sender may do. Always a string here; a record without one reads as
+   * `tui`.
+   */
+  kind: string;
   ipcPath: string;
   /**
    * Inbox auth token from the peer's record. Absent for a peer written by
@@ -79,6 +88,10 @@ export function toPeerSessionInfo(
     ref: peerRef(record.sessionId),
     cwd: flattenPeerLabel(record.cwd),
     pid: record.pid,
+    // Not flattened: the registry's own read guard already bounds `kind`
+    // to lowercase ASCII, digits and dashes, which is narrower than
+    // anything flattening would remove.
+    kind: describeSessionKind(record.kind),
     ipcPath: record.ipcPath,
     ...(record.ipcToken !== undefined ? { ipcToken: record.ipcToken } : {}),
     startedAt: record.startedAt,

--- a/packages/core/src/ipc/peer-send.test.ts
+++ b/packages/core/src/ipc/peer-send.test.ts
@@ -12,7 +12,10 @@ const readOwnSessionRecord = vi.fn();
 const listMessageablePeers = vi.fn();
 const sendPeerFrame = vi.fn();
 
-vi.mock('../services/session-registry.js', () => ({
+vi.mock('../services/session-registry.js', async () => ({
+  ...(await vi.importActual<typeof import('../services/session-registry.js')>(
+    '../services/session-registry.js',
+  )),
   readOwnSessionRecord: (...args: unknown[]) => readOwnSessionRecord(...args),
 }));
 vi.mock('./uds-client.js', async () => {
@@ -72,6 +75,7 @@ function peer(
     ref,
     cwd,
     pid: 100,
+    kind: 'tui',
     ipcPath: `/tmp/${sessionId}.sock`,
     startedAt: 1_000,
   };

--- a/packages/core/src/services/session-registry.test.ts
+++ b/packages/core/src/services/session-registry.test.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   deriveSessionName,
+  describeSessionKind,
   getSessionRecordPath,
   getSessionRegistryDir,
   listLiveSessions,
@@ -17,6 +18,7 @@ import {
   registerSession,
   resetRegisteredRecordPathForTest,
   unregisterSession,
+  SESSION_KINDS,
   SESSION_REGISTRY_SCHEMA_VERSION,
   readOwnSessionRecord,
 } from './session-registry.js';
@@ -217,6 +219,25 @@ describe('deriveSessionName', () => {
   });
 });
 
+describe('describeSessionKind', () => {
+  it('reads a record without a kind as the interactive UI', () => {
+    // The one caller-visible consequence of the field being optional: a
+    // record written before it existed came from the interactive UI,
+    // because nothing else registered then.
+    expect(describeSessionKind(undefined)).toBe('tui');
+    expect(describeSessionKind('')).toBe('tui');
+  });
+
+  it('passes every other kind through, known or not', () => {
+    for (const kind of SESSION_KINDS) {
+      expect(describeSessionKind(kind)).toBe(kind);
+    }
+    // A build that knows more kinds than this one is describing itself
+    // accurately; showing its own word beats showing "unknown".
+    expect(describeSessionKind('relay-2')).toBe('relay-2');
+  });
+});
+
 describe('registerSession', () => {
   it('writes a record for this process and lists it back', async () => {
     const before = Date.now();
@@ -252,6 +273,54 @@ describe('registerSession', () => {
       await fs.readFile(getSessionRecordPath(), 'utf8'),
     ) as Record<string, unknown>;
     expect(raw['pidNs']).toBe(readPidNamespaceId());
+  });
+
+  it('records what kind of session registered, defaulting to tui', async () => {
+    await registerSession({ sessionId: 's1', cwd: '/w/app', kind: 'serve' });
+    expect((await listLiveSessions())[0]?.kind).toBe('serve');
+
+    await unregisterSession();
+    resetRegisteredRecordPathForTest();
+    // The default is not cosmetic: every caller that omits the field is an
+    // interactive terminal, and a listing that showed them as unknown
+    // would read as a bug in the common case.
+    await registerSession({ sessionId: 's1', cwd: '/w/app' });
+    expect((await listLiveSessions())[0]?.kind).toBe('tui');
+  });
+
+  it('records an explicit name in place of the derived one', async () => {
+    await registerSession({
+      sessionId: 's1',
+      cwd: '/w/app',
+      kind: 'external',
+      name: 'live',
+    });
+    expect((await listLiveSessions())[0]?.name).toBe('live');
+  });
+
+  it('flattens and bounds an explicit name, and falls back when it empties', async () => {
+    await registerSession({
+      sessionId: 's1',
+      cwd: '/w/app',
+      // A name reaches a fixed-width table and a peer listing, so it gets
+      // what a peer-supplied label gets rather than being trusted whole.
+      name: `voice bridge\n${'x'.repeat(80)}`,
+    });
+    const flattened = (await listLiveSessions())[0]?.name ?? '';
+    expect(flattened).not.toContain('\n');
+    expect(Array.from(flattened)).toHaveLength(40);
+    expect(flattened.endsWith('…')).toBe(true);
+
+    await unregisterSession();
+    resetRegisteredRecordPathForTest();
+    // Nothing left to address the session by: the derived name is a
+    // working handle, and an empty one would be unaddressable.
+    await registerSession({
+      sessionId: 's1',
+      cwd: '/w/app',
+      name: '\u0000\u0007',
+    });
+    expect((await listLiveSessions())[0]?.name).toMatch(/^app-[0-9a-f]{2}$/);
   });
 
   it('records an explicit null qwenVersion when it is omitted', async () => {
@@ -1301,6 +1370,31 @@ describe('listLiveSessions', () => {
     );
     expect(await listLiveSessions()).toEqual([liveBody()]);
   });
+
+  it('keeps a kind it has never heard of, as its writer wrote it', async () => {
+    // Forward compatibility: a newer build may register a kind this one
+    // does not know, and replacing it with a guess would lose the one
+    // thing the record actually says about itself.
+    await writeRaw(`${process.pid}.json`, liveBody({ kind: 'relay-2' }));
+    expect((await listLiveSessions())[0]?.kind).toBe('relay-2');
+  });
+
+  it.each([
+    ['not a string', 42],
+    ['empty', ''],
+    ['uppercase', 'Serve'],
+    ['over sixteen characters', 'a'.repeat(17)],
+    ['shaped like a path', '../../etc'],
+  ])(
+    'drops a kind that is %s, rather than passing it on',
+    async (_what, kind) => {
+      // Dropped, not defaulted: absent has a meaning of its own, and
+      // `describeSessionKind` is the single place that decides how it reads.
+      // A record is otherwise usable, so the field goes and the record stays.
+      await writeRaw(`${process.pid}.json`, liveBody({ kind }));
+      expect(await listLiveSessions()).toEqual([liveBody()]);
+    },
+  );
 
   it.each([
     ['a string schemaVersion', { schemaVersion: '1' }],

--- a/packages/core/src/services/session-registry.ts
+++ b/packages/core/src/services/session-registry.ts
@@ -69,6 +69,7 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { Storage } from '../config/storage.js';
+import { flattenPeerLabel } from '../ipc/peer-envelope.js';
 import { atomicWriteJSON } from '../utils/atomicFileWrite.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -114,6 +115,49 @@ const TEMP_FILENAME = /^\d+\.json\.[0-9a-f]{12}\.tmp$/;
 /** Younger temps may belong to a writer mid-rename — leave them alone. */
 const TEMP_MAX_AGE_MS = 5 * 60 * 1000;
 
+/**
+ * What kind of process registered: an interactive terminal, a
+ * `qwen --acp` process running on its own, one the daemon spawned, or a
+ * program that is not Qwen Code at all.
+ *
+ * A label for listings and for aggregators that want to tell a user's own
+ * terminals apart from sessions something else is driving. Nothing that
+ * decides trust reads it: a record is written by the process it
+ * describes, so this is a claim like `name` and `cwd`. What a sender may
+ * do is decided by what its connection presents (see `uds-inbox.ts`).
+ */
+export type SessionKind = 'tui' | 'headless' | 'serve' | 'external';
+
+/** The kinds this build writes. Readers accept more; see {@link KIND_RE}. */
+export const SESSION_KINDS: readonly SessionKind[] = [
+  'tui',
+  'headless',
+  'serve',
+  'external',
+];
+
+/**
+ * What a reader keeps in `kind`.
+ *
+ * Deliberately wider than {@link SESSION_KINDS}: a newer build may write a
+ * kind this one has never heard of, and dropping it would make that
+ * indistinguishable from a record too old to carry one — which is the one
+ * case that reads as `tui`. Bounded and shape-checked like every other
+ * field that crosses a process boundary.
+ */
+const KIND_RE = /^[a-z][a-z0-9-]{0,15}$/;
+
+/**
+ * Longest explicit display name kept.
+ *
+ * Derived names are short by construction, but an explicit one comes from
+ * a caller and lands in `qwen sessions ps` and in peer listings, so it
+ * gets what a peer-supplied label gets: flattened to one line, then
+ * bounded. Shorter than the envelope's 200 because this one is printed in
+ * a fixed-width table column.
+ */
+export const MAX_SESSION_NAME_CHARS = 40;
+
 /** One live session, as recorded on disk. */
 export interface SessionRegistryRecord {
   schemaVersion: number;
@@ -132,6 +176,15 @@ export interface SessionRegistryRecord {
   /** Epoch milliseconds. */
   startedAt: number;
   qwenVersion: string | null;
+  /**
+   * What registered this session; see {@link SessionKind}.
+   *
+   * Typed as `string` rather than `SessionKind` because a reader keeps a
+   * kind it does not recognize (a newer build's) rather than dropping it.
+   * Absent means the writer predates the field, which is the interactive
+   * UI: nothing else registered before it existed.
+   */
+  kind?: string;
   /**
    * Path to this session's peer-messaging socket, when it has one.
    *
@@ -160,6 +213,48 @@ export interface RegisterSessionFields {
   sessionId: string;
   cwd: string;
   qwenVersion?: string | null;
+  /** What is registering. Defaults to `tui`, the only historical writer. */
+  kind?: SessionKind;
+  /**
+   * Display name to record instead of the derived one.
+   *
+   * For a caller whose directory says nothing useful about it — a voice
+   * front-end or a relay wants to be called what its user calls it, not
+   * after whatever directory it happens to have started in. Flattened and
+   * bounded on the way in; one that flattens to nothing falls back to the
+   * derived name rather than recording a session nobody can address.
+   */
+  name?: string;
+}
+
+/**
+ * The name to record: an explicit one, flattened and bounded, or the one
+ * derived from the working directory.
+ */
+function resolveSessionName(fields: RegisterSessionFields): string {
+  const explicit = flattenPeerLabel(fields.name ?? '');
+  if (explicit.length === 0) {
+    return deriveSessionName(fields.cwd, fields.sessionId);
+  }
+  // Counted in code points, like `deriveSessionName`'s own cap: slicing
+  // UTF-16 units can cut an astral character into a lone surrogate.
+  const points = Array.from(explicit);
+  return points.length > MAX_SESSION_NAME_CHARS
+    ? `${points.slice(0, MAX_SESSION_NAME_CHARS - 1).join('')}…`
+    : explicit;
+}
+
+/**
+ * How to describe a record's `kind` to a person.
+ *
+ * An unrecognized kind is passed through rather than replaced: it was
+ * written by a build that knows something this one does not, and showing
+ * the writer's own word is more useful than showing "unknown". An absent
+ * one reads as `tui` — the interactive UI was the only registrant before
+ * the field existed.
+ */
+export function describeSessionKind(kind: string | undefined): string {
+  return kind === undefined || kind.length === 0 ? 'tui' : kind;
 }
 
 export function getSessionRegistryDir(): string {
@@ -295,9 +390,10 @@ export async function registerSession(
     pidNs,
     sessionId: fields.sessionId,
     cwd: fields.cwd,
-    name: deriveSessionName(fields.cwd, fields.sessionId),
+    name: resolveSessionName(fields),
     startedAt: Date.now(),
     qwenVersion: fields.qwenVersion ?? null,
+    kind: fields.kind ?? 'tui',
   };
 
   try {
@@ -727,6 +823,7 @@ async function readRecord(filePath: string): Promise<ReadRecordResult> {
   const procStart = value['procStart'];
   const pidNs = value['pidNs'];
   const qwenVersion = value['qwenVersion'];
+  const kind = value['kind'];
   const ipcPath = value['ipcPath'];
   const ipcToken = value['ipcToken'];
 
@@ -742,6 +839,11 @@ async function readRecord(filePath: string): Promise<ReadRecordResult> {
       name,
       startedAt,
       qwenVersion: typeof qwenVersion === 'string' ? qwenVersion : null,
+      // Dropped rather than defaulted when it is missing or malformed:
+      // absent has a meaning of its own (a writer older than the field),
+      // and `describeSessionKind` is the one place that decides how that
+      // reads. A value this build does not know is kept as written.
+      ...(typeof kind === 'string' && KIND_RE.test(kind) ? { kind } : {}),
       // Optional rather than nulled: absent and empty both mean "not
       // messageable", and a record written before this field existed must
       // read back identically to one written after it.

--- a/packages/core/src/tools/list-agents.test.ts
+++ b/packages/core/src/tools/list-agents.test.ts
@@ -33,6 +33,7 @@ function peerRow(over: Record<string, unknown> = {}) {
     ref: 'abc123',
     cwd: '/w/docs',
     pid: 200,
+    kind: 'tui',
     ipcPath: '/tmp/s1.sock',
     startedAt: 1_700_000_000_000,
     ...over,
@@ -222,10 +223,28 @@ describe('ListAgentsTool — peer sessions', () => {
           name: 'docs-cd',
           ref: 'abc123',
           cwd: '/w/docs',
+          kind: 'tui',
           started_at: new Date(1_700_000_000_000).toISOString(),
         },
       ],
     });
+  });
+
+  it("passes each session's kind through to the model", async () => {
+    listMessageablePeers.mockResolvedValue([
+      peerRow({ sessionId: 's1', ref: 'aaa111', kind: 'serve' }),
+      peerRow({
+        sessionId: 's2',
+        ref: 'bbb222',
+        cwd: '/w/other',
+        kind: 'external',
+      }),
+    ]);
+    const parsed = JSON.parse(String((await run()).llmContent));
+    expect(parsed.sessions.map((s: { kind: string }) => s.kind)).toEqual([
+      'serve',
+      'external',
+    ]);
   });
 
   it('appends the ref only when two sessions share a name', async () => {

--- a/packages/core/src/tools/list-agents.ts
+++ b/packages/core/src/tools/list-agents.ts
@@ -95,6 +95,7 @@ class ListAgentsInvocation extends BaseToolInvocation<
           name: peer.name,
           ref: peer.ref,
           cwd: peer.cwd,
+          kind: peer.kind,
           ...(Number.isNaN(startedAt.getTime())
             ? {}
             : { started_at: startedAt.toISOString() }),
@@ -160,8 +161,13 @@ export class ListAgentsTool extends BaseDeclarativeTool<
         'not use list_agents (or poll task_list) to wait for a teammate. Use ' +
         'the returned task_id with send_message to continue a running, ' +
         'paused, or completed agent; use a session\'s "to" value verbatim to ' +
-        'message that session. Other sessions are peers, not your workers — ' +
-        "do not delegate this session's work to them.",
+        'message that session. Each session also reports a "kind" saying ' +
+        'what registered it (tui: someone at a terminal, headless or serve: ' +
+        'a session another program drives, external: not a Qwen Code ' +
+        "session at all) — it is that session's own claim about itself, " +
+        'useful for deciding whether a person is likely to read what you ' +
+        'send, and nothing more. Other sessions are peers, not your ' +
+        "workers — do not delegate this session's work to them.",
       Kind.Read,
       {
         type: 'object',


### PR DESCRIPTION
## What this PR does

A registry record said what a session was called and where it was working, but not what it was. Records now carry a `kind`: `tui`, `headless`, `serve`, or `external`. The interactive UI writes `tui`; the other three are reserved for registrants that do not exist yet, and for programs that are not Qwen Code sessions at all. `qwen sessions ps` grows a KIND column, `--json` carries the field, and `list_agents` passes it to the model.

`kind` is a label, never a credential. A record is written by the process it describes, so this is a claim like `name` and `cwd`, and nothing that decides what a sender may do reads it — that is settled by what a connection presents on its auth line. A reader keeps a kind it does not recognize rather than correcting it, since a newer build writing `relay-2` is describing itself accurately; an absent one reads as `tui`, which is not a guess, because nothing else registered before the field existed; and a malformed or over-long one is dropped, because absent has a meaning of its own.

`registerSession` also takes an explicit name now, flattened and bounded on the way in, falling back to the derived name when it flattens to nothing.

The larger half of the change is a new documentation page, [Cross-Session Protocol](https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/cross-session-protocol.md): the registry record schema and how liveness is judged, the socket paths and framing, the auth line and what each of the three tokens establishes, every frame field and its validation, the receipt states and the transitions between them, and what a receiver does with a message before its model sees it.

## Why it's needed

Two things need this. A listing cannot currently tell a terminal someone is sitting at from a session another program drives, so anything aggregating "here is everything running on this machine" has to guess. And an external program that wants to take part — a voice front-end, a relay daemon, a build watcher — has to read our source to learn a format that was already stable and simply never written down.

Both are what [#10118](https://github.com/QwenLM/qwen-code/issues/10118) M3 needs from this side: `session_list` aggregating the registry with a managed / user-owned distinction, and a non-Qwen-Code process registering itself well enough to be addressed and to receive delivery receipts. The page is explicit that the auth line is the whole trust model, so nobody reads `kind: "external"` as something to lean on.

## Reviewer Test Plan

### How to verify

Unit suites cover the read guard (a malformed, empty, uppercase, over-long or path-shaped `kind` is dropped; an unknown-but-well-formed one is kept), the explicit-name flattening and its fallback, the projection into `list_agents`, and the table layout including truncation of an over-wide kind.

```
packages/core: npx vitest run src/services src/ipc src/tools/list-agents.test.ts   # 80 files, 3519 passed
packages/cli:  npx vitest run src/commands/sessions src/peerMessaging             # 7 files, 161 passed
tsc --noEmit clean for core and cli; eslint and prettier clean on every changed file
```

End to end, against a scoped `QWEN_HOME` and the built bundle: start an interactive session and confirm its record carries `kind: "tui"` and that `qwen sessions ps` shows it in the KIND column; then register a program that is not a Qwen Code session by following the new page and nothing else — bind an inbox, `rename` a 0600 temp file over `<pid>.json` with `kind: "external"` and an explicit name — and confirm it is listed, that `--json` carries the kind while still stripping the inbox token, and that the projection `list_agents` hands the model carries it too. Finally, write out the documented auth line and user frame by hand and send them over the socket, to check that the format on the page is the real one.

### Evidence (Before & After)

Before — the same listing on `main`, with no way to tell the two kinds of registrant apart (and the external program not shown at all, since only the interactive UI registers):

```
NAME                  PID      AGE       DIRECTORY
ws-plain-85           87335    43s       /run/user/1001/smoke-d1/ws-plain
```

After:

```
$ qwen sessions ps
NAME                  KIND      PID      AGE       DIRECTORY
live                  external  87515    11s       /run/user/1001/smoke-d1
live                  external  87440    20s       /run/user/1001/smoke-d1
ws-plain-85           tui       87335    43s       /run/user/1001/smoke-d1/ws-plain
```

`--json`, with the inbox token still stripped:

```
{'name': 'live', 'kind': 'external', 'pid': 87515, …}   ipcToken present: False
{'name': 'ws-plain-85', 'kind': 'tui', 'pid': 87335, …} ipcToken present: False
```

The projection behind `list_agents`:

```
{"name":"live","kind":"external","ref":"6ef817"}
{"name":"ws-plain-85","kind":"tui","ref":"855286"}
```

The hand-written frame, sent as the page describes (auth line first, one write, half-close), reaching the gate and being judged by it:

```
Held a message from another session (the sender and this session are in different review modes: one reviews each action and the other can apply some without per-action review). 1 waiting — /peers to review.
```

And the empty listing, in its new wording:

```
$ qwen sessions ps
No Qwen Code sessions are registered right now.
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Built bundle (`node scripts/cli-entry.js`) against a scoped `QWEN_HOME` under `XDG_RUNTIME_DIR`, Linux.

## Risk & Scope

- Main risk or tradeoff: `kind` is a self-report, and someone could take it for more than it is. The page and the tool description both say what it is worth in as many words, and no code path branches on it. The one behavioural change beyond the added field is cosmetic: `qwen sessions ps` gains a column and its empty-listing sentence changed, so anything scraping the human-readable table (rather than `--json`, which is the documented machine surface) sees a different layout.
- Not validated / out of scope: `serve` and `headless` are reserved but nothing writes them yet — daemon-managed sessions still do not register, which is the next change. Name yielding, a rename control frame, and same-name reporting are named in the page as unsettled and are not attempted here.
- Breaking changes / migration notes: none. `kind` is optional and additive; a record written by an older build reads back exactly as before, and a reader older than this change ignores the field.

## Linked Issues

Part of #10925
Unblocks #10118 (M3)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

注册记录里有会话叫什么、在哪个目录工作，却没有"它是什么"。现在记录多一个 `kind`：`tui`、`headless`、`serve`、`external`。交互式界面写 `tui`；另外三种留给尚不存在的注册方，以及根本不是 Qwen Code 会话的程序。`qwen sessions ps` 增加 KIND 列，`--json` 带上该字段，`list_agents` 也把它交给模型。

`kind` 是标签，不是凭据。记录由它所描述的那个进程自己写，所以这和 `name`、`cwd` 一样是自述，任何决定"发送方能做什么"的代码都不读它——那是由连接在 auth 行出示的东西决定的。读取方遇到不认识的 kind 会原样保留而不是改写，因为新版本写的 `relay-2` 是它对自己的准确描述；缺省读作 `tui`，这不是猜测，因为该字段存在之前没有别的注册方；格式错误或过长的一律丢弃，因为"缺省"本身有含义。

`registerSession` 现在也接受显式名字，写入时先扁平化并限长，扁平化后为空则回退到派生名。

改动里更大的一半是一页新文档 [Cross-Session Protocol](https://github.com/QwenLM/qwen-code/blob/main/docs/users/features/cross-session-protocol.md)：注册记录的 schema 与存活判定、socket 路径与分帧、auth 行以及三种令牌各自证明了什么、每个帧字段及其校验、回执状态与状态转移，以及接收方在模型看到消息之前对它做了什么。

## 为什么需要

两件事需要它。一是现在的列表分不清"有人守着的终端"和"被别的程序驱动的会话"，任何想聚合"这台机器上在跑什么"的东西只能靠猜。二是想接入的外部程序——语音前端、中继守护进程、构建监视器——必须读我们的源码才能知道一套本来就稳定、只是从没写下来的格式。

这两点正是 [#10118](https://github.com/QwenLM/qwen-code/issues/10118) M3 需要本线提供的：`session_list` 聚合注册表并区分 managed / user-owned，以及非 Qwen Code 进程把自己注册到能被寻址、能收到投递回执的程度。文档明确写了 auth 行就是信任模型的全部，因此没人会把 `kind: "external"` 当成可以依赖的东西。

## 评审者验证计划

### 如何验证

单测覆盖读取侧的守卫（格式错误、空、大写、超长、路径形状的 `kind` 一律丢弃；格式合法但未知的保留）、显式名字的扁平化与回退、到 `list_agents` 的投影，以及表格布局（含过宽 kind 的截断）。

```
packages/core: npx vitest run src/services src/ipc src/tools/list-agents.test.ts   # 80 文件，3519 通过
packages/cli:  npx vitest run src/commands/sessions src/peerMessaging             # 7 文件，161 通过
core 与 cli 的 tsc --noEmit 均无错；所有改动文件 eslint、prettier 干净
```

端到端：在受限的 `QWEN_HOME` 下用构建产物启动一个交互会话，确认记录带 `kind: "tui"` 且 `qwen sessions ps` 在 KIND 列显示；随后只依据这页新文档注册一个并非 Qwen Code 会话的程序——绑定 inbox，把 0600 临时文件 `rename` 成 `<pid>.json`，带 `kind: "external"` 和显式名字——确认它出现在列表里、`--json` 带 kind 且仍然剥掉 inbox 令牌、`list_agents` 使用的投影同样带上 kind。最后手写文档里的 auth 行和 user 帧发过去，检验文档写的格式就是真正的格式。

### 证据（前后对比）

之前——`main` 上同样的列表，无法区分两类注册方（而且外部程序根本不会出现，因为只有交互式界面会注册）：

```
NAME                  PID      AGE       DIRECTORY
ws-plain-85           87335    43s       /run/user/1001/smoke-d1/ws-plain
```

之后：

```
$ qwen sessions ps
NAME                  KIND      PID      AGE       DIRECTORY
live                  external  87515    11s       /run/user/1001/smoke-d1
live                  external  87440    20s       /run/user/1001/smoke-d1
ws-plain-85           tui       87335    43s       /run/user/1001/smoke-d1/ws-plain
```

`--json`，inbox 令牌仍被剥掉：

```
{'name': 'live', 'kind': 'external', 'pid': 87515, …}   ipcToken present: False
{'name': 'ws-plain-85', 'kind': 'tui', 'pid': 87335, …} ipcToken present: False
```

`list_agents` 背后的投影：

```
{"name":"live","kind":"external","ref":"6ef817"}
{"name":"ws-plain-85","kind":"tui","ref":"855286"}
```

按文档手写的帧（auth 行在前，一次写入，半关闭）抵达闸门并被它判定：

```
Held a message from another session (the sender and this session are in different review modes: one reviews each action and the other can apply some without per-action review). 1 waiting — /peers to review.
```

以及空列表的新措辞：

```
$ qwen sessions ps
No Qwen Code sessions are registered right now.
```

### 测试环境

|    系统    |  状态  |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

构建产物（`node scripts/cli-entry.js`），在 `XDG_RUNTIME_DIR` 下的受限 `QWEN_HOME` 中运行，Linux。

## 风险与范围

- 主要风险或权衡：`kind` 是自述字段，有人可能把它当成更强的东西。文档和工具描述都明确写了它值多少，也没有任何代码路径依据它分支。除新增字段外唯一的行为变化是外观上的：`qwen sessions ps` 多了一列、空列表那句话改了措辞，所以任何在抓取人类可读表格（而不是文档规定的机器接口 `--json`）的东西会看到不同的排版。
- 未验证 / 不在范围内：`serve` 与 `headless` 已保留但暂时没有写入方——daemon 托管的会话仍未注册，那是下一步。同名让步、rename 控制帧、同名报告都在文档中列为未定，本 PR 不做。
- 破坏性变更 / 迁移说明：无。`kind` 是可选的增量字段；旧版本写的记录读回来与以前完全一致，早于本改动的读取方会忽略该字段。

## 关联 Issue

Part of #10925
Unblocks #10118 (M3)

</details>
