### PR TITLE
fix(serve): reconnect evicted SSE clients

### DIFF
--- a/packages/cli/src/serve/routes/sse-events.ts
+++ b/packages/cli/src/serve/routes/sse-events.ts
@@ -326,6 +326,27 @@ export function registerSseEventsRoutes(
         );
         closeReason = 'event_bus_evicted';
         terminalEventType = 'client_evicted';
+        try {
+          res.write(
+            formatSseFrame({
+              v: 1,
+              type: 'client_evicted',
+              data: {
+                reason: diagnostic.data.reason,
+                droppedAfter: diagnostic.data.droppedAfter,
+                queueSize: diagnostic.data.queueSize,
+                maxQueued: diagnostic.data.maxQueued,
+                queuedBytes: diagnostic.data.queuedBytes,
+                maxQueuedBytes: diagnostic.data.maxQueuedBytes,
+                ...(diagnostic.data.eventBytes === undefined
+                  ? {}
+                  : { eventBytes: diagnostic.data.eventBytes }),
+              },
+            }),
+          );
+        } catch {
+          /* socket already destroyed; reconnect still proceeds. */
+        }
         res.destroy();
       }
       return handled;
@@ -1053,7 +1074,7 @@ export function registerSseEventsRoutes(
         }
       } finally {
         cleanup();
-        if (!res.writableEnded) res.end();
+        if (!res.destroyed && !res.writableEnded) res.end();
       }
     })();
   });

--- a/packages/cli/src/serve/routes/sse-events.ts
+++ b/packages/cli/src/serve/routes/sse-events.ts
@@ -214,6 +214,8 @@ export function registerSseEventsRoutes(
     };
     let slowWarningCount = 0;
     let eventBusEvictionReason: string | undefined;
+    let closeReason: SseCloseReason | undefined;
+    let terminalEventType: string | undefined;
     const onSubscriberDiagnostic = (
       diagnostic: EventBusSubscriberDiagnostic,
     ): boolean => {
@@ -322,6 +324,9 @@ export function registerSseEventsRoutes(
               : {}),
           },
         );
+        closeReason = 'event_bus_evicted';
+        terminalEventType = 'client_evicted';
+        res.destroy();
       }
       return handled;
     };
@@ -449,9 +454,7 @@ export function registerSseEventsRoutes(
     }
 
     const openedAt = performance.now();
-    let closeReason: SseCloseReason | undefined;
     let terminalCandidate: SseCloseReason | undefined;
-    let terminalEventType: string | undefined;
     let eventFramesWriteSettled = 0;
     let lastEventIdWritten: number | undefined;
     let backpressureCount = 0;

--- a/packages/cli/src/serve/routes/sse-events.ts
+++ b/packages/cli/src/serve/routes/sse-events.ts
@@ -326,22 +326,15 @@ export function registerSseEventsRoutes(
         );
         closeReason = 'event_bus_evicted';
         terminalEventType = 'client_evicted';
+        const evictionData = { ...diagnostic.data };
+        Reflect.deleteProperty(evictionData, 'triggerEventType');
+        Reflect.deleteProperty(evictionData, 'triggerEventBytes');
         try {
           res.write(
             formatSseFrame({
               v: 1,
               type: 'client_evicted',
-              data: {
-                reason: diagnostic.data.reason,
-                droppedAfter: diagnostic.data.droppedAfter,
-                queueSize: diagnostic.data.queueSize,
-                maxQueued: diagnostic.data.maxQueued,
-                queuedBytes: diagnostic.data.queuedBytes,
-                maxQueuedBytes: diagnostic.data.maxQueuedBytes,
-                ...(diagnostic.data.eventBytes === undefined
-                  ? {}
-                  : { eventBytes: diagnostic.data.eventBytes }),
-              },
+              data: evictionData,
             }),
           );
         } catch {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -35984,7 +35984,10 @@ describe('GET /session/:id/events (SSE)', () => {
       .get('/session/sess-%E2%80%A8A/events?connectReason=resume')
       .set('Host', `127.0.0.1:${baseOpts.port}`)
       .set('X-Qwen-Client-Id', 'client-1')
-      .then((response) => response);
+      .then(
+        (response) => response,
+        (error: Error) => error,
+      );
 
     await vi.waitFor(() => {
       expect(subscribeOptions?.onSubscriberDiagnostic).toBeTypeOf('function');
@@ -36049,7 +36052,7 @@ describe('GET /session/:id/events (SSE)', () => {
 
     release.resolve();
     const res = await responsePromise;
-    expect(res.headers['x-qwen-sse-stream-id']).toBe(streamId);
+    expect(res).toBeInstanceOf(Error);
     expect(getActiveSseCount()).toBe(beforeActive);
   });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -36053,7 +36053,12 @@ describe('GET /session/:id/events (SSE)', () => {
     release.resolve();
     const res = await responsePromise;
     expect(res).toBeInstanceOf(Error);
-    expect(getActiveSseCount()).toBe(beforeActive);
+    // `res.destroy()` tears the client socket down before the server-side
+    // 'close' listener runs, so the active-stream counter settles a tick
+    // after the request promise rejects.
+    await vi.waitFor(() => {
+      expect(getActiveSseCount()).toBe(beforeActive);
+    });
   });
 
   it('starts live lag measurement only after replay_complete settles', async () => {


### PR DESCRIPTION
## What this PR does

When the daemon evicts an SSE subscriber because its queue overflowed, immediately close that subscriber's HTTP response. The Web Shell then uses its existing bounded reconnect loop and `Last-Event-ID` cursor to resume the same session.

## Why it's needed

The eviction event currently travels through the same response writer that is already blocked on backpressure. If that writer never drains, the eviction frame is never consumed, the response never reaches its normal close path, and the browser receives neither the terminal frame nor EOF. The session keeps running, but the pane cannot start its existing reconnect path until a manual reload.

## Reviewer Test Plan

### How to verify

Attach an SSE consumer with a small queue limit, stop it from consuming quickly enough, and publish enough session events to trigger queue eviction. Confirm that the old HTTP stream closes promptly, a new subscription resumes from its last delivered event ID, and the underlying session turn is not cancelled. Also confirm that healthy subscribers remain connected.

### Evidence (Before & After)

Before: daemon logs show `queue_overflow`, but a backpressured response can remain open and the pane does not reconnect until reload.

After: the route first bypasses the blocked writer chain to attempt the synthetic `client_evicted` frame, then closes only the evicted response, which activates the existing Web Shell resume path. The existing route diagnostic test asserts that eviction terminates the response.

UI verification: N/A. This changes the daemon transport recovery boundary and does not modify UI rendering.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

The failure mechanism and the v0.23.1 daemon configuration were verified on Linux. No local test, build, typecheck, or CI command was run, following the requested local workflow constraint. `git diff --check` and static review completed cleanly.

## Risk & Scope

- Main risk or tradeoff: the direct terminal-frame write is best-effort when the socket send buffer is already full; closing the socket still guarantees that reconnect/replay can begin.
- Not validated / out of scope: daemon restart recovery, model-stream idle watchdogs, and host turn-settlement callbacks.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #11119

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 daemon 因 SSE 订阅者队列溢出而淘汰该订阅者时，立即关闭这一个订阅者的 HTTP 响应。Web Shell 随后复用现有的有界重连循环和 `Last-Event-ID` 游标，恢复同一个 Session。

## 为什么需要

当前淘汰事件仍通过已经因背压阻塞的同一个响应 writer 发送。如果 writer 始终不再 drain，淘汰帧就无法被消费，响应也走不到正常关闭路径，浏览器既收不到终态帧也收不到 EOF。Session 仍在运行，但 pane 无法启动已有的重连路径，只能靠手动刷新恢复。

## Reviewer 验证计划

### 如何验证

用较小的队列上限连接一个 SSE 消费者，让它的消费速度落后，并发布足够多的 Session 事件以触发队列淘汰。确认旧 HTTP stream 会立即关闭，新订阅会从最后已交付的事件 ID 恢复，并且底层 Session turn 不会被取消；同时确认健康订阅者不受影响。

### 证据（Before & After）

Before：daemon 日志已经记录 `queue_overflow`，但受背压阻塞的响应可能一直保持打开，pane 直到手动刷新才会重连。

After：路由先绕过已阻塞的 writer chain，直接尝试写出合成的 `client_evicted` 帧，然后只关闭被淘汰的响应，从而触发现有 Web Shell 恢复路径。已有路由诊断测试会断言淘汰操作终止该响应。

UI 验证：N/A。本改动位于 daemon 传输恢复边界，不修改 UI 渲染。

### 已验证平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

已在 Linux 上核对故障机制和 v0.23.1 daemon 配置。按照要求，未在本地运行 test、build、typecheck 或 CI；`git diff --check` 和静态审查均通过。

## 风险与范围

- 主要风险或权衡：如果 socket 发送缓冲区已经占满，直接写终态帧仍然只能尽力而为；关闭 socket 仍能保证启动重连和 replay。
- 未验证 / 范围外：daemon 重启恢复、模型流 idle watchdog、宿主 turn-settlement callback。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #11119

</details>
