### PR TITLE
fix(web-shell): hide the sidebar version label at the compact footer breakpoint

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.footer-version.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.footer-version.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, type Root } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const { connection, workspace, workspaceActions, active, pinned, archived } =
+  vi.hoisted(() => {
+    const makeSessions = () => {
+      const state = {
+        sessions: [] as never[],
+        loading: false,
+        error: null as Error | null,
+        data: [] as never[] | undefined,
+        reload: vi.fn().mockResolvedValue(undefined),
+        deleteSession: vi.fn().mockResolvedValue(true),
+        archiveSession: vi.fn().mockResolvedValue(true),
+        unarchiveSession: vi.fn().mockResolvedValue(true),
+        exportSession: vi.fn(),
+      };
+      state.data = state.sessions;
+      return state;
+    };
+    return {
+      connection: {
+        status: 'connected',
+        sessionId: null as string | null,
+        workspaceCwd: '/tmp/project',
+        capabilities: { qwenCodeVersion: '1.2.3', features: [] } as
+          | { qwenCodeVersion: string; features: string[] }
+          | undefined,
+      },
+      workspace: {
+        capabilities: undefined,
+        client: {
+          workspaceByCwd: vi.fn(() => ({
+            listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+            listSessionGroups: vi.fn().mockResolvedValue({
+              groups: [],
+              colorOptions: [],
+            }),
+          })),
+        },
+        refreshCapabilities: vi.fn(),
+      },
+      workspaceActions: {
+        addWorkspace: vi.fn(),
+        removeWorkspace: vi.fn(),
+        listSessionGroups: vi.fn().mockResolvedValue({
+          groups: [],
+          colorOptions: [],
+        }),
+        createSessionGroup: vi.fn(),
+        updateSessionGroup: vi.fn(),
+        deleteSessionGroup: vi.fn(),
+        updateSessionOrganization: vi.fn(),
+      },
+      active: makeSessions(),
+      pinned: makeSessions(),
+      archived: makeSessions(),
+    };
+  });
+
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
+  useConnection: () => connection,
+  useActions: () => ({ renameSession: vi.fn() }),
+  useWorkspace: () => workspace,
+  useWorkspaceActions: () => workspaceActions,
+  useChannels: () => ({ data: undefined, catalog: [], channels: {} }),
+  useSessions: (options?: { archiveState?: string; group?: string }) => {
+    if (options?.archiveState === 'archived') return archived;
+    if (options?.group === 'pinned') return pinned;
+    return active;
+  },
+}));
+
+vi.mock('../../session-catalog/session-catalog-hooks', () => ({
+  useWebShellSessions: (options?: {
+    archiveState?: string;
+    group?: string;
+  }) => {
+    if (options?.archiveState === 'archived') return archived;
+    if (options?.group === 'pinned') return pinned;
+    return active;
+  },
+  useSessionCatalogController: () => ({
+    refreshQueries: vi.fn(),
+    invalidateWorkspace: vi.fn(),
+    refreshWorkspace: vi.fn(),
+    renamed: vi.fn(),
+  }),
+  useSessionCatalogPolling: () => undefined,
+  useSessionCatalogQuery: () => ({
+    sessions: [],
+    loading: false,
+    error: undefined,
+    reload: vi.fn(),
+  }),
+  useSessionCatalogQueries: vi.fn(() => []),
+}));
+
+const { I18nProvider } = await import('../../i18n');
+const { WebShellSidebar } = await import('./WebShellSidebar');
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+if (!globalThis.PointerEvent) {
+  globalThis.PointerEvent = MouseEvent as typeof PointerEvent;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
+const VERSION_BADGE_TITLE = 'Qwen Code v1.2.3';
+const SETTINGS_LABEL = 'Settings';
+const COLLAPSE_LABEL = 'Collapse';
+const DAEMON_STATUS_LABEL = 'Daemon Status';
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+/**
+ * The sidebar reads its persisted width on mount, so each width under test
+ * needs its own mount.
+ */
+function mountAtWidth(width: number): HTMLElement {
+  window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(width));
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <WebShellSidebar
+          collapsed={false}
+          onCollapsedChange={() => {}}
+          onOpenSettings={() => {}}
+          onOpenDaemonStatus={() => {}}
+          onOpenScheduledTasks={() => {}}
+          onOpenWorkflows={() => {}}
+          onOpenGoals={() => {}}
+          onOpenSessions={() => {}}
+          onOpenSplitView={() => {}}
+          onNewSession={() => false}
+          onLoadSession={vi.fn()}
+          onError={() => {}}
+        />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+function versionBadge(container: HTMLElement): Element | null {
+  return container.querySelector(`[title="${VERSION_BADGE_TITLE}"]`);
+}
+
+function settingsButton(container: HTMLElement): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(
+    `button[aria-label="${SETTINGS_LABEL}"]`,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+});
+
+afterEach(() => {
+  for (const entry of mounted.splice(0)) {
+    act(() => {
+      entry.root.unmount();
+    });
+    entry.container.remove();
+  }
+});
+
+describe('WebShellSidebar footer version label degradation', () => {
+  it('drops the version label at the compact breakpoint along with the settings label', () => {
+    // 260px is SIDEBAR_DEFAULT_WIDTH and sits inside the compact footer window
+    // (<344px) where #6522 already hides the settings text label and switches
+    // the footer buttons to fixed 26px icons.
+    const container = mountAtWidth(260);
+    const settings = settingsButton(container);
+
+    expect(settings).not.toBeNull();
+    expect(settings?.querySelector('svg')).not.toBeNull();
+    expect(settings?.textContent).not.toContain(SETTINGS_LABEL);
+
+    // The version label is the only footer child that can neither shrink nor
+    // truncate (`flex: 0 0 auto; white-space: nowrap`), so once the footer is
+    // compact it has to leave the row at the same breakpoint as the settings
+    // label. Otherwise it overflows `.footerPrimary` and paints over the
+    // action icons in `.footerActions` (issue #11453).
+    expect(versionBadge(container)).toBeNull();
+    expect(container.textContent ?? '').not.toContain('v1.2.3');
+
+    // Hiding the label must not take the action icons with it.
+    expect(
+      container.querySelector(`button[aria-label="${DAEMON_STATUS_LABEL}"]`),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(`button[aria-label="${COLLAPSE_LABEL}"]`),
+    ).not.toBeNull();
+  });
+
+  it('keeps the version label hidden across the whole overlap range from #11453', () => {
+    for (const width of [250, 280, 300, 330, 343]) {
+      const container = mountAtWidth(width);
+      expect(
+        versionBadge(container),
+        `version label should be hidden at ${width}px`,
+      ).toBeNull();
+    }
+  });
+
+  it('shows the settings label and the version label above the compact breakpoint', () => {
+    const container = mountAtWidth(360);
+    const settings = settingsButton(container);
+    const badge = versionBadge(container);
+
+    expect(settings).not.toBeNull();
+    expect(settings?.textContent).toContain(SETTINGS_LABEL);
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('v1.2.3');
+  });
+
+  it('leaves the footer below the former tight breakpoint unchanged', () => {
+    const container = mountAtWidth(220);
+    const settings = settingsButton(container);
+
+    expect(settings).not.toBeNull();
+    expect(settings?.querySelector('svg')).not.toBeNull();
+    expect(settings?.textContent).not.toContain(SETTINGS_LABEL);
+    expect(versionBadge(container)).toBeNull();
+    expect(container.textContent ?? '').not.toContain('v1.2.3');
+    expect(
+      container.querySelector(`button[aria-label="${COLLAPSE_LABEL}"]`),
+    ).not.toBeNull();
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -1664,20 +1664,16 @@
   text-overflow: ellipsis;
 }
 
-.footerCompact,
-.footerTight {
+.footerCompact {
   gap: 4px;
 }
 
 .footerCompact .footerPrimary,
-.footerCompact .footerActions,
-.footerTight .footerPrimary,
-.footerTight .footerActions {
+.footerCompact .footerActions {
   gap: 4px;
 }
 
-.footerCompact .footerButton,
-.footerTight .footerButton {
+.footerCompact .footerButton {
   width: 26px;
   height: 28px;
   flex: 0 0 26px;
@@ -1685,13 +1681,11 @@
   padding: 0;
 }
 
-.footerCompact .footerButtonLabel,
-.footerTight .footerButtonLabel {
+.footerCompact .footerButtonLabel {
   display: none;
 }
 
-.footerCompact .collapseButton,
-.footerTight .collapseButton {
+.footerCompact .collapseButton {
   width: 26px;
   height: 28px;
 }

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -151,7 +151,6 @@ const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 420;
 const SIDEBAR_MAX_WIDTH_WINDOW_RATIO = 0.5;
 const SIDEBAR_FOOTER_COMPACT_WIDTH = 344;
-const SIDEBAR_FOOTER_TIGHT_WIDTH = 250;
 const SIDEBAR_DRAG_VISUAL_MIN_WIDTH = 200;
 const SIDEBAR_COLLAPSE_DRAG_THRESHOLD = 56;
 const SIDEBAR_COLLAPSE_DRAG_WIDTH =
@@ -2072,9 +2071,13 @@ export function WebShellSidebar({
       ? `v${qwenCodeVersion}`
       : qwenCodeVersion
     : '';
+  // One breakpoint degrades the whole footer: below it the settings button
+  // drops its text label, every footer button becomes a fixed 26px icon, and the
+  // version label leaves the row. That label can neither shrink nor truncate
+  // (`flex: 0 0 auto; white-space: nowrap`), so keeping it rendered past this
+  // point overflowed `.footerPrimary` into the action icons (#11453).
   const footerCompact =
     !collapsed && sidebarWidth < SIDEBAR_FOOTER_COMPACT_WIDTH;
-  const footerTight = !collapsed && sidebarWidth < SIDEBAR_FOOTER_TIGHT_WIDTH;
   const sidebarStyle = {
     '--web-shell-sidebar-width': `${sidebarWidth}px`,
     '--web-shell-sidebar-min-width': `${SIDEBAR_MIN_WIDTH}px`,
@@ -6259,11 +6262,7 @@ export function WebShellSidebar({
 
         {(footer !== false || mobileOpen) && (
           <div
-            className={cx(
-              styles.footer,
-              footerCompact && styles.footerCompact,
-              footerTight && styles.footerTight,
-            )}
+            className={cx(styles.footer, footerCompact && styles.footerCompact)}
           >
             <div className={styles.footerPrimary}>
               {footer && typeof footer === 'object' && footer.render?.()}
@@ -6286,7 +6285,7 @@ export function WebShellSidebar({
                 </button>
               )}
               {!collapsed &&
-                !footerTight &&
+                !footerCompact &&
                 versionLabel &&
                 footerItems.has('version') && (
                   <span


### PR DESCRIPTION
## What this PR does

The web-shell sidebar footer used to degrade in two steps that did not line up. Below 344px (`SIDEBAR_FOOTER_COMPACT_WIDTH`) the settings button already drops its text label and every footer button becomes a fixed 26px icon, but the version label kept rendering all the way down to 250px (`SIDEBAR_FOOTER_TIGHT_WIDTH`). Between those two breakpoints the footer was already in its compact form yet still carried a label that could neither shrink nor truncate, so the label overflowed its own flex group and painted into the action icons. This PR moves the version label onto the same compact breakpoint that already gates the settings text label, so the footer now degrades in a single step and there is no expanded width where the label is rendered while the row has no room for it.

Because that was the only thing still distinguishing the two breakpoints, `footerTight`, `SIDEBAR_FOOTER_TIGHT_WIDTH` and the `.footerTight` CSS selectors become dead and are removed in the same change. Every CSS rule that named `.footerTight` was already grouped with an identical `.footerCompact` rule, so removing the selectors changes no computed style.

## Why it's needed

Fixes #11453. The version label and the footer action icons overlap, with the glyphs colliding and the icons painting on top of the text while staying clickable.

This is not only reachable by dragging the resize handle: `SIDEBAR_DEFAULT_WIDTH` is 260, which sits inside the affected window, so a default sidebar renders the overlapped footer out of the box. The sidebar is clamped to 220–420px, so the compact window covers a substantial part of the usable range.

The redundant `.footerTight` selectors were already flagged during the review of #6522 — the PR that introduced the two-tier breakpoints — with the advice to drop them from the grouped CSS but keep the JSX flag, because the version badge still needed it at the time ([pull/6522#issuecomment-4912726828](https://github.com/QwenLM/qwen-code/pull/6522#issuecomment-4912726828)). Moving the badge onto the compact breakpoint removes the last thing that flag did, so this drops the CSS and the flag together rather than leaving one half of the redundancy behind.

## Reviewer Test Plan

### How to verify

Mechanism, from the CSS and the JSX gate:

- `.footerPrimary` is `flex: 0 1 auto; min-width: 0`, so it absorbs the squeeze and can go to zero.
- `.footerActions` is `flex: 0 0 auto; margin-left: auto`, so it is pinned right and never shrinks.
- `.version` was `flex: 0 0 auto; white-space: nowrap` with no `min-width`, `overflow` or `text-overflow` — the one footer child that can neither shrink nor truncate, so it overflows `.footerPrimary` and lands under `.footerActions`, which comes later in the DOM and therefore paints on top.

Unit test (new file `WebShellSidebar.footer-version.test.tsx`, 4 cases). It mounts the real `WebShellSidebar` at a persisted width and asserts that the version label and the settings text label now leave the footer at the same breakpoint:

```
# before the fix — the two red cases are the overlap window
$ npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.footer-version.test.tsx
AssertionError: expected <span …(2)></span> to be null
+ Received:
<span class="_version_aae97e" title="Qwen Code v1.2.3">v1.2.3</span>
  ❯ WebShellSidebar.footer-version.test.tsx:209:37   (sidebar width 260)
AssertionError: version label should be hidden at 250px: expected <span …(2)></span> to be null
  ❯ WebShellSidebar.footer-version.test.tsx:227:9
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)

# after the fix
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The 2 cases that already passed before the fix are the regression guards: width 360 still shows the settings text label *and* the `v1.2.3` badge, and width 220 (below the former tight breakpoint) still hides the badge while keeping the settings button and the collapse button reachable. The two red cases cover width 260 (`SIDEBAR_DEFAULT_WIDTH`) and the sweep 250 / 280 / 300 / 330 / 343. Each also asserts the daemon-status and collapse action buttons are still in the DOM, so hiding the label did not take the icons with it.

Wider regression run, unchanged:

```
$ npx vitest run --config vitest.config.ts client/components/sidebar/
 Test Files  23 passed (23)
      Tests  447 passed (447)

$ npx tsc -p tsconfig.json --noEmit      # exit 0, no output
$ npx prettier --check <the 3 touched files>
All matched files use Prettier code style!
$ npx eslint WebShellSidebar.tsx WebShellSidebar.footer-version.test.tsx   # exit 0, no output
```

Browser verification. The repo's own e2e harness (vite dev server + `installMockDaemon`, `capabilities.qwenCodeVersion` pinned to `0.23.1` to match the report) driven by headless Chromium, with the sidebar width seeded through `localStorage` before load. Real `getBoundingClientRect()` geometry, not a visual diff — the question asked is whether the label's box intersects any footer action button's box:

```
# main @19ba03fb70 (before)
GEOMETRY[before][260] {"sidebarWidth":260,"versionText":"v0.23.1",
  "versionRect":{"left":42,"right":88.953125,"top":876,"bottom":888},
  "actionCount":5,"overlaps":[{"label":"Switch to light theme","overlapPx":17.953125}]}
GEOMETRY[before][300] {... "versionText":"v0.23.1", "overlaps":[]}
GEOMETRY[before][330] {... "versionText":"v0.23.1", "overlaps":[]}

# this branch (after)
GEOMETRY[after][260]  {"sidebarWidth":260,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
GEOMETRY[after][300]  {"sidebarWidth":300,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
GEOMETRY[after][330]  {"sidebarWidth":330,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
```

At 260px the label spans x 42 → 88.95 while the theme toggle starts at x 71, a 17.95px intersection — the reported symptom, at the default sidebar width and with no resizing. Stating the 300/330 results plainly: there the label still rendered but did not geometrically intersect in this harness. The intersection threshold depends on how many footer action buttons are enabled, which the reporter noted as well; with the default set the label collides from 250px up to roughly 277px, and a wider action group pushes that ceiling higher. What is true across the whole reported 250–330px range is that the label renders while the footer is already compact and has no shrinkable room left for it, which is why the fix removes it across the entire compact window rather than only below the measured intersection point.

### Evidence (Before & After)

Footer row captured at 3x device scale from the real component, `qwenCodeVersion` set to `0.23.1` as in the report.

Sidebar at 260px (`SIDEBAR_DEFAULT_WIDTH`) — before: `v0.23.1` runs under the theme toggle icon; after: the footer is compact and clean.

| Before (main) | After (this branch) |
| :---: | :---: |
| ![before 260px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-before-260.png) | ![after 260px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-after-260.png) |

Sidebar at 300px — before: the label still renders inside the compact footer (no intersection at this width, but no room for it either); after: hidden.

| Before (main) | After (this branch) |
| :---: | :---: |
| ![before 300px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-before-300.png) | ![after 300px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-after-300.png) |

Above the compact breakpoint (≥344px) the footer is untouched: the settings text label and the version badge both still render, as the 360px unit test case pins.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

`npm run dev` for the web-shell vite server with the daemon mocked through the existing `client/e2e/utils/mockDaemon.ts` harness, driven by headless Chromium via `npx playwright test --project=chromium`. Unit tests and typecheck ran against a worktree based on `main` @ `19ba03fb70`.

## Risk & Scope

- Main risk or tradeoff: the version label now disappears below 344px instead of below 250px, so in the 250–343px band the version is no longer visible in the footer. That band previously rendered the label overlapped by icons, so the practical choice there was between unreadable and absent. The sidebar clamps to 220–420px, so the label is still shown across 344–420px, and the full version remains available via `/about`. This is also exactly how the settings text label already behaves at the same breakpoint.
- Not validated / out of scope: no browser verification on macOS or Windows. The drag-to-collapse rail behaviour, the `collapsedByDrag` double-fire guard and `clampSidebarVisualWidth` are not touched by this diff and are not re-tested here — their original #6522 tests lived in `WebShellSidebar.test.tsx`, which #6804 deleted wholesale, and restoring that suite is a separate job from this fix. Whether `.version` should additionally get `overflow: hidden; text-overflow: ellipsis` as a belt-and-braces rule for custom `footer.items` configurations with more action buttons than the default is left alone: no such overflow was observed at ≥344px with the default set, so adding it here would be guarding an unobserved case.
- Breaking changes / migration notes: none. `footerTight` and `SIDEBAR_FOOTER_TIGHT_WIDTH` were module-local and never exported, and `.footerTight` is a CSS-modules-scoped class; a repo-wide search for all three returns zero remaining references. No public props, no persisted storage keys and no DOM contract changed.

## Linked Issues

Fixes #11453

Related, not closing: #6522 introduced the two-tier footer breakpoints this aligns, and its review already flagged the redundant `.footerTight` selectors.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

web-shell 侧边栏 footer 原本分两级降级，但两级没有对齐。低于 344px（`SIDEBAR_FOOTER_COMPACT_WIDTH`）时，设置按钮已经去掉文字标签、所有 footer 按钮变成固定 26px 图标，但版本号标签一直渲染到 250px（`SIDEBAR_FOOTER_TIGHT_WIDTH`）才消失。在这两个断点之间，footer 已经是紧凑形态，却还带着一个既不能压缩也不能截断的标签，于是它溢出自己的 flex 分组、画进动作图标区域。本 PR 把版本号标签挪到已经在管设置按钮文字标签的同一个 compact 断点上，让 footer 一步降级完成，因而不存在"标签还在渲染、但这一行已经放不下它"的展开宽度。

由于这是两个断点之间唯一还有区别的地方，`footerTight`、`SIDEBAR_FOOTER_TIGHT_WIDTH` 和 `.footerTight` 的 CSS 选择器随即变成死代码，在同一次改动里一并删除。所有提到 `.footerTight` 的 CSS 规则本来就和完全相同的 `.footerCompact` 规则写在一组选择器里，因此删掉这些选择器不改变任何计算样式。

## 为什么需要

修复 #11453。版本号标签与 footer 动作图标重叠，字形撞在一起，图标盖在文字上方且仍然可点击。

这不只是拖拽 resize 手柄才能触发：`SIDEBAR_DEFAULT_WIDTH` 是 260，正落在受影响区间内，所以默认宽度的侧边栏开箱就是重叠状态。侧边栏宽度被夹在 220–420px，compact 区间占了可用范围的相当大一段。

冗余的 `.footerTight` 选择器在 #6522（引入这套两级断点的 PR）的 review 里就已被指出，当时的建议是从分组 CSS 里删掉、但保留 JSX 里的 flag，因为版本号 badge 那时还需要它（[pull/6522#issuecomment-4912726828](https://github.com/QwenLM/qwen-code/pull/6522#issuecomment-4912726828)）。把 badge 挪到 compact 断点后，这个 flag 已经无事可做，因此本 PR 把 CSS 和 flag 一起删掉，而不是只清理一半冗余。

## Reviewer 测试计划

### 如何验证

机制层面，从 CSS 与 JSX 门条件看：

- `.footerPrimary` 是 `flex: 0 1 auto; min-width: 0`，会被压缩，可以压到 0。
- `.footerActions` 是 `flex: 0 0 auto; margin-left: auto`，固定在右侧且永不收缩。
- `.version` 原本是 `flex: 0 0 auto; white-space: nowrap`，且没有 `min-width`、`overflow`、`text-overflow` —— footer 里唯一既不能压缩也不能截断的子元素，所以它溢出 `.footerPrimary` 并落到 `.footerActions` 下面；后者在 DOM 中靠后，因此盖在上层。

单元测试（新文件 `WebShellSidebar.footer-version.test.tsx`，4 个用例）。它在指定持久化宽度下挂载真实的 `WebShellSidebar`，断言版本号标签与设置文字标签现在在同一个断点一起退出 footer：

```
# 修复前 —— 两个红用例正是重叠区间
$ npx vitest run --config vitest.config.ts client/components/sidebar/WebShellSidebar.footer-version.test.tsx
AssertionError: expected <span …(2)></span> to be null
+ Received:
<span class="_version_aae97e" title="Qwen Code v1.2.3">v1.2.3</span>
  ❯ WebShellSidebar.footer-version.test.tsx:209:37   (sidebar width 260)
AssertionError: version label should be hidden at 250px: expected <span …(2)></span> to be null
  ❯ WebShellSidebar.footer-version.test.tsx:227:9
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)

# 修复后
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

修复前就已经通过的 2 个用例是回归保护：360px 仍然同时显示设置文字标签和 `v1.2.3` badge；220px（低于原 tight 断点）仍然隐藏 badge，同时设置按钮与 collapse 按钮仍可访问。两个红用例覆盖 260px（`SIDEBAR_DEFAULT_WIDTH`）以及 250 / 280 / 300 / 330 / 343 的宽度扫描。每个用例还断言 daemon-status 与 collapse 动作按钮仍在 DOM 中，确认隐藏标签没有把图标一起带走。

更大范围的回归运行，结果不变：

```
$ npx vitest run --config vitest.config.ts client/components/sidebar/
 Test Files  23 passed (23)
      Tests  447 passed (447)

$ npx tsc -p tsconfig.json --noEmit      # exit 0, no output
$ npx prettier --check <改动的 3 个文件>
All matched files use Prettier code style!
$ npx eslint WebShellSidebar.tsx WebShellSidebar.footer-version.test.tsx   # exit 0, no output
```

浏览器验证。使用仓库自带的 e2e harness（vite dev server + `installMockDaemon`，`capabilities.qwenCodeVersion` 固定为 `0.23.1` 以对齐报告环境），由 headless Chromium 驱动，侧边栏宽度在页面加载前通过 `localStorage` 注入。用的是真实 `getBoundingClientRect()` 几何数据，不是视觉 diff —— 要回答的问题是标签的盒子是否与任何 footer 动作按钮的盒子相交：

```
# main @19ba03fb70（修复前）
GEOMETRY[before][260] {"sidebarWidth":260,"versionText":"v0.23.1",
  "versionRect":{"left":42,"right":88.953125,"top":876,"bottom":888},
  "actionCount":5,"overlaps":[{"label":"Switch to light theme","overlapPx":17.953125}]}
GEOMETRY[before][300] {... "versionText":"v0.23.1", "overlaps":[]}
GEOMETRY[before][330] {... "versionText":"v0.23.1", "overlaps":[]}

# 本分支（修复后）
GEOMETRY[after][260]  {"sidebarWidth":260,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
GEOMETRY[after][300]  {"sidebarWidth":300,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
GEOMETRY[after][330]  {"sidebarWidth":330,"versionText":null,"versionRect":null,"actionCount":5,"overlaps":[]}
```

260px 时标签横跨 x 42 → 88.95，而 theme toggle 从 x 71 开始，相交 17.95px —— 正是报告里的现象，且发生在默认侧边栏宽度、无需任何拖拽。300/330 的结果如实说明：标签仍在渲染，但在本 harness 中没有几何相交。相交阈值取决于启用了多少个 footer 动作按钮（报告者也提到了这一点）；在默认按钮集合下，标签从 250px 到大约 277px 会相撞，动作组更宽则把这个上限推得更高。在整个报告的 250–330px 范围内成立的事实是：footer 已经进入 compact 形态、这一行已经没有可收缩的余量，标签却仍在渲染 —— 这也是本 PR 选择在整个 compact 区间移除标签、而不只是移除到实测相交点为止的原因。

### 证据（Before & After）

footer 一行以 3x device scale 从真实组件截取，`qwenCodeVersion` 按报告设为 `0.23.1`。

侧边栏 260px（`SIDEBAR_DEFAULT_WIDTH`）—— 修复前：`v0.23.1` 钻到 theme toggle 图标下面；修复后：footer 紧凑且干净。

| 修复前（main） | 修复后（本分支） |
| :---: | :---: |
| ![before 260px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-before-260.png) | ![after 260px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-after-260.png) |

侧边栏 300px —— 修复前：标签仍在 compact footer 里渲染（此宽度下不相交，但也没有它的余量）；修复后：已隐藏。

| 修复前（main） | 修复后（本分支） |
| :---: | :---: |
| ![before 300px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-before-300.png) | ![after 300px](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/web-shell-footer-overlap-11453-after-300.png) |

compact 断点以上（≥344px）footer 完全不受影响：设置文字标签与版本号 badge 都照常渲染，由 360px 的单元用例钉住。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

web-shell vite server 用 `npm run dev` 起，daemon 通过既有的 `client/e2e/utils/mockDaemon.ts` harness mock，由 headless Chromium 经 `npx playwright test --project=chromium` 驱动。单元测试与 typecheck 跑在基于 `main` @ `19ba03fb70` 的 worktree 上。

## 风险与范围

- 主要风险 / 取舍：版本号标签现在低于 344px 就消失，而不是低于 250px，因此 250–343px 这一段 footer 里不再能看到版本号。而这一段此前渲染出来的是被图标压住的标签，所以实际可选的只有"看不清"和"不显示"两种。侧边栏宽度夹在 220–420px，标签在 344–420px 仍然显示，完整版本号也依然可以通过 `/about` 获取。这也正是设置文字标签在同一个断点上的既有行为。
- 未验证 / 不在范围内：未在 macOS 与 Windows 上做浏览器验证。拖拽折叠成 rail 的行为、`collapsedByDrag` 防双触发守卫、`clampSidebarVisualWidth` 都没有被本 diff 触及，也没有在此重新测试 —— 它们原本在 #6522 的测试位于 `WebShellSidebar.test.tsx`，该文件已被 #6804 整体删除，恢复那套测试是与本修复独立的另一件事。是否再给 `.version` 补一条 `overflow: hidden; text-overflow: ellipsis` 作为兜底（用于 `footer.items` 自定义出比默认更多动作按钮的配置）这里没有做：默认按钮集合下 ≥344px 未观测到溢出，加它就是在防一个没发生过的场景。
- 破坏性变更 / 迁移说明：无。`footerTight` 与 `SIDEBAR_FOOTER_TIGHT_WIDTH` 都是模块内局部变量、从未导出，`.footerTight` 是 CSS Modules 作用域内的类名；对这三者做全仓搜索均无残留引用。公开 props、持久化 storage key、DOM 契约都没有变化。

## 关联 Issue

Fixes #11453

相关但不关闭：#6522 引入了本 PR 所对齐的这套两级 footer 断点，其 review 已经指出过冗余的 `.footerTight` 选择器。

</details>
