### PR TITLE
fix(bridge): keep pending permission/question across refreshed session loads

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6845,151 +6845,191 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
-  it('stops refetching the persisted page when a question arrives mid-fetch', async () => {
-    let pendingAnswer: Promise<unknown> | undefined;
-    let reopening = false;
-    let questionRegistered = false;
-    const handle = makeChannel({
-      loadSessionImpl: () => ({
+  it.each([
+    {
+      label: 'question',
+      sessionSuffix: 'question',
+      toolCall: {
+        toolCallId: 'q-mid-fetch',
+        title: 'Ask user 1 question',
         _meta: {
-          'qwen.session.loadReplay': {
-            v: 1,
-            updates: [
-              {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'initial prompt' },
-              },
-            ],
-          },
+          toolName: 'ask_user_question',
+          qwenInteractionKind: 'user_question',
+          qwenQuestions: [{ question: 'Continue?' }],
         },
-      }),
-      extMethodImpl: async (method, params) => {
-        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
-          throw new Error(`unexpected extMethod ${method}`);
-        }
-        if (reopening && pendingAnswer === undefined) {
-          // The question arrives while the reopened load's transcript fetch
-          // is in flight: publish + registration land before the page
-          // returns. Read the session id from the request itself — reading
-          // the later-declared `loaded` binding here would be a TDZ hazard
-          // if a cold load ever fetched a page.
-          pendingAnswer = (
-            handle.agentConnection as unknown as {
-              requestPermission(p: unknown): Promise<unknown>;
-            }
-          ).requestPermission({
-            sessionId: String(params['sessionId']),
-            toolCall: {
-              toolCallId: 'q-mid-fetch',
-              title: 'Ask user 1 question',
-              _meta: {
-                toolName: 'ask_user_question',
-                qwenInteractionKind: 'user_question',
-                qwenQuestions: [{ question: 'Continue?' }],
-              },
-            },
-            options: [
-              { optionId: 'proceed_once', name: 'Submit', kind: 'allow_once' },
-              { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
-            ],
-          });
-          await vi.waitFor(() =>
-            expect(
-              bridge.getSessionSummary(String(params['sessionId']))
-                ?.isWaitingForUserQuestion,
-            ).toBe(true),
-          );
-          // Recorded outside the production catch: a failed precondition
-          // inside this mock would otherwise be swallowed by
-          // refreshedReplayFieldsFor's catch and leave the test green
-          // without ever exercising the guarded path.
-          questionRegistered = true;
-        }
-        return {
-          v: 1,
-          sessionId: params['sessionId'],
-          events: [
-            {
-              v: 1,
-              type: 'session_update',
-              data: {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'persisted tail' },
-                _meta: { 'qwen.session.recordId': 'record-persisted' },
-              },
-            },
-          ],
-          hasMore: false,
-        };
       },
-    });
-    // Count only the refreshed-load loop's fetches (identified by the
-    // requested page size); the pagination-anchor backfill fetches with a
-    // different fixed limit and must not be attributed to the guard.
-    const loopTranscriptFetches = () =>
-      handle.agent.extMethodCalls.filter(
-        (call) =>
-          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
-          (call.params as { limit?: number }).limit === 100,
-      ).length;
-    const bridge = makeBridge({ channelFactory: async () => handle.channel });
-    const loaded = await bridge.loadSession({
-      sessionId: 'persisted-mid-fetch-question',
-      workspaceCwd: WS_A,
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
+      options: [
+        { optionId: 'proceed_once', name: 'Submit', kind: 'allow_once' },
+        { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
+      ],
+      waitFlag: 'isWaitingForUserQuestion' as const,
+      voteOptionId: 'proceed_once',
+      payloadMarks: ['Continue?', 'proceed_once'],
+    },
+    {
+      // The loop-exit break is kind-agnostic: a plain tool approval arriving
+      // mid-fetch must stop the retry exactly like a question does.
+      label: 'tool permission',
+      sessionSuffix: 'permission',
+      toolCall: {
+        toolCallId: 'perm-mid-fetch',
+        title: 'Run command',
+        kind: 'execute',
+      },
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
+      ],
+      waitFlag: 'isWaitingForPermission' as const,
+      voteOptionId: 'allow',
+      payloadMarks: ['Run command', 'allow'],
+    },
+  ])(
+    'stops refetching the persisted page when a $label arrives mid-fetch',
+    async (variant) => {
+      let pendingAnswer: Promise<unknown> | undefined;
+      let reopening = false;
+      let interactionRegistered = false;
+      const handle = makeChannel({
+        loadSessionImpl: () => ({
+          _meta: {
+            'qwen.session.loadReplay': {
+              v: 1,
+              updates: [
+                {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'initial prompt' },
+                },
+              ],
+            },
+          },
+        }),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+            throw new Error(`unexpected extMethod ${method}`);
+          }
+          if (reopening && pendingAnswer === undefined) {
+            // The interaction arrives while the reopened load's transcript
+            // fetch is in flight: publish + registration land before the
+            // page returns. Read the session id from the request itself —
+            // reading the later-declared `loaded` binding here would be a
+            // TDZ hazard if a cold load ever fetched a page.
+            pendingAnswer = (
+              handle.agentConnection as unknown as {
+                requestPermission(p: unknown): Promise<unknown>;
+              }
+            ).requestPermission({
+              sessionId: String(params['sessionId']),
+              toolCall: variant.toolCall,
+              options: variant.options,
+            });
+            await vi.waitFor(() =>
+              expect(
+                bridge.getSessionSummary(String(params['sessionId']))?.[
+                  variant.waitFlag
+                ],
+              ).toBe(true),
+            );
+            // Recorded outside the production catch: a failed precondition
+            // inside this mock would otherwise be swallowed by
+            // refreshedReplayFieldsFor's catch and leave the test green
+            // without ever exercising the guarded path.
+            interactionRegistered = true;
+          }
+          return {
+            v: 1,
+            sessionId: params['sessionId'],
+            events: [
+              {
+                v: 1,
+                type: 'session_update',
+                data: {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'persisted tail' },
+                  _meta: { 'qwen.session.recordId': 'record-persisted' },
+                },
+              },
+            ],
+            hasMore: false,
+          };
+        },
+      });
+      // Count only the refreshed-load loop's fetches (identified by the
+      // requested page size); the pagination-anchor backfill fetches with a
+      // different fixed limit and must not be attributed to the guard.
+      const loopTranscriptFetches = () =>
+        handle.agent.extMethodCalls.filter(
+          (call) =>
+            call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
+            (call.params as { limit?: number }).limit === 100,
+        ).length;
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const loaded = await bridge.loadSession({
+        sessionId: `persisted-mid-fetch-${variant.sessionSuffix}`,
+        workspaceCwd: WS_A,
+        historyReplay: 'response',
+        historyPageSize: 100,
+      });
 
-    // Premise: the cold load issues no fetch, so the one fetch asserted
-    // below belongs to the reopened load.
-    expect(loopTranscriptFetches()).toBe(0);
-    reopening = true;
-    const reopened = await bridge.loadSession({
-      sessionId: loaded.sessionId,
-      workspaceCwd: WS_A,
-      clientId: 'client-reopen',
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
+      // Premise: the cold load issues no fetch, so the one fetch asserted
+      // below belongs to the reopened load.
+      expect(loopTranscriptFetches()).toBe(0);
+      reopening = true;
+      const reopened = await bridge.loadSession({
+        sessionId: loaded.sessionId,
+        workspaceCwd: WS_A,
+        clientId: 'client-reopen',
+        historyReplay: 'response',
+        historyPageSize: 100,
+      });
 
-    expect(questionRegistered).toBe(true);
-    // Exactly one fetch: the interaction arrived mid-fetch, so the loop
-    // leaves instead of re-fetching a page that cannot contain it.
-    expect(loopTranscriptFetches()).toBe(1);
-    // The fetched page was discarded, not spliced in front of the journal.
-    expect(
-      [
-        ...(reopened.compactedReplay ?? []),
-        ...(reopened.liveJournal ?? []),
-      ].some((event) => JSON.stringify(event.data).includes('persisted tail')),
-    ).toBe(false);
+      expect(interactionRegistered).toBe(true);
+      // Exactly one fetch: the interaction arrived mid-fetch, so the loop
+      // leaves instead of re-fetching a page that cannot contain it.
+      expect(loopTranscriptFetches()).toBe(1);
+      // The fetched page was discarded, not spliced in front of the journal.
+      expect(
+        [
+          ...(reopened.compactedReplay ?? []),
+          ...(reopened.liveJournal ?? []),
+        ].some((event) =>
+          JSON.stringify(event.data).includes('persisted tail'),
+        ),
+      ).toBe(false);
 
-    const frame = (reopened.liveJournal ?? []).find(
-      (event) => event.type === 'permission_request',
-    );
-    expect(frame).toBeDefined();
-    expect(JSON.stringify(frame?.data)).toContain('Continue?');
-    expect(JSON.stringify(frame?.data)).toContain('proceed_once');
-    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
-      ?.requestId;
-    expect(frameRequestId).toBeDefined();
-    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
-      ?.pendingInteractions?.[0]?.requestId;
-    expect(frameRequestId).toBe(registryRequestId);
+      const frame = (reopened.liveJournal ?? []).find(
+        (event) => event.type === 'permission_request',
+      );
+      expect(frame).toBeDefined();
+      for (const mark of variant.payloadMarks) {
+        expect(JSON.stringify(frame?.data)).toContain(mark);
+      }
+      const frameRequestId = (frame?.data as { requestId?: string } | undefined)
+        ?.requestId;
+      expect(frameRequestId).toBeDefined();
+      const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
+        ?.pendingInteractions?.[0]?.requestId;
+      expect(frameRequestId).toBe(registryRequestId);
 
-    expect(
-      bridge.respondToSessionPermission(
-        loaded.sessionId,
-        frameRequestId!,
-        { outcome: { outcome: 'selected', optionId: 'proceed_once' } },
-        { clientId: reopened.clientId },
-      ),
-    ).toBe(true);
-    await expect(pendingAnswer).resolves.toEqual({
-      outcome: { outcome: 'selected', optionId: 'proceed_once' },
-    });
-    await bridge.shutdown();
-  });
+      expect(
+        bridge.respondToSessionPermission(
+          loaded.sessionId,
+          frameRequestId!,
+          {
+            outcome: {
+              outcome: 'selected',
+              optionId: variant.voteOptionId,
+            },
+          },
+          { clientId: reopened.clientId },
+        ),
+      ).toBe(true);
+      await expect(pendingAnswer).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: variant.voteOptionId },
+      });
+      await bridge.shutdown();
+    },
+  );
 
   it('keeps the current turn error when refreshing from persisted history', async () => {
     const handle = makeChannel({

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6699,10 +6699,17 @@ describe('createAcpSessionBridge', () => {
     const requestId = bridge.getSessionSummary(loaded.sessionId)
       ?.pendingInteractions?.[0]?.requestId;
     expect(requestId).toBeDefined();
-    bridge.respondToPermission(requestId!, {
+    // Delivery alone is not enough — the re-presented card must stay
+    // answerable: the vote must be accepted by the mediator and resolve the
+    // parked call with the user's selection.
+    expect(
+      bridge.respondToPermission(requestId!, {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).toBe(true);
+    await expect(pendingAnswer).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'proceed_once' },
     });
-    await pendingAnswer;
     await bridge.shutdown();
   });
 
@@ -6804,10 +6811,16 @@ describe('createAcpSessionBridge', () => {
     const requestId = bridge.getSessionSummary(loaded.sessionId)
       ?.pendingInteractions?.[0]?.requestId;
     expect(requestId).toBeDefined();
-    bridge.respondToPermission(requestId!, {
+    // The card delivered by the guarded load must stay answerable: the vote
+    // is accepted and resolves the parked call with the user's selection.
+    expect(
+      bridge.respondToPermission(requestId!, {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).toBe(true);
+    await expect(pendingAnswer).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'proceed_once' },
     });
-    await pendingAnswer;
     await bridge.shutdown();
   });
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6585,6 +6585,224 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('serves the in-memory journal on refreshed load while a question is pending', async () => {
+    const handle = makeChannel({
+      loadSessionImpl: () => ({
+        _meta: {
+          'qwen.session.loadReplay': {
+            v: 1,
+            updates: [
+              {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'initial prompt' },
+              },
+            ],
+          },
+        },
+      }),
+      extMethodImpl: (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        // The persisted page can never contain the pending question:
+        // permission requests are journaled in memory only.
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [
+            {
+              v: 1,
+              type: 'session_update',
+              data: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'persisted tail' },
+                _meta: { 'qwen.session.recordId': 'record-persisted' },
+              },
+            },
+          ],
+          hasMore: false,
+        };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-pending-question',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    // Park the session on an unanswered ask_user_question. A parked turn
+    // does not keep promptActive set, so the refreshed-load guard would
+    // otherwise serve the persisted page with an empty liveJournal —
+    // stranding the interaction (badge on, no card) for the re-opening
+    // client.
+    const pendingAnswer = (
+      handle.agentConnection as unknown as {
+        requestPermission(p: unknown): Promise<unknown>;
+      }
+    ).requestPermission({
+      sessionId: loaded.sessionId,
+      toolCall: {
+        toolCallId: 'q1',
+        title: 'Ask user 1 question',
+        _meta: {
+          toolName: 'ask_user_question',
+          qwenInteractionKind: 'user_question',
+          qwenQuestions: [{ question: 'Continue?' }],
+        },
+      },
+      options: [
+        { optionId: 'proceed_once', name: 'Submit', kind: 'allow_once' },
+        { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
+      ],
+    });
+    await vi.waitFor(() =>
+      expect(
+        bridge.getSessionSummary(loaded.sessionId)?.isWaitingForUserQuestion,
+      ).toBe(true),
+    );
+
+    const reopened = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: 'client-reopen',
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    expect(
+      (reopened.liveJournal ?? []).some(
+        (event) => event.type === 'permission_request',
+      ),
+    ).toBe(true);
+    // The guarded branch switches the history source to the in-memory
+    // replay; the session's prior history must survive the switch.
+    const reopenedEvents = [
+      ...(reopened.compactedReplay ?? []),
+      ...(reopened.liveJournal ?? []),
+    ];
+    expect(
+      reopenedEvents.some(
+        (event) =>
+          event.type === 'session_update' &&
+          JSON.stringify(event.data).includes('initial prompt'),
+      ),
+    ).toBe(true);
+
+    const requestId = bridge.getSessionSummary(loaded.sessionId)
+      ?.pendingInteractions?.[0]?.requestId;
+    expect(requestId).toBeDefined();
+    bridge.respondToPermission(requestId!, {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    });
+    await pendingAnswer;
+    await bridge.shutdown();
+  });
+
+  it('re-checks pending interactions at serve time when a question arrives mid-fetch', async () => {
+    let transcriptFetches = 0;
+    let pendingAnswer: Promise<unknown> | undefined;
+    const handle = makeChannel({
+      loadSessionImpl: () => ({
+        _meta: {
+          'qwen.session.loadReplay': {
+            v: 1,
+            updates: [
+              {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'initial prompt' },
+              },
+            ],
+          },
+        },
+      }),
+      extMethodImpl: async (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        transcriptFetches += 1;
+        if (transcriptFetches === 1) {
+          // The question arrives while the first transcript fetch is in
+          // flight: publish + registration land before the page returns.
+          pendingAnswer = (
+            handle.agentConnection as unknown as {
+              requestPermission(p: unknown): Promise<unknown>;
+            }
+          ).requestPermission({
+            sessionId: loaded.sessionId,
+            toolCall: {
+              toolCallId: 'q-mid-fetch',
+              title: 'Ask user 1 question',
+              _meta: {
+                toolName: 'ask_user_question',
+                qwenInteractionKind: 'user_question',
+                qwenQuestions: [{ question: 'Continue?' }],
+              },
+            },
+            options: [
+              { optionId: 'proceed_once', name: 'Submit', kind: 'allow_once' },
+              { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
+            ],
+          });
+          await vi.waitFor(() =>
+            expect(
+              bridge.getSessionSummary(loaded.sessionId)
+                ?.isWaitingForUserQuestion,
+            ).toBe(true),
+          );
+        }
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [
+            {
+              v: 1,
+              type: 'session_update',
+              data: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'persisted tail' },
+                _meta: { 'qwen.session.recordId': 'record-persisted' },
+              },
+            },
+          ],
+          hasMore: false,
+        };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-mid-fetch-question',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    const reopened = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: 'client-reopen',
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    expect(transcriptFetches).toBeGreaterThanOrEqual(1);
+    expect(
+      (reopened.liveJournal ?? []).some(
+        (event) => event.type === 'permission_request',
+      ),
+    ).toBe(true);
+
+    const requestId = bridge.getSessionSummary(loaded.sessionId)
+      ?.pendingInteractions?.[0]?.requestId;
+    expect(requestId).toBeDefined();
+    bridge.respondToPermission(requestId!, {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    });
+    await pendingAnswer;
+    await bridge.shutdown();
+  });
+
   it('keeps the current turn error when refreshing from persisted history', async () => {
     const handle = makeChannel({
       promptImpl: () => {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6585,73 +6585,10 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
-  it('serves the in-memory journal on refreshed load while a question is pending', async () => {
-    const handle = makeChannel({
-      loadSessionImpl: () => ({
-        _meta: {
-          'qwen.session.loadReplay': {
-            v: 1,
-            updates: [
-              {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'initial prompt' },
-              },
-            ],
-          },
-        },
-      }),
-      extMethodImpl: (method, params) => {
-        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
-          throw new Error(`unexpected extMethod ${method}`);
-        }
-        // The persisted page can never contain the pending question:
-        // permission requests are journaled in memory only.
-        return {
-          v: 1,
-          sessionId: params['sessionId'],
-          events: [
-            {
-              v: 1,
-              type: 'session_update',
-              data: {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'persisted tail' },
-                _meta: { 'qwen.session.recordId': 'record-persisted' },
-              },
-            },
-          ],
-          hasMore: false,
-        };
-      },
-    });
-    // Count only the refreshed-load loop's fetches (identified by the
-    // requested page size); the pagination-anchor backfill fetches with a
-    // different fixed limit and must not be attributed to the guard.
-    const loopTranscriptFetches = () =>
-      handle.agent.extMethodCalls.filter(
-        (call) =>
-          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
-          (call.params as { limit?: number }).limit === 100,
-      ).length;
-    const bridge = makeBridge({ channelFactory: async () => handle.channel });
-    const loaded = await bridge.loadSession({
-      sessionId: 'persisted-pending-question',
-      workspaceCwd: WS_A,
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
-
-    // Park the session on an unanswered ask_user_question. A parked
-    // Goal/background-notification turn does not keep promptActive set, so
-    // the refreshed-load guard would otherwise serve the persisted page with
-    // an empty liveJournal — stranding the interaction (badge on, no card)
-    // for the re-opening client.
-    const pendingAnswer = (
-      handle.agentConnection as unknown as {
-        requestPermission(p: unknown): Promise<unknown>;
-      }
-    ).requestPermission({
-      sessionId: loaded.sessionId,
+  it.each([
+    {
+      label: 'question',
+      sessionSuffix: 'question',
       toolCall: {
         toolCallId: 'q1',
         title: 'Ask user 1 question',
@@ -6665,134 +6602,16 @@ describe('createAcpSessionBridge', () => {
         { optionId: 'proceed_once', name: 'Submit', kind: 'allow_once' },
         { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
       ],
-    });
-    await vi.waitFor(() =>
-      expect(
-        bridge.getSessionSummary(loaded.sessionId)?.isWaitingForUserQuestion,
-      ).toBe(true),
-    );
-
-    const reopened = await bridge.loadSession({
-      sessionId: loaded.sessionId,
-      workspaceCwd: WS_A,
-      clientId: 'client-reopen',
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
-
-    const frame = (reopened.liveJournal ?? []).find(
-      (event) => event.type === 'permission_request',
-    );
-    expect(frame).toBeDefined();
-    // The re-presented card must carry the payload that makes it answerable
-    // (questions + options), not merely the frame's type.
-    expect(JSON.stringify(frame?.data)).toContain('Continue?');
-    expect(JSON.stringify(frame?.data)).toContain('proceed_once');
-    // The card the client renders must be the interaction the mediator
-    // accepts a vote for: the delivered frame's id equals the registry key.
-    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
-      ?.requestId;
-    expect(frameRequestId).toBeDefined();
-    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
-      ?.pendingInteractions?.[0]?.requestId;
-    expect(frameRequestId).toBe(registryRequestId);
-    // The guard's observable effect: no persisted-page fetch happens at all
-    // while an interaction is pending (this fixture's journal emits no
-    // history_truncated marker, so the anchor backfill fetches nothing here).
-    expect(loopTranscriptFetches()).toBe(0);
-    // The guarded branch switches the history source to the in-memory
-    // replay; the session's prior history must survive the switch.
-    const reopenedEvents = [
-      ...(reopened.compactedReplay ?? []),
-      ...(reopened.liveJournal ?? []),
-    ];
-    expect(
-      reopenedEvents.some(
-        (event) =>
-          event.type === 'session_update' &&
-          JSON.stringify(event.data).includes('initial prompt'),
-      ),
-    ).toBe(true);
-
-    // Delivery alone is not enough — the re-presented card must stay
-    // answerable for the client that just attached: vote with its
-    // registered identity through the session-scoped route.
-    expect(
-      bridge.respondToSessionPermission(
-        loaded.sessionId,
-        frameRequestId!,
-        { outcome: { outcome: 'selected', optionId: 'proceed_once' } },
-        { clientId: reopened.clientId },
-      ),
-    ).toBe(true);
-    await expect(pendingAnswer).resolves.toEqual({
-      outcome: { outcome: 'selected', optionId: 'proceed_once' },
-    });
-    await bridge.shutdown();
-  });
-
-  it('serves the in-memory journal on refreshed load while a tool permission is pending', async () => {
-    const handle = makeChannel({
-      loadSessionImpl: () => ({
-        _meta: {
-          'qwen.session.loadReplay': {
-            v: 1,
-            updates: [
-              {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'initial prompt' },
-              },
-            ],
-          },
-        },
-      }),
-      extMethodImpl: (method, params) => {
-        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
-          throw new Error(`unexpected extMethod ${method}`);
-        }
-        // The persisted page can never contain the pending interaction:
-        // permission requests are journaled in memory only.
-        return {
-          v: 1,
-          sessionId: params['sessionId'],
-          events: [
-            {
-              v: 1,
-              type: 'session_update',
-              data: {
-                sessionUpdate: 'user_message_chunk',
-                content: { type: 'text', text: 'persisted tail' },
-                _meta: { 'qwen.session.recordId': 'record-persisted' },
-              },
-            },
-          ],
-          hasMore: false,
-        };
-      },
-    });
-    const loopTranscriptFetches = () =>
-      handle.agent.extMethodCalls.filter(
-        (call) =>
-          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
-          (call.params as { limit?: number }).limit === 100,
-      ).length;
-    const bridge = makeBridge({ channelFactory: async () => handle.channel });
-    const loaded = await bridge.loadSession({
-      sessionId: 'persisted-pending-permission',
-      workspaceCwd: WS_A,
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
-
-    // The guard is kind-agnostic ("A pending permission/question"): park a
-    // plain tool-approval request with no question metadata. Narrowing the
-    // guard to the question kind must turn this test red.
-    const pendingAnswer = (
-      handle.agentConnection as unknown as {
-        requestPermission(p: unknown): Promise<unknown>;
-      }
-    ).requestPermission({
-      sessionId: loaded.sessionId,
+      waitFlag: 'isWaitingForUserQuestion' as const,
+      voteOptionId: 'proceed_once',
+      payloadMarks: ['Continue?', 'proceed_once'],
+    },
+    {
+      // The guard is kind-agnostic: a plain tool-approval request with no
+      // question metadata must be re-presented exactly like a question.
+      // Narrowing the guard to the question kind must turn this variant red.
+      label: 'tool permission',
+      sessionSuffix: 'permission',
       toolCall: {
         toolCallId: 'perm-1',
         title: 'Run command',
@@ -6802,50 +6621,155 @@ describe('createAcpSessionBridge', () => {
         { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
         { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
       ],
-    });
-    await vi.waitFor(() =>
+      waitFlag: 'isWaitingForPermission' as const,
+      voteOptionId: 'allow',
+      // 'allow' alone would be satisfied by the option kind ("allow_once")
+      // even if its optionId were stripped — match the frame's own spelling.
+      payloadMarks: ['Run command', '"optionId":"allow"'],
+    },
+  ])(
+    'serves the in-memory journal on refreshed load while a $label is pending',
+    async (variant) => {
+      const handle = makeChannel({
+        loadSessionImpl: () => ({
+          _meta: {
+            'qwen.session.loadReplay': {
+              v: 1,
+              updates: [
+                {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'initial prompt' },
+                },
+              ],
+            },
+          },
+        }),
+        extMethodImpl: (method, params) => {
+          if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+            throw new Error(`unexpected extMethod ${method}`);
+          }
+          // The persisted page can never contain the pending interaction:
+          // permission requests are journaled in memory only.
+          return {
+            v: 1,
+            sessionId: params['sessionId'],
+            events: [
+              {
+                v: 1,
+                type: 'session_update',
+                data: {
+                  sessionUpdate: 'user_message_chunk',
+                  content: { type: 'text', text: 'persisted tail' },
+                  _meta: { 'qwen.session.recordId': 'record-persisted' },
+                },
+              },
+            ],
+            hasMore: false,
+          };
+        },
+      });
+      // Count only the refreshed-load loop's fetches (identified by the
+      // requested page size); the pagination-anchor backfill fetches with a
+      // different fixed limit and must not be attributed to the guard.
+      const loopTranscriptFetches = () =>
+        handle.agent.extMethodCalls.filter(
+          (call) =>
+            call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
+            (call.params as { limit?: number }).limit === 100,
+        ).length;
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const loaded = await bridge.loadSession({
+        sessionId: `persisted-pending-${variant.sessionSuffix}`,
+        workspaceCwd: WS_A,
+        historyReplay: 'response',
+        historyPageSize: 100,
+      });
+
+      // Park the session on an unanswered interaction. A parked
+      // Goal/background-notification turn does not keep promptActive set, so
+      // the refreshed-load guard would otherwise serve the persisted page
+      // with an empty liveJournal — stranding the interaction (badge on, no
+      // card) for the re-opening client.
+      const pendingAnswer = (
+        handle.agentConnection as unknown as {
+          requestPermission(p: unknown): Promise<unknown>;
+        }
+      ).requestPermission({
+        sessionId: loaded.sessionId,
+        toolCall: variant.toolCall,
+        options: variant.options,
+      });
+      await vi.waitFor(() =>
+        expect(
+          bridge.getSessionSummary(loaded.sessionId)?.[variant.waitFlag],
+        ).toBe(true),
+      );
+
+      const reopened = await bridge.loadSession({
+        sessionId: loaded.sessionId,
+        workspaceCwd: WS_A,
+        clientId: 'client-reopen',
+        historyReplay: 'response',
+        historyPageSize: 100,
+      });
+
+      const frame = (reopened.liveJournal ?? []).find(
+        (event) => event.type === 'permission_request',
+      );
+      expect(frame).toBeDefined();
+      // The re-presented card must carry the payload that makes it
+      // answerable (questions + options), not merely the frame's type.
+      for (const mark of variant.payloadMarks) {
+        expect(JSON.stringify(frame?.data)).toContain(mark);
+      }
+      // The card the client renders must be the interaction the mediator
+      // accepts a vote for: the delivered frame's id equals the registry key.
+      const frameRequestId = (frame?.data as { requestId?: string } | undefined)
+        ?.requestId;
+      expect(frameRequestId).toBeDefined();
+      const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
+        ?.pendingInteractions?.[0]?.requestId;
+      expect(frameRequestId).toBe(registryRequestId);
+      // The guard's observable effect: no persisted-page fetch happens at all
+      // while an interaction is pending (this fixture's journal emits no
+      // history_truncated marker, so the anchor backfill fetches nothing).
+      expect(loopTranscriptFetches()).toBe(0);
+      // The guarded branch switches the history source to the in-memory
+      // replay; the session's prior history must survive the switch.
+      const reopenedEvents = [
+        ...(reopened.compactedReplay ?? []),
+        ...(reopened.liveJournal ?? []),
+      ];
       expect(
-        bridge.getSessionSummary(loaded.sessionId)?.isWaitingForPermission,
-      ).toBe(true),
-    );
+        reopenedEvents.some(
+          (event) =>
+            event.type === 'session_update' &&
+            JSON.stringify(event.data).includes('initial prompt'),
+        ),
+      ).toBe(true);
 
-    const reopened = await bridge.loadSession({
-      sessionId: loaded.sessionId,
-      workspaceCwd: WS_A,
-      clientId: 'client-reopen',
-      historyReplay: 'response',
-      historyPageSize: 100,
-    });
-
-    const frame = (reopened.liveJournal ?? []).find(
-      (event) => event.type === 'permission_request',
-    );
-    expect(frame).toBeDefined();
-    expect(JSON.stringify(frame?.data)).toContain('Run command');
-    // 'allow' alone would be satisfied by the option's kind ("allow_once")
-    // even if its optionId were stripped — match the frame's own spelling.
-    expect(JSON.stringify(frame?.data)).toContain('"optionId":"allow"');
-    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
-      ?.requestId;
-    expect(frameRequestId).toBeDefined();
-    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
-      ?.pendingInteractions?.[0]?.requestId;
-    expect(frameRequestId).toBe(registryRequestId);
-    expect(loopTranscriptFetches()).toBe(0);
-
-    expect(
-      bridge.respondToSessionPermission(
-        loaded.sessionId,
-        frameRequestId!,
-        { outcome: { outcome: 'selected', optionId: 'allow' } },
-        { clientId: reopened.clientId },
-      ),
-    ).toBe(true);
-    await expect(pendingAnswer).resolves.toEqual({
-      outcome: { outcome: 'selected', optionId: 'allow' },
-    });
-    await bridge.shutdown();
-  });
+      // Delivery alone is not enough — the re-presented card must stay
+      // answerable for the client that just attached: vote with its
+      // registered identity through the session-scoped route.
+      expect(
+        bridge.respondToSessionPermission(
+          loaded.sessionId,
+          frameRequestId!,
+          {
+            outcome: {
+              outcome: 'selected',
+              optionId: variant.voteOptionId,
+            },
+          },
+          { clientId: reopened.clientId },
+        ),
+      ).toBe(true);
+      await expect(pendingAnswer).resolves.toEqual({
+        outcome: { outcome: 'selected', optionId: variant.voteOptionId },
+      });
+      await bridge.shutdown();
+    },
+  );
 
   it.each([
     {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6586,7 +6586,6 @@ describe('createAcpSessionBridge', () => {
   });
 
   it('serves the in-memory journal on refreshed load while a question is pending', async () => {
-    let transcriptFetches = 0;
     const handle = makeChannel({
       loadSessionImpl: () => ({
         _meta: {
@@ -6605,7 +6604,6 @@ describe('createAcpSessionBridge', () => {
         if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
           throw new Error(`unexpected extMethod ${method}`);
         }
-        transcriptFetches += 1;
         // The persisted page can never contain the pending question:
         // permission requests are journaled in memory only.
         return {
@@ -6626,6 +6624,15 @@ describe('createAcpSessionBridge', () => {
         };
       },
     });
+    // Count only the refreshed-load loop's fetches (identified by the
+    // requested page size); the pagination-anchor backfill fetches with a
+    // different fixed limit and must not be attributed to the guard.
+    const loopTranscriptFetches = () =>
+      handle.agent.extMethodCalls.filter(
+        (call) =>
+          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
+          (call.params as { limit?: number }).limit === 100,
+      ).length;
     const bridge = makeBridge({ channelFactory: async () => handle.channel });
     const loaded = await bridge.loadSession({
       sessionId: 'persisted-pending-question',
@@ -6673,15 +6680,26 @@ describe('createAcpSessionBridge', () => {
       historyPageSize: 100,
     });
 
-    expect(
-      (reopened.liveJournal ?? []).some(
-        (event) => event.type === 'permission_request',
-      ),
-    ).toBe(true);
+    const frame = (reopened.liveJournal ?? []).find(
+      (event) => event.type === 'permission_request',
+    );
+    expect(frame).toBeDefined();
+    // The re-presented card must carry the payload that makes it answerable
+    // (questions + options), not merely the frame's type.
+    expect(JSON.stringify(frame?.data)).toContain('Continue?');
+    expect(JSON.stringify(frame?.data)).toContain('proceed_once');
+    // The card the client renders must be the interaction the mediator
+    // accepts a vote for: the delivered frame's id equals the registry key.
+    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
+      ?.requestId;
+    expect(frameRequestId).toBeDefined();
+    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
+      ?.pendingInteractions?.[0]?.requestId;
+    expect(frameRequestId).toBe(registryRequestId);
     // The guard's observable effect: no persisted-page fetch happens at all
     // while an interaction is pending (this fixture's journal emits no
     // history_truncated marker, so the anchor backfill fetches nothing here).
-    expect(transcriptFetches).toBe(0);
+    expect(loopTranscriptFetches()).toBe(0);
     // The guarded branch switches the history source to the in-memory
     // replay; the session's prior history must survive the switch.
     const reopenedEvents = [
@@ -6696,16 +6714,16 @@ describe('createAcpSessionBridge', () => {
       ),
     ).toBe(true);
 
-    const requestId = bridge.getSessionSummary(loaded.sessionId)
-      ?.pendingInteractions?.[0]?.requestId;
-    expect(requestId).toBeDefined();
     // Delivery alone is not enough — the re-presented card must stay
-    // answerable: the vote must be accepted by the mediator and resolve the
-    // parked call with the user's selection.
+    // answerable for the client that just attached: vote with its
+    // registered identity through the session-scoped route.
     expect(
-      bridge.respondToPermission(requestId!, {
-        outcome: { outcome: 'selected', optionId: 'proceed_once' },
-      }),
+      bridge.respondToSessionPermission(
+        loaded.sessionId,
+        frameRequestId!,
+        { outcome: { outcome: 'selected', optionId: 'proceed_once' } },
+        { clientId: reopened.clientId },
+      ),
     ).toBe(true);
     await expect(pendingAnswer).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'proceed_once' },
@@ -6713,9 +6731,124 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
+  it('serves the in-memory journal on refreshed load while a tool permission is pending', async () => {
+    const handle = makeChannel({
+      loadSessionImpl: () => ({
+        _meta: {
+          'qwen.session.loadReplay': {
+            v: 1,
+            updates: [
+              {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'initial prompt' },
+              },
+            ],
+          },
+        },
+      }),
+      extMethodImpl: (method, params) => {
+        if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
+          throw new Error(`unexpected extMethod ${method}`);
+        }
+        // The persisted page can never contain the pending interaction:
+        // permission requests are journaled in memory only.
+        return {
+          v: 1,
+          sessionId: params['sessionId'],
+          events: [
+            {
+              v: 1,
+              type: 'session_update',
+              data: {
+                sessionUpdate: 'user_message_chunk',
+                content: { type: 'text', text: 'persisted tail' },
+                _meta: { 'qwen.session.recordId': 'record-persisted' },
+              },
+            },
+          ],
+          hasMore: false,
+        };
+      },
+    });
+    const loopTranscriptFetches = () =>
+      handle.agent.extMethodCalls.filter(
+        (call) =>
+          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
+          (call.params as { limit?: number }).limit === 100,
+      ).length;
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const loaded = await bridge.loadSession({
+      sessionId: 'persisted-pending-permission',
+      workspaceCwd: WS_A,
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    // The guard is kind-agnostic ("A pending permission/question"): park a
+    // plain tool-approval request with no question metadata. Narrowing the
+    // guard to the question kind must turn this test red.
+    const pendingAnswer = (
+      handle.agentConnection as unknown as {
+        requestPermission(p: unknown): Promise<unknown>;
+      }
+    ).requestPermission({
+      sessionId: loaded.sessionId,
+      toolCall: {
+        toolCallId: 'perm-1',
+        title: 'Run command',
+        kind: 'execute',
+      },
+      options: [
+        { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+        { optionId: 'cancel', name: 'Cancel', kind: 'reject_once' },
+      ],
+    });
+    await vi.waitFor(() =>
+      expect(
+        bridge.getSessionSummary(loaded.sessionId)?.isWaitingForPermission,
+      ).toBe(true),
+    );
+
+    const reopened = await bridge.loadSession({
+      sessionId: loaded.sessionId,
+      workspaceCwd: WS_A,
+      clientId: 'client-reopen',
+      historyReplay: 'response',
+      historyPageSize: 100,
+    });
+
+    const frame = (reopened.liveJournal ?? []).find(
+      (event) => event.type === 'permission_request',
+    );
+    expect(frame).toBeDefined();
+    expect(JSON.stringify(frame?.data)).toContain('Run command');
+    expect(JSON.stringify(frame?.data)).toContain('allow');
+    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
+      ?.requestId;
+    expect(frameRequestId).toBeDefined();
+    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
+      ?.pendingInteractions?.[0]?.requestId;
+    expect(frameRequestId).toBe(registryRequestId);
+    expect(loopTranscriptFetches()).toBe(0);
+
+    expect(
+      bridge.respondToSessionPermission(
+        loaded.sessionId,
+        frameRequestId!,
+        { outcome: { outcome: 'selected', optionId: 'allow' } },
+        { clientId: reopened.clientId },
+      ),
+    ).toBe(true);
+    await expect(pendingAnswer).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow' },
+    });
+    await bridge.shutdown();
+  });
+
   it('stops refetching the persisted page when a question arrives mid-fetch', async () => {
-    let transcriptFetches = 0;
     let pendingAnswer: Promise<unknown> | undefined;
+    let reopening = false;
+    let questionRegistered = false;
     const handle = makeChannel({
       loadSessionImpl: () => ({
         _meta: {
@@ -6734,16 +6867,18 @@ describe('createAcpSessionBridge', () => {
         if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
           throw new Error(`unexpected extMethod ${method}`);
         }
-        transcriptFetches += 1;
-        if (transcriptFetches === 1) {
-          // The question arrives while the first transcript fetch is in
-          // flight: publish + registration land before the page returns.
+        if (reopening && pendingAnswer === undefined) {
+          // The question arrives while the reopened load's transcript fetch
+          // is in flight: publish + registration land before the page
+          // returns. Read the session id from the request itself — reading
+          // the later-declared `loaded` binding here would be a TDZ hazard
+          // if a cold load ever fetched a page.
           pendingAnswer = (
             handle.agentConnection as unknown as {
               requestPermission(p: unknown): Promise<unknown>;
             }
           ).requestPermission({
-            sessionId: loaded.sessionId,
+            sessionId: String(params['sessionId']),
             toolCall: {
               toolCallId: 'q-mid-fetch',
               title: 'Ask user 1 question',
@@ -6760,10 +6895,15 @@ describe('createAcpSessionBridge', () => {
           });
           await vi.waitFor(() =>
             expect(
-              bridge.getSessionSummary(loaded.sessionId)
+              bridge.getSessionSummary(String(params['sessionId']))
                 ?.isWaitingForUserQuestion,
             ).toBe(true),
           );
+          // Recorded outside the production catch: a failed precondition
+          // inside this mock would otherwise be swallowed by
+          // refreshedReplayFieldsFor's catch and leave the test green
+          // without ever exercising the guarded path.
+          questionRegistered = true;
         }
         return {
           v: 1,
@@ -6783,6 +6923,15 @@ describe('createAcpSessionBridge', () => {
         };
       },
     });
+    // Count only the refreshed-load loop's fetches (identified by the
+    // requested page size); the pagination-anchor backfill fetches with a
+    // different fixed limit and must not be attributed to the guard.
+    const loopTranscriptFetches = () =>
+      handle.agent.extMethodCalls.filter(
+        (call) =>
+          call.method === SERVE_STATUS_EXT_METHODS.sessionTranscript &&
+          (call.params as { limit?: number }).limit === 100,
+      ).length;
     const bridge = makeBridge({ channelFactory: async () => handle.channel });
     const loaded = await bridge.loadSession({
       sessionId: 'persisted-mid-fetch-question',
@@ -6791,6 +6940,10 @@ describe('createAcpSessionBridge', () => {
       historyPageSize: 100,
     });
 
+    // Premise: the cold load issues no fetch, so the one fetch asserted
+    // below belongs to the reopened load.
+    expect(loopTranscriptFetches()).toBe(0);
+    reopening = true;
     const reopened = await bridge.loadSession({
       sessionId: loaded.sessionId,
       workspaceCwd: WS_A,
@@ -6799,24 +6952,38 @@ describe('createAcpSessionBridge', () => {
       historyPageSize: 100,
     });
 
+    expect(questionRegistered).toBe(true);
     // Exactly one fetch: the interaction arrived mid-fetch, so the loop
     // leaves instead of re-fetching a page that cannot contain it.
-    expect(transcriptFetches).toBe(1);
+    expect(loopTranscriptFetches()).toBe(1);
+    // The fetched page was discarded, not spliced in front of the journal.
     expect(
-      (reopened.liveJournal ?? []).some(
-        (event) => event.type === 'permission_request',
-      ),
-    ).toBe(true);
+      [
+        ...(reopened.compactedReplay ?? []),
+        ...(reopened.liveJournal ?? []),
+      ].some((event) => JSON.stringify(event.data).includes('persisted tail')),
+    ).toBe(false);
 
-    const requestId = bridge.getSessionSummary(loaded.sessionId)
+    const frame = (reopened.liveJournal ?? []).find(
+      (event) => event.type === 'permission_request',
+    );
+    expect(frame).toBeDefined();
+    expect(JSON.stringify(frame?.data)).toContain('Continue?');
+    expect(JSON.stringify(frame?.data)).toContain('proceed_once');
+    const frameRequestId = (frame?.data as { requestId?: string } | undefined)
+      ?.requestId;
+    expect(frameRequestId).toBeDefined();
+    const registryRequestId = bridge.getSessionSummary(loaded.sessionId)
       ?.pendingInteractions?.[0]?.requestId;
-    expect(requestId).toBeDefined();
-    // The card delivered by the guarded load must stay answerable: the vote
-    // is accepted and resolves the parked call with the user's selection.
+    expect(frameRequestId).toBe(registryRequestId);
+
     expect(
-      bridge.respondToPermission(requestId!, {
-        outcome: { outcome: 'selected', optionId: 'proceed_once' },
-      }),
+      bridge.respondToSessionPermission(
+        loaded.sessionId,
+        frameRequestId!,
+        { outcome: { outcome: 'selected', optionId: 'proceed_once' } },
+        { clientId: reopened.clientId },
+      ),
     ).toBe(true);
     await expect(pendingAnswer).resolves.toEqual({
       outcome: { outcome: 'selected', optionId: 'proceed_once' },

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6822,7 +6822,9 @@ describe('createAcpSessionBridge', () => {
     );
     expect(frame).toBeDefined();
     expect(JSON.stringify(frame?.data)).toContain('Run command');
-    expect(JSON.stringify(frame?.data)).toContain('allow');
+    // 'allow' alone would be satisfied by the option's kind ("allow_once")
+    // even if its optionId were stripped — match the frame's own spelling.
+    expect(JSON.stringify(frame?.data)).toContain('"optionId":"allow"');
     const frameRequestId = (frame?.data as { requestId?: string } | undefined)
       ?.requestId;
     expect(frameRequestId).toBeDefined();
@@ -6882,7 +6884,9 @@ describe('createAcpSessionBridge', () => {
       ],
       waitFlag: 'isWaitingForPermission' as const,
       voteOptionId: 'allow',
-      payloadMarks: ['Run command', 'allow'],
+      // 'allow' alone would be satisfied by the option kind ("allow_once");
+      // match the frame's own spelling so a stripped optionId fails here.
+      payloadMarks: ['Run command', '"optionId":"allow"'],
     },
   ])(
     'stops refetching the persisted page when a $label arrives mid-fetch',

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6586,6 +6586,7 @@ describe('createAcpSessionBridge', () => {
   });
 
   it('serves the in-memory journal on refreshed load while a question is pending', async () => {
+    let transcriptFetches = 0;
     const handle = makeChannel({
       loadSessionImpl: () => ({
         _meta: {
@@ -6604,6 +6605,7 @@ describe('createAcpSessionBridge', () => {
         if (method !== SERVE_STATUS_EXT_METHODS.sessionTranscript) {
           throw new Error(`unexpected extMethod ${method}`);
         }
+        transcriptFetches += 1;
         // The persisted page can never contain the pending question:
         // permission requests are journaled in memory only.
         return {
@@ -6632,11 +6634,11 @@ describe('createAcpSessionBridge', () => {
       historyPageSize: 100,
     });
 
-    // Park the session on an unanswered ask_user_question. A parked turn
-    // does not keep promptActive set, so the refreshed-load guard would
-    // otherwise serve the persisted page with an empty liveJournal —
-    // stranding the interaction (badge on, no card) for the re-opening
-    // client.
+    // Park the session on an unanswered ask_user_question. A parked
+    // Goal/background-notification turn does not keep promptActive set, so
+    // the refreshed-load guard would otherwise serve the persisted page with
+    // an empty liveJournal — stranding the interaction (badge on, no card)
+    // for the re-opening client.
     const pendingAnswer = (
       handle.agentConnection as unknown as {
         requestPermission(p: unknown): Promise<unknown>;
@@ -6676,6 +6678,10 @@ describe('createAcpSessionBridge', () => {
         (event) => event.type === 'permission_request',
       ),
     ).toBe(true);
+    // The guard's observable effect: no persisted-page fetch happens at all
+    // while an interaction is pending (this fixture's journal emits no
+    // history_truncated marker, so the anchor backfill fetches nothing here).
+    expect(transcriptFetches).toBe(0);
     // The guarded branch switches the history source to the in-memory
     // replay; the session's prior history must survive the switch.
     const reopenedEvents = [
@@ -6700,7 +6706,7 @@ describe('createAcpSessionBridge', () => {
     await bridge.shutdown();
   });
 
-  it('re-checks pending interactions at serve time when a question arrives mid-fetch', async () => {
+  it('stops refetching the persisted page when a question arrives mid-fetch', async () => {
     let transcriptFetches = 0;
     let pendingAnswer: Promise<unknown> | undefined;
     const handle = makeChannel({
@@ -6786,7 +6792,9 @@ describe('createAcpSessionBridge', () => {
       historyPageSize: 100,
     });
 
-    expect(transcriptFetches).toBeGreaterThanOrEqual(1);
+    // Exactly one fetch: the interaction arrived mid-fetch, so the loop
+    // leaves instead of re-fetching a page that cannot contain it.
+    expect(transcriptFetches).toBe(1);
     expect(
       (reopened.liveJournal ?? []).some(
         (event) => event.type === 'permission_request',

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -7674,6 +7674,15 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     historyPageSize: number,
     liveReplayMode: 'full' | 'summary',
   ): Promise<ReturnType<typeof replayFieldsFor>> {
+    // A pending permission/question lives only in the in-memory journal — it
+    // is never persisted to the chat transcript — and a turn parked on it
+    // does not keep promptActive set. Serving the persisted page with an
+    // empty liveJournal here would strand the interaction: the session
+    // summary still advertises it (input-needed badge) while the re-opening
+    // client receives nothing to answer.
+    if (entry.pendingInteractions.size > 0) {
+      return replayFieldsFor(entry, 'load', liveReplayMode);
+    }
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const lastEventId = entry.events.lastEventId;
@@ -7715,6 +7724,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         if (
           byId.get(entry.sessionId) === entry &&
           !entry.promptActive &&
+          // Re-checked at serve time, not only before the fetch: an
+          // interaction that arrives mid-fetch leaves pendingInteractions
+          // non-empty here, and the persisted page can never contain it.
+          entry.pendingInteractions.size === 0 &&
           entry.events.epoch === eventEpoch &&
           entry.events.lastEventId === lastEventId
         ) {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -7675,11 +7675,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     liveReplayMode: 'full' | 'summary',
   ): Promise<ReturnType<typeof replayFieldsFor>> {
     // A pending permission/question lives only in the in-memory journal — it
-    // is never persisted to the chat transcript — and a turn parked on it
-    // does not keep promptActive set. Serving the persisted page with an
-    // empty liveJournal here would strand the interaction: the session
-    // summary still advertises it (input-needed badge) while the re-opening
-    // client receives nothing to answer.
+    // is never persisted to the chat transcript — and the turns that park on
+    // one without an RPC prompt (Goal and background-notification turns)
+    // never flip promptActive, so the !promptActive check below does not
+    // cover them. Serving the persisted page with an empty liveJournal here
+    // would strand the interaction: the session summary still advertises it
+    // (input-needed badge) while the re-opening client receives nothing to
+    // answer.
     if (entry.pendingInteractions.size > 0) {
       return replayFieldsFor(entry, 'load', liveReplayMode);
     }
@@ -7724,10 +7726,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         if (
           byId.get(entry.sessionId) === entry &&
           !entry.promptActive &&
-          // Re-checked at serve time, not only before the fetch: an
-          // interaction that arrives mid-fetch leaves pendingInteractions
-          // non-empty here, and the persisted page can never contain it.
-          entry.pendingInteractions.size === 0 &&
           entry.events.epoch === eventEpoch &&
           entry.events.lastEventId === lastEventId
         ) {
@@ -7764,6 +7762,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             ...(page.hasMore ? { historyHasMore: true as const } : {}),
           };
         }
+        // Not transient: only a human answer, a cancel or a timeout clears
+        // a pending interaction, so a re-fetched page cannot contain it
+        // either. Keep retrying only the genuinely transient terms.
+        if (entry.pendingInteractions.size > 0) break;
       } catch {
         // A failed bounded read (missing/unreadable persisted transcript or a
         // workspace timeout) must not tear down a healthy live session; fall


### PR DESCRIPTION
## What this PR does

Fixes the daemon's refreshed session-load path so that a session parked on an unanswered question or permission prompt re-presents the interactive card when a client re-opens it, instead of serving only the persisted transcript page.

Concretely, the refreshed-load branch now refuses to serve the persisted page whenever the session has pending interactions: once as an early return (a parked interaction makes the persisted page provably incomplete), and once as a serve-time freshness term inside the retry loop, so an interaction that arrives while the transcript page is being fetched cannot slip past either.

## Why it's needed

A turn parked on an unanswered question — the standing case being a background-notification turn — does not register as an active prompt, so a load carrying a history page size (which the Web Shell always sends) was served the persisted transcript page with an empty live journal. Question and permission requests are journaled in memory only and never persisted, so the re-opening client received nothing to answer while the session summary kept advertising the pending interaction: the sidebar showed "Input needed" indefinitely, the conversation showed no card, and the session waited forever. The only escape was sending a new message that happened to cancel the parked turn. Issue #11448 has the full incident forensics.

## Reviewer Test Plan

### How to verify

Unit level: `cd packages/acp-bridge && npx vitest run src/bridge.test.ts` — two new regression tests cover the two guards independently; each was mutation-checked (the test goes red when its guard is removed, and the sibling test stays green, proving they pin different behaviors).

End-to-end (what the reproduction engineer ran): with a daemon built from this branch, drive a session whose model asks a question during a background-notification turn while no client is attached; confirm the live-state reports the pending question; then re-open the session the way the Web Shell does (load with a history page size) and confirm the response's live journal contains the pending permission frame and the question can be answered, un-parking the session cleanly.

### Evidence (Before & After)

Before (load with page size, parked session): `liveJournal: []`, compacted replay serves the question only as a dead `failed` tool call — no interactive card.

After (same session, same load): `liveJournal` contains the pending `permission_request` frame (`permissionRequestFrames: 1`), the card renders, and answering it resolves the turn (`background_notification_turn_complete`, badge clears).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Headless daemon (`node dist/cli.js serve`) with a scripted mock OpenAI endpoint for deterministic tool calls.

## Risk & Scope

- Main risk or tradeoff: while a session has a pending interaction, a refreshed load serves the in-memory replay rather than the freshest persisted page — the same response shape the busy-session path already produces; the window lasts only until the interaction is answered, and the history anchor backfill still runs on that path.
- Not validated / out of scope: eviction of a parked request from a flooded journal (pre-existing), and mid-flight goal-turn journal freshness on refreshed loads (same guard family, no pending interaction involved).
- Breaking changes / migration notes: none.

## Linked Issues

Closes #11448

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 daemon 的会话刷新加载路径：当会话挂在一个未回答的问题或权限确认上时，客户端重新打开会话能重新呈现可交互卡片，而不是只拿到持久化转录页。

具体来说，刷新加载分支现在只要发现会话存在未决交互就拒绝提供持久化页面：一处在函数入口提前返回（挂起的交互使持久化页面必然不完整），一处作为重试循环内的服务时新鲜度条件，保证在抓取转录页期间新到达的交互也无法漏过。

## 为什么需要

挂在未回答问题上的回合——典型情形是后台通知回合——不会被计为活动 prompt，因此携带分页参数的加载（Web Shell 总是如此）会走刷新路径，拿到的是持久化转录页加空的 live journal。问题与权限请求只存在于内存事件日志、从不落盘，所以重新打开的客户端拿不到任何可回答的内容，而会话摘要仍在对外广播该未决交互：侧边栏一直显示"需输入"，会话里却没有卡片，会话无限干等。唯一解脱是碰巧发一条新消息把挂起的回合顶掉。完整事故取证见 issue #11448。

## 评审验证计划

### 如何验证

单元级：`cd packages/acp-bridge && npx vitest run src/bridge.test.ts`——两个新回归测试分别覆盖两道守卫，均做过变异验证（去掉对应守卫测试变红，且姊妹测试保持绿色，证明两者各自独立承载）。

端到端（复现工程师执行过）：用本分支构建的 daemon，驱动一个在后台通知回合中提问、且提问时无客户端连接的会话；确认 live-state 报告未决问题；然后按 Web Shell 的方式重新打开会话（带分页参数的 load），确认响应的 live journal 含有未决的权限请求帧，且问题可被回答、会话干净解除挂起。

### 证据（前后对比）

修复前（挂起会话带分页加载）：`liveJournal: []`，问题在持久化页里只呈现为一张已死的 `failed` 工具卡——没有可交互卡片。

修复后（同会话同加载）：`liveJournal` 含有未决的 `permission_request` 帧（`permissionRequestFrames: 1`），卡片可渲染，回答后回合继续（`background_notification_turn_complete`，徽标熄灭）。

### 测试平台

macOS ✅；Windows / Linux 未本地验证（由 CI 覆盖）。

## 风险与范围

- 主要风险/取舍：会话存在未决交互期间，刷新加载改为提供内存重放而非最新持久化页——与现有忙碌会话路径相同的响应形态；该窗口仅持续到交互被回答，且历史锚点回填在该路径上照常工作。
- 未覆盖/范围外：journal 洪峰逐出挂起请求的边角（修复前已存在）；goal 回合进行中的 journal 新鲜度（同族守卫，但不涉及未决交互）。
- 破坏性变更/迁移：无。

</details>
