### PR TITLE
test(channels): canonicalize restored worktree fixture paths

### DIFF
--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -2545,7 +2545,7 @@ describe('SessionRouter', () => {
           'ch:alice:chat1': {
             sessionId: 'worktree-session',
             target,
-            cwd: '/tmp/worktree-task',
+            cwd: worktreeTaskPath,
             isolation: 'worktree',
             workspaceCwd: '/tmp',
           },
@@ -2560,7 +2560,7 @@ describe('SessionRouter', () => {
         hasActivePrompt: false,
         worktree: {
           slug: 'task',
-          path: '/tmp/worktree-task',
+          path: worktreeTaskPath,
           branch: 'task',
         },
         worktreeState: 'persisted-v1' as const,
@@ -2601,9 +2601,7 @@ describe('SessionRouter', () => {
       expect(router.getSession('ch', 'alice', 'chat1')).toBe(
         'worktree-session',
       );
-      expect(router.getSessionCwd('worktree-session')).toBe(
-        '/tmp/worktree-task',
-      );
+      expect(router.getSessionCwd('worktree-session')).toBe(worktreeTaskPath);
 
       // A later persist keeps the restore metadata on the route.
       router.activateManagedSession(
@@ -2615,7 +2613,7 @@ describe('SessionRouter', () => {
         'ch:alice:chat1': {
           sessionId: 'worktree-session',
           target,
-          cwd: '/tmp/worktree-task',
+          cwd: worktreeTaskPath,
           isolation: 'worktree',
           workspaceCwd: '/tmp',
         },
@@ -2699,7 +2697,7 @@ describe('SessionRouter', () => {
         'replacement-session',
       );
       expect(router.getSessionCwd('replacement-session')).toBe(
-        '/tmp/worktree-task',
+        worktreeTaskPath,
       );
 
       // The replacement inherits the route's restore metadata.
@@ -2712,7 +2710,7 @@ describe('SessionRouter', () => {
       expect(data['ch:alice:chat1']).toEqual({
         sessionId: 'replacement-session',
         target,
-        cwd: '/tmp/worktree-task',
+        cwd: worktreeTaskPath,
         isolation: 'worktree',
         workspaceCwd: '/tmp',
       });
@@ -2747,7 +2745,7 @@ describe('SessionRouter', () => {
         'ch:alice:chat1': {
           sessionId: 'replacement-session',
           target,
-          cwd: '/tmp/worktree-task',
+          cwd: worktreeTaskPath,
           isolation: 'worktree',
           workspaceCwd: '/tmp',
         },
@@ -2765,7 +2763,7 @@ describe('SessionRouter', () => {
           'ch:alice:chat1': {
             sessionId: 'worktree-session',
             target,
-            cwd: '/tmp/worktree-task',
+            cwd: worktreeTaskPath,
           },
         }),
       );
@@ -2778,7 +2776,7 @@ describe('SessionRouter', () => {
       router.activateManagedSession(
         'worktree-session',
         target,
-        '/tmp/worktree-task',
+        worktreeTaskPath,
         { isolation: 'worktree', workspaceCwd: '/tmp' },
       );
 
@@ -2786,7 +2784,7 @@ describe('SessionRouter', () => {
         'ch:alice:chat1': {
           sessionId: 'worktree-session',
           target,
-          cwd: '/tmp/worktree-task',
+          cwd: worktreeTaskPath,
           isolation: 'worktree',
           workspaceCwd: '/tmp',
         },
@@ -2820,7 +2818,7 @@ describe('SessionRouter', () => {
           'ch:alice:chat1': {
             sessionId: 'worktree-session',
             target,
-            cwd: '/tmp/worktree-task',
+            cwd: worktreeTaskPath,
             isolation: 'worktree',
           },
         }),
@@ -2845,7 +2843,7 @@ describe('SessionRouter', () => {
       router.activateManagedSession(
         'worktree-session',
         target,
-        '/tmp/worktree-task',
+        worktreeTaskPath,
         { isolation: 'worktree', workspaceCwd: '/tmp' },
       );
 
@@ -2853,7 +2851,7 @@ describe('SessionRouter', () => {
         'ch:alice:chat1': {
           sessionId: 'worktree-session',
           target,
-          cwd: '/tmp/worktree-task',
+          cwd: worktreeTaskPath,
           isolation: 'worktree',
           workspaceCwd: '/tmp',
         },
@@ -2872,7 +2870,7 @@ describe('SessionRouter', () => {
       router.activateManagedSession(
         'worktree-session',
         target,
-        '/tmp/worktree-task',
+        worktreeTaskPath,
         { isolation: 'worktree', workspaceCwd: '/tmp' },
       );
       expect(router.removeSessionId('worktree-session')).toBe(true);
@@ -2887,7 +2885,7 @@ describe('SessionRouter', () => {
         router.activateManagedSession(
           'worktree-session',
           target,
-          '/tmp/worktree-task',
+          worktreeTaskPath,
           { isolation: 'worktree', workspaceCwd: '' },
         ),
       ).toThrow('workspace cwd');
@@ -2911,7 +2909,7 @@ describe('SessionRouter', () => {
       expect(data['ch:alice:chat1']).toEqual({
         sessionId: 'worktree-session',
         target,
-        cwd: '/tmp/worktree-task',
+        cwd: worktreeTaskPath,
         isolation: 'worktree',
         workspaceCwd: '/tmp',
       });


### PR DESCRIPTION
## What this PR does

This test-only follow-up makes the remaining managed-worktree restore fixtures use the same canonical checkout spelling for persisted routes, daemon attestations, activations, and expectations. It does not change production behavior.

## Why it's needed

#11318 fixed the original six Windows-only path assertions from #11317, but #11308 added another restore-test block after that fix branch had been prepared. The [next scheduled Windows run](https://github.com/QwenLM/qwen-code/actions/runs/34268570401/job/102204085889) still exposed three assertions where Windows resolved `/tmp/worktree-task` as `C:\tmp\worktree-task` while the new fixtures expected the raw POSIX spelling.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/channels/base && npx vitest run src/SessionRouter.test.ts`; expect all 153 tests to pass.
2. Run `cd packages/channels/base && npx vitest run`; expect all 1,335 package tests to pass.
3. On Windows, confirm the three managed-worktree restore cases no longer report `/tmp/worktree-task` versus `C:\tmp\worktree-task` mismatches.

### Evidence (Before & After)

Before: the scheduled Windows job failed three managed-worktree restore assertions because the fixture mixed raw and canonical path spellings.

After: every occurrence in that restore-test block uses the existing platform-aware canonical path fixture.

### Tested on

| Platform | Status |
| --- | --- |
| macOS | ✅ Focused test: 153 passed; package suite: 1,335 passed |
| Windows | ⚠️ Not available locally; covered by CI/next scheduled run |
| Linux | ⚠️ Not run locally; behavior is unchanged on POSIX |

### Environment (optional)

Node.js 22.22.0 with the repository's pnpm worktree bootstrap and Vitest.

## Risk & Scope

- Main risk or tradeoff: Minimal; the change only reuses an existing test helper already used by adjacent path assertions.
- Not validated / out of scope: Other independent failures reported by the later scheduled Windows job are not addressed here. The root build is currently blocked on unchanged main by the existing document-export runtime size budget (`4212156 > 4200000`); the package build passes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #11317

Related: #11308, #11318

<details>
<summary>中文说明</summary>

## 本 PR 的改动

这是一个仅修改测试的后续修复：让剩余的托管 worktree 恢复测试，在持久化路由、daemon 校验、激活记录和断言中统一使用平台规范化后的 checkout 路径，不改变任何生产逻辑。

## 为什么需要这个改动

#11318 修复了 #11317 最初的 6 个 Windows 路径断言，但 #11308 在该修复分支准备完成后又加入了一组恢复测试。[下一次 Windows 定时任务](https://github.com/QwenLM/qwen-code/actions/runs/34268570401/job/102204085889)仍有 3 个断言失败：Windows 会把 `/tmp/worktree-task` 解析成 `C:\tmp\worktree-task`，而新测试仍在期待未经规范化的 POSIX 路径。

## Reviewer 测试计划

### 验证方式

1. 执行 `cd packages/channels/base && npx vitest run src/SessionRouter.test.ts`，应有 153 个测试全部通过。
2. 执行 `cd packages/channels/base && npx vitest run`，应有 1,335 个包内测试全部通过。
3. 在 Windows 上确认 3 个托管 worktree 恢复用例不再出现 `/tmp/worktree-task` 与 `C:\tmp\worktree-task` 的路径不一致。

### 前后对比

修复前：Windows 定时任务中的 3 个托管 worktree 恢复断言失败，因为测试数据混用了原始路径和规范化路径。

修复后：该恢复测试块中的所有相关路径都复用了现有的平台感知规范化测试数据。

### 已测试平台

| 平台 | 状态 |
| --- | --- |
| macOS | ✅ 单文件 153 个测试通过；包内 1,335 个测试通过 |
| Windows | ⚠️ 本地无环境，交由 CI 或下一次定时任务验证 |
| Linux | ⚠️ 本地未执行；POSIX 下行为不变 |

### 环境

Node.js 22.22.0，使用仓库的 pnpm worktree 初始化流程和 Vitest。

## 风险与范围

- 主要风险或取舍：很低；仅复用相邻路径断言已经使用的测试辅助变量。
- 未验证 / 不在范围内：后续 Windows 定时任务中的其他独立失败不由本 PR 处理。当前未改动的 main 本身仍会因文档导出运行时代码体积预算（`4212156 > 4200000`）导致根目录构建失败；本次涉及的包构建已通过。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #11317

相关：#11308、#11318

</details>
