### PR TITLE
docs(daemon): add a REST integration entry point, guarded against the route surface

### DIFF
--- a/docs/developers/_meta.ts
+++ b/docs/developers/_meta.ts
@@ -20,6 +20,7 @@ export default {
 
   'channel-plugins': 'Channel Plugin Guide',
   tools: 'Tools',
+  'rest-api-integration': 'REST API integration guide',
   'qwen-serve-protocol': 'qwen serve HTTP protocol',
   daemon: 'Daemon Mode (Developer Deep Dive)',
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2787,7 +2787,9 @@ session SSE stream after `lastEventId` and correlate `turn_complete` or
 
 `turn_complete.data.stopReason` carries the ACP `StopReason` the agent
 returned — `end_turn`, `max_tokens`, `max_turn_requests`, `refusal` or
-`cancelled`. **Treat the field as an open string**: it is typed `string` on the
+`cancelled` — where `cancelled` may also be originated by the daemon itself
+for a prompt it aborted without the agent running it (queued-prompt removal,
+caller disconnect, drain/teardown). **Treat the field as an open string**: it is typed `string` on the
 wire, the ACP set can grow, and a client that exhaustively switches on it will
 break on the next addition.
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2793,20 +2793,30 @@ break on the next addition.
 
 Two daemon-side outcomes do **not** arrive on this field. A turn that fails
 inside the daemon — deadline expiry, teardown flush, child crash — is published
-as a `turn_error` event carrying its `code` / `errorKind`, never as a
-`turn_complete` stopReason. A turn recovered from persisted history after a
-restart is not re-published on the stream at all; it surfaces as
-`promptTerminals[].stopReason === "reconstructed_from_transcript"` in the
-`POST /session/:id/load` response body.
+as a `turn_error` event, never as a `turn_complete` stopReason. Its `data`
+always carries `message`; `code` is present only when the daemon classified the
+failure (deadline expiry → `prompt_deadline_exceeded`, teardown flush →
+`channel_closed`, `session_closed`, `session_killed` or `daemon_shutdown`), and
+the frame for a prompt rejected because the ACP child died mid-request carries
+neither `code` nor `errorKind`. Treat both as optional and branch on `message`.
+
+A turn recovered from persisted history after a restart is not re-published on
+the stream at all; it surfaces in `promptTerminals[]` in the
+`POST /session/:id/load` response body — as
+`{ terminal: "completed", stopReason: "reconstructed_from_transcript" }` when
+the persisted tail shows the turn finished, or
+`{ terminal: "interrupted", code: "daemon_lost" }` with **no** `stopReason` when
+the daemon died mid-turn. Match the entry by `promptId` and branch on
+`terminal`; `promptTerminals` is omitted from the response entirely when the
+ledger holds no evidence for the session.
 
 If the HTTP client disconnects mid-prompt, the daemon sends an ACP `cancel` notification to the agent, which winds the prompt down with `stopReason: "cancelled"`.
 
 When `prompt_absolute_deadline` is advertised, `deadlineMs` may shorten the
 configured server deadline. Expiry emits a correlated `turn_error` with
-`errorKind: "prompt_deadline_exceeded"`. The deadline releases the caller
-without killing the agent; if the agent later settles, turn-status polls for
-that `promptId` return the settled transcript outcome instead of the deadline
-error.
+`code: "prompt_deadline_exceeded"`. The deadline releases the caller without
+killing the agent; if the agent later settles, turn-status polls for that
+`promptId` return the settled transcript outcome instead of the deadline error.
 
 ### `POST /session/:id/cancel`
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2787,12 +2787,17 @@ session SSE stream after `lastEventId` and correlate `turn_complete` or
 
 `turn_complete.data.stopReason` carries the ACP `StopReason` the agent
 returned — `end_turn`, `max_tokens`, `max_turn_requests`, `refusal` or
-`cancelled` — plus two values the daemon originates itself: `error` when a turn
-fails inside the daemon rather than the agent, and
-`reconstructed_from_transcript` for a turn recovered from persisted history
-rather than observed live. **Treat the field as an open string**: it is typed
-`string` on the wire, the ACP set can grow, and a client that exhaustively
-switches on it will break on the next addition.
+`cancelled`. **Treat the field as an open string**: it is typed `string` on the
+wire, the ACP set can grow, and a client that exhaustively switches on it will
+break on the next addition.
+
+Two daemon-side outcomes do **not** arrive on this field. A turn that fails
+inside the daemon — deadline expiry, teardown flush, child crash — is published
+as a `turn_error` event carrying its `code` / `errorKind`, never as a
+`turn_complete` stopReason. A turn recovered from persisted history after a
+restart is not re-published on the stream at all; it surfaces as
+`promptTerminals[].stopReason === "reconstructed_from_transcript"` in the
+`POST /session/:id/load` response body.
 
 If the HTTP client disconnects mid-prompt, the daemon sends an ACP `cancel` notification to the agent, which winds the prompt down with `stopReason: "cancelled"`.
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2783,8 +2783,16 @@ Response:
 
 The `202` response acknowledges admission, not Agent completion. Observe the
 session SSE stream after `lastEventId` and correlate `turn_complete` or
-`turn_error` by `promptId`. `turn_complete.data.stopReason` may be `end_turn`,
-`cancelled`, `max_tokens`, `error`, or `length`.
+`turn_error` by `promptId`.
+
+`turn_complete.data.stopReason` carries the ACP `StopReason` the agent
+returned — `end_turn`, `max_tokens`, `max_turn_requests`, `refusal` or
+`cancelled` — plus two values the daemon originates itself: `error` when a turn
+fails inside the daemon rather than the agent, and
+`reconstructed_from_transcript` for a turn recovered from persisted history
+rather than observed live. **Treat the field as an open string**: it is typed
+`string` on the wire, the ACP set can grow, and a client that exhaustively
+switches on it will break on the next addition.
 
 If the HTTP client disconnects mid-prompt, the daemon sends an ACP `cancel` notification to the agent, which winds the prompt down with `stopReason: "cancelled"`.
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2787,7 +2787,9 @@ session SSE stream after `lastEventId` and correlate `turn_complete` or
 
 `turn_complete.data.stopReason` carries the ACP `StopReason` the agent
 returned — `end_turn`, `max_tokens`, `max_turn_requests`, `refusal` or
-`cancelled`. **Treat the field as an open string**: it is typed `string` on the
+`cancelled`. The daemon can also emit `cancelled` for a queued prompt removed
+before dispatch; that value does not prove the agent ran the prompt.
+**Treat the field as an open string**: it is typed `string` on the
 wire, the ACP set can grow, and a client that exhaustively switches on it will
 break on the next addition.
 

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -30,10 +30,15 @@ stdio for editors, channels, extensions — are covered by their own guides.
 **The daemon does not run inference in-process.** It spawns `qwen --acp` child
 processes and brokers between them and HTTP, so **the `qwen` executable must be
 installed on the daemon host**. A missing entry point surfaces as
-`MissingCliEntryError`. This is deliberate — each session's agent gets its own
-process, so a crash or runaway allocation is contained to one session. Size the
-container for the daemon plus its concurrent children and cap them with
-`--max-sessions`.
+`MissingCliEntryError`.
+
+There is **at most one child per workspace runtime**, not one per session. Every
+session in a workspace multiplexes onto that child and shares its process, OAuth
+state, file cache and hierarchy-memory parse. So the fault domain is the
+workspace: if the child exits, every session multiplexed onto it is torn down
+together. Size the container for the daemon plus one child per registered
+workspace, and when sessions must fail independently, run separate daemons —
+`--max-sessions` caps concurrency, not blast radius.
 
 **Authentication is single-operator.** One bearer token grants the whole API,
 and a trusted loopback caller gets full authority including code execution as
@@ -59,9 +64,9 @@ through `/proc/<pid>/cmdline`.
 
 ## The routes an integration actually uses
 
-The daemon registers **237** routes. Most of them exist to drive the Web Shell —
-git operations, extension install, workspace trust, voice, scheduled tasks — and
-change with that UI.
+Most of what the daemon registers exists to drive the Web Shell — git
+operations, extension install, workspace trust, voice, scheduled tasks — and
+changes with that UI. The subset below is an order of magnitude smaller.
 
 These are the ones a REST integration needs. Treat the rest as internal.
 
@@ -150,9 +155,10 @@ curl -N http://daemon:4170/session/$SID/events \
 Each `data:` line is a full envelope on one line; the envelope's `type` matches
 the `event:` line.
 
-**4. Prompt.** `202` means admitted. Correlate `turn_complete` / `turn_error` on
-the stream by `promptId`; `stopReason` is one of `end_turn`, `cancelled`,
-`max_tokens`, `error`, `length`.
+**4. Prompt.** `202` means admitted, not finished. Correlate `turn_complete` /
+`turn_error` on the stream by `promptId`, and read `stopReason` for why the turn
+ended — see
+[`POST /session/:id/prompt`](./qwen-serve-protocol.md#post-sessionidprompt).
 
 ```bash
 curl -sX POST http://daemon:4170/session/$SID/prompt \
@@ -176,13 +182,13 @@ curl -sX POST http://daemon:4170/permission/$REQUEST_ID \
 
 ## Operations
 
-| Concern          | Where                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------- |
-| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`    |
-| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                      |
-| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                    |
-| Memory           | `--memory-budget-mb`, `--child-heap-mode` — the budget covers the daemon **and** its children |
-| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                             |
-| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                               |
-| Observability    | [Observability](./daemon/19-observability.md)                                                 |
-| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                 |
+| Concern          | Where                                                                                                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                              |
+| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                |
+| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                              |
+| Memory           | `--memory-budget-mb`, `--child-heap-mode` — **observe-only today**: they report a modelled partition, size no child and refuse no spawn |
+| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                       |
+| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                         |
+| Observability    | [Observability](./daemon/19-observability.md)                                                                                           |
+| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                           |

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -1,0 +1,188 @@
+# REST API integration guide
+
+For teams putting Qwen Code inside their own product over HTTP: run `qwen serve`
+as a backend and drive it from your own front end.
+
+This page is the entry point. The full route reference is
+[`qwen-serve-protocol.md`](./qwen-serve-protocol.md); the internals are the
+[daemon deep dive](./daemon/00-index.md); a runnable TypeScript walkthrough is
+[`examples/daemon-client-quickstart.md`](./examples/daemon-client-quickstart.md).
+
+## Which paths exist
+
+Six ways to build on the daemon, separated by one question — **how much of the
+front end do you own?**
+
+| Path                                 | You own                           | Status                                                                                    |
+| ------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------- |
+| daemon + bundled Web Shell           | nothing — use it as shipped       | ships today ([user guide](../users/qwen-serve.md))                                        |
+| daemon `--no-web` + your own UI      | the entire front end              | ships today — **this page**                                                               |
+| daemon + branded Web Shell           | branding, not code                | not built ([#11357](https://github.com/QwenLM/qwen-code/issues/11357))                    |
+| daemon + self-hosted Web Shell build | the front-end build               | not built ([#11358](https://github.com/QwenLM/qwen-code/issues/11358))                    |
+| daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Python](./sdk-python.md), [Java](./sdk-java.md)) |
+| daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk`                                             |
+
+Integration paths that do not involve the daemon — headless `qwen -p`, ACP over
+stdio for editors, channels, extensions — are covered by their own guides.
+
+## Two things to know before designing
+
+**The daemon does not run inference in-process.** It spawns `qwen --acp` child
+processes and brokers between them and HTTP, so **the `qwen` executable must be
+installed on the daemon host**. A missing entry point surfaces as
+`MissingCliEntryError`. This is deliberate — each session's agent gets its own
+process, so a crash or runaway allocation is contained to one session. Size the
+container for the daemon plus its concurrent children and cap them with
+`--max-sessions`.
+
+**Authentication is single-operator.** One bearer token grants the whole API,
+and a trusted loopback caller gets full authority including code execution as
+the daemon user. There is no per-end-user principal model. If you are putting
+this behind a multi-user product, your backend owns user identity and must not
+hand the daemon token to browsers. Containerised and multi-tenant deployment
+are explicitly deferred — see "v0.16-alpha known limits" in the
+[user guide](../users/qwen-serve.md).
+
+## Start the daemon
+
+```bash
+export QWEN_SERVER_TOKEN="$(openssl rand -hex 32)"
+
+qwen serve --no-web --require-auth \
+  --hostname 0.0.0.0 --port 4170 \
+  --workspace /srv/project
+```
+
+`--no-web` drops the Web Shell assets; it does **not** narrow the API. Pass the
+token by environment rather than `--token`, which is readable by any local user
+through `/proc/<pid>/cmdline`.
+
+## The routes an integration actually uses
+
+The daemon registers **237** routes. Most of them exist to drive the Web Shell —
+git operations, extension install, workspace trust, voice, scheduled tasks — and
+change with that UI.
+
+These are the ones a REST integration needs. Treat the rest as internal.
+
+### Discovery
+
+| Route                                                            | Purpose                                                                      |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [`GET /health`](./qwen-serve-protocol.md#get-health)             | Liveness probe                                                               |
+| [`GET /capabilities`](./qwen-serve-protocol.md#get-capabilities) | Preflight — read `workspaceCwd` and `policy.permission` before anything else |
+
+### Session lifecycle
+
+| Route                                                                                                                                | Purpose                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| [`POST /session`](./qwen-serve-protocol.md#post-session)                                                                             | Create. Send `sessionScope: "thread"` for an independent conversation |
+| [`DELETE /session/:id`](./qwen-serve-protocol.md#delete-sessionid)                                                                   | Close. The persisted session survives and can be reloaded             |
+| [`POST /session/:id/load`](./qwen-serve-protocol.md#post-sessionidload) · [`/resume`](./qwen-serve-protocol.md#post-sessionidresume) | Restore a persisted session                                           |
+| [`POST /session/:id/heartbeat`](./qwen-serve-protocol.md#post-sessionidheartbeat)                                                    | Defer the idle reaper                                                 |
+| [`PATCH /session/:id/metadata`](./qwen-serve-protocol.md#patch-sessionidmetadata)                                                    | Session metadata                                                      |
+| [`POST /session/:id/model`](./qwen-serve-protocol.md#post-sessionidmodel)                                                            | Switch model within the bound service                                 |
+| `GET /session/:id/status`                                                                                                            | Runtime status — _no dedicated reference section yet_                 |
+
+### Prompting and streaming
+
+| Route                                                                             | Purpose                                                |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [`POST /session/:id/prompt`](./qwen-serve-protocol.md#post-sessionidprompt)       | Submit. Returns `202` on **admission**, not completion |
+| [`POST /session/:id/cancel`](./qwen-serve-protocol.md#post-sessionidcancel)       | Cancel the active prompt only                          |
+| [`GET /session/:id/events`](./qwen-serve-protocol.md#get-sessionidevents-sse)     | SSE stream. Subscribe **before** prompting             |
+| [`GET /session/:id/transcript`](./qwen-serve-protocol.md#get-sessionidtranscript) | Conversation history                                   |
+| [`GET /session/:id/context`](./qwen-serve-protocol.md#get-sessionidcontext)       | Context window usage                                   |
+| `GET /session/:id/export` · `GET /session/:id/pending-prompts`                    | _No dedicated reference sections yet_                  |
+
+### Permissions
+
+| Route                                                                              | Purpose                                          |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------ |
+| [`POST /permission/:requestId`](./qwen-serve-protocol.md#post-permissionrequestid) | Answer a `permission_request`                    |
+| `POST /session/:id/permission/:requestId`                                          | Session-scoped form — _no dedicated section yet_ |
+
+### Read-only workspace context
+
+| Route                                                                                                      | Purpose                                                              |
+| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`GET /file`](./qwen-serve-protocol.md#get-file) · [`/file/bytes`](./qwen-serve-protocol.md#get-filebytes) | Read a file, or a byte range                                         |
+| `GET /stat` · `GET /list` · `GET /glob`                                                                    | Path metadata, directory listing, glob — _no dedicated sections yet_ |
+| `GET /workspace/tools`                                                                                     | Available tools — _no dedicated section yet_                         |
+
+> **Reference coverage.** 17 of the 25 routes above have a dedicated section in
+> the protocol reference; the 8 marked otherwise are reachable and stable but
+> currently documented only in passing. Closing that is tracked in
+> [#11359](https://github.com/QwenLM/qwen-code/issues/11359).
+
+## Minimal flow
+
+**1. Preflight.** Read `workspaceCwd` (so you can omit `cwd` on create) and
+`policy.permission` (so you know who may answer permission requests).
+
+```bash
+curl -sH "Authorization: Bearer $QWEN_SERVER_TOKEN" http://daemon:4170/capabilities
+```
+
+**2. Create a session.** Use `sessionScope: "thread"` unless callers are meant
+to share one conversation — the default `"single"` makes a second
+same-workspace create _reuse_ the existing session, serialising unrelated
+callers through one queue.
+
+```bash
+curl -sX POST http://daemon:4170/session \
+  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sessionScope":"thread"}'
+# → {"sessionId":"…","workspaceCwd":"/srv/project","attached":false}
+```
+
+**3. Subscribe before prompting.** `Last-Event-ID: 0` replays from the oldest
+retained event, which is how you catch events fired between create and
+subscribe — notably `model_switch_failed`, the only signal that a bad
+`modelServiceId` was rejected (the create itself still returns 200).
+
+```bash
+curl -N http://daemon:4170/session/$SID/events \
+  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" \
+  -H 'Accept: text/event-stream' -H 'Last-Event-ID: 0'
+```
+
+Each `data:` line is a full envelope on one line; the envelope's `type` matches
+the `event:` line.
+
+**4. Prompt.** `202` means admitted. Correlate `turn_complete` / `turn_error` on
+the stream by `promptId`; `stopReason` is one of `end_turn`, `cancelled`,
+`max_tokens`, `error`, `length`.
+
+```bash
+curl -sX POST http://daemon:4170/session/$SID/prompt \
+  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"prompt":[{"type":"text","text":"What does src/main.ts do?"}]}'
+# → 202 {"promptId":"…","lastEventId":42}
+```
+
+**5. Answer permission requests.** When the agent wants to run a tool it emits
+`permission_request` and the turn blocks until someone answers or the timeout
+fires. Decide up front how your integration answers — an auto-approve policy is
+a security decision, not a default.
+
+```bash
+curl -sX POST http://daemon:4170/permission/$REQUEST_ID \
+  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"outcome":{"outcome":"selected","optionId":"proceed_once"}}'
+```
+
+**6. Close.** `DELETE /session/$SID` → `204`. The on-disk session is retained.
+
+## Operations
+
+| Concern          | Where                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`    |
+| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                      |
+| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                    |
+| Memory           | `--memory-budget-mb`, `--child-heap-mode` — the budget covers the daemon **and** its children |
+| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                             |
+| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                               |
+| Observability    | [Observability](./daemon/19-observability.md)                                                 |
+| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                 |

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -13,14 +13,14 @@ This page is the entry point. The full route reference is
 Six ways to build on the daemon, separated by one question — **how much of the
 front end do you own?**
 
-| Path                                 | You own                           | Status                                                                                    |
-| ------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------- |
-| daemon + bundled Web Shell           | nothing — use it as shipped       | ships today ([user guide](../users/qwen-serve.md))                                        |
-| daemon `--no-web` + your own UI      | the entire front end              | ships today — **this page**                                                               |
-| daemon + branded Web Shell           | branding, not code                | not built ([#11357](https://github.com/QwenLM/qwen-code/issues/11357))                    |
-| daemon + self-hosted Web Shell build | the front-end build               | not built ([#11358](https://github.com/QwenLM/qwen-code/issues/11358))                    |
-| daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Python](./sdk-python.md), [Java](./sdk-java.md)) |
-| daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk`                                             |
+| Path                                 | You own                           | Status                                                                                                                                                                                                     |
+| ------------------------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| daemon + bundled Web Shell           | nothing — use it as shipped       | ships today ([user guide](../users/qwen-serve.md))                                                                                                                                                         |
+| daemon `--no-web` + your own UI      | the entire front end              | ships today — **this page**                                                                                                                                                                                |
+| daemon + branded Web Shell           | branding, not code                | not built ([#11357](https://github.com/QwenLM/qwen-code/issues/11357))                                                                                                                                     |
+| daemon + self-hosted Web Shell build | the front-end build               | not built ([#11358](https://github.com/QwenLM/qwen-code/issues/11358))                                                                                                                                     |
+| daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Java](./sdk-java.md)) — the [Python SDK](./sdk-python.md) is process-transport-only and has no daemon client, so a Python integration drives path 2 over raw HTTP |
+| daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk`                                                                                                                                                              |
 
 Integration paths that do not involve the daemon — headless `qwen -p`, ACP over
 stdio for editors, channels, extensions — are covered by their own guides.
@@ -102,10 +102,10 @@ These are the ones a REST integration needs. Treat the rest as internal.
 
 ### Permissions
 
-| Route                                                                              | Purpose                                          |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------ |
-| [`POST /permission/:requestId`](./qwen-serve-protocol.md#post-permissionrequestid) | Answer a `permission_request`                    |
-| `POST /session/:id/permission/:requestId`                                          | Session-scoped form — _no dedicated section yet_ |
+| Route                                                                              | Purpose                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /session/:id/permission/:requestId`                                          | Answer a `permission_request`. Routed to the runtime that owns the session, so it is correct in every workspace state — _no dedicated section yet_                                                                                                                                          |
+| [`POST /permission/:requestId`](./qwen-serve-protocol.md#post-permissionrequestid) | Process-global form, wired to the **primary** workspace's bridge only: it `404`s for a session owned by another registered runtime, with the same body as a lost vote under the default `first-responder` policy — so a `404` here does not by itself mean the request was already answered |
 
 ### Read-only workspace context
 
@@ -143,8 +143,13 @@ curl -sX POST http://daemon:4170/session \
 
 **3. Subscribe before prompting.** `Last-Event-ID: 0` replays from the oldest
 retained event, which is how you catch events fired between create and
-subscribe — notably `model_switch_failed`, the only signal that a bad
-`modelServiceId` was rejected (the create itself still returns 200).
+subscribe — notably `model_switch_failed`. On an **attach** (the default
+`sessionScope: "single"` reusing an existing session) that event is the only
+signal that a bad `modelServiceId` was rejected, because the failure is
+deliberately not propagated as an HTTP error. On a **fresh create** — which is
+what `sessionScope: "thread"` in step 2 forces — the `200` body also carries
+`modelApplied: false`, and that is the deterministic one to act on rather than
+an event on a bounded ring.
 
 ```bash
 curl -N http://daemon:4170/session/$SID/events \
@@ -168,12 +173,18 @@ curl -sX POST http://daemon:4170/session/$SID/prompt \
 ```
 
 **5. Answer permission requests.** When the agent wants to run a tool it emits
-`permission_request` and the turn blocks until someone answers or the timeout
-fires. Decide up front how your integration answers — an auto-approve policy is
-a security decision, not a default.
+`permission_request` and the turn blocks until someone answers or you cancel —
+**by default there is no timeout** (`--permission-response-timeout-ms` defaults
+to `0` = wait indefinitely), so an unanswered request keeps holding a slot in
+the session's prompt queue until you cancel or close the session. Arm your own
+deadline if the flow needs one. Decide up front how your integration answers —
+an auto-approve policy is a security decision, not a default.
+
+Answer on the session-scoped route: it is routed to the runtime that owns the
+session, so it works whatever the workspace configuration.
 
 ```bash
-curl -sX POST http://daemon:4170/permission/$REQUEST_ID \
+curl -sX POST http://daemon:4170/session/$SID/permission/$REQUEST_ID \
   -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
   -d '{"outcome":{"outcome":"selected","optionId":"proceed_once"}}'
 ```
@@ -182,13 +193,13 @@ curl -sX POST http://daemon:4170/permission/$REQUEST_ID \
 
 ## Operations
 
-| Concern          | Where                                                                                                                                   |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                              |
-| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                |
-| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                              |
-| Memory           | `--memory-budget-mb`, `--child-heap-mode` — **observe-only today**: they report a modelled partition, size no child and refuse no spawn |
-| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                       |
-| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                         |
-| Observability    | [Observability](./daemon/19-observability.md)                                                                                           |
-| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                           |
+| Concern          | Where                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Memory           | `--child-heap-mode` — **observe-only**: reports a modelled per-child partition, sizes no child and refuses no spawn. `--memory-budget-mb` sizes no child and refuses no spawn either, but it does set the daemon-wide adaptive live-journal growth pool (5% of the effective budget, capped at 1024 MB, and 0 — growth disabled — below the 1024 MB minimum), which bounds how much SSE history `Last-Event-ID` replay can return; see `--max-journal-bytes`. Neither flag governs the heap ceiling ACP children are actually spawned with (`--max-old-space-size`, derived from host memory) |
+| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Observability    | [Observability](./daemon/19-observability.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -22,31 +22,38 @@ front end do you own?**
 | daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Java](./sdk-java.md)) — the [Python SDK](./sdk-python.md) is process-transport-only and has no daemon client, so a Python integration drives path 2 over raw HTTP |
 | daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk`                                                                                                                                                              |
 
-Integration paths that do not involve the daemon — headless `qwen -p`, ACP over
-stdio for editors, channels, extensions — are covered by their own guides.
+Headless `qwen -p` and ACP over stdio for editors are separate integration
+paths. Channels and extensions can also run through the daemon; their own
+guides cover those surfaces.
 
 ## Two things to know before designing
 
 **The daemon does not run inference in-process.** It spawns `qwen --acp` child
-processes and brokers between them and HTTP, so **the `qwen` executable must be
-installed on the daemon host**. A missing entry point surfaces as
-`MissingCliEntryError`.
+processes and brokers between them and HTTP. It runs the CLI entry script under
+the same Node binary, using `QWEN_CLI_ENTRY` or otherwise `process.argv[1]`.
+An embedding Node backend must point `QWEN_CLI_ENTRY` at the installed Qwen CLI
+entry script; there is no `qwen` lookup on `PATH`.
 
-There is **at most one child per workspace runtime**, not one per session. Every
+In steady state there is **one child per active workspace runtime**, not one per session. Every
 session in a workspace multiplexes onto that child and shares its process, OAuth
 state, file cache and hierarchy-memory parse. So the fault domain is the
 workspace: if the child exits, every session multiplexed onto it is torn down
 together. Size the container for the daemon plus one child per registered
-workspace, and when sessions must fail independently, run separate daemons —
+workspace, with headroom for overlapping old and replacement children during
+channel swaps. When sessions must fail independently, run separate daemons —
 `--max-sessions` caps concurrency, not blast radius.
 
-**Authentication is single-operator.** One bearer token grants the whole API,
+**Authentication is single-operator.** The runtime bearer token grants API authority,
 and a trusted loopback caller gets full authority including code execution as
 the daemon user. There is no per-end-user principal model. If you are putting
 this behind a multi-user product, your backend owns user identity and must not
 hand the daemon token to browsers. Containerised and multi-tenant deployment
 are explicitly deferred — see "v0.16-alpha known limits" in the
 [user guide](../users/qwen-serve.md).
+
+Configured channel webhook ingress uses its own `x-qwen-webhook-secret`
+authentication before bearer authentication; `--require-auth` does not make
+that ingress require the runtime bearer token.
 
 ## Start the daemon
 
@@ -58,9 +65,14 @@ qwen serve --no-web --require-auth \
   --workspace /srv/project
 ```
 
-`--no-web` drops the Web Shell assets; it does **not** narrow the API. Pass the
+`--no-web` preserves the routes listed below, but disables Web Shell assets
+and dependent surfaces, including macOS live voice and the MCP app sandbox.
+Pass the
 token by environment rather than `--token`, which is readable by any local user
 through `/proc/<pid>/cmdline`.
+
+The Bash examples below pass the Authorization header through a file descriptor
+using the shell's `printf` builtin, keeping the token out of curl's arguments.
 
 ## The routes an integration actually uses
 
@@ -109,15 +121,15 @@ These are the ones a REST integration needs. Treat the rest as internal.
 
 ### Read-only workspace context
 
-| Route                                                                                                      | Purpose                                                              |
-| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [`GET /file`](./qwen-serve-protocol.md#get-file) · [`/file/bytes`](./qwen-serve-protocol.md#get-filebytes) | Read a file, or a byte range                                         |
-| `GET /stat` · `GET /list` · `GET /glob`                                                                    | Path metadata, directory listing, glob — _no dedicated sections yet_ |
-| `GET /workspace/tools`                                                                                     | Available tools — _no dedicated section yet_                         |
+| Route                                                                                                      | Purpose                                                                                                                        |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [`GET /file`](./qwen-serve-protocol.md#get-file) · [`/file/bytes`](./qwen-serve-protocol.md#get-filebytes) | Read a file, or a byte range                                                                                                   |
+| `GET /stat` · `GET /list` · `GET /glob`                                                                    | Path metadata, directory listing, glob — _no dedicated sections yet_                                                           |
+| `GET /workspace/tools`                                                                                     | Tools reported by the live ACP child; an empty list without a child is not a capability inventory — _no dedicated section yet_ |
 
-> **Reference coverage.** 17 of the 25 routes above have a dedicated section in
-> the protocol reference; the 8 marked otherwise are reachable and stable but
-> currently documented only in passing. Closing that is tracked in
+> **Reference coverage.** Routes marked as lacking a dedicated section may be
+> mentioned only in passing or absent from the protocol reference.
+> Closing that is tracked in
 > [#11359](https://github.com/QwenLM/qwen-code/issues/11359).
 
 ## Minimal flow
@@ -126,7 +138,7 @@ These are the ones a REST integration needs. Treat the rest as internal.
 `policy.permission` (so you know who may answer permission requests).
 
 ```bash
-curl -sH "Authorization: Bearer $QWEN_SERVER_TOKEN" http://daemon:4170/capabilities
+curl -sH @<(printf 'Authorization: Bearer %s\n' "$QWEN_SERVER_TOKEN") http://daemon:4170/capabilities
 ```
 
 **2. Create a session.** Use `sessionScope: "thread"` unless callers are meant
@@ -136,7 +148,7 @@ callers through one queue.
 
 ```bash
 curl -sX POST http://daemon:4170/session \
-  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -H @<(printf 'Authorization: Bearer %s\n' "$QWEN_SERVER_TOKEN") -H 'Content-Type: application/json' \
   -d '{"sessionScope":"thread"}'
 # → {"sessionId":"…","workspaceCwd":"/srv/project","attached":false}
 ```
@@ -154,21 +166,25 @@ without `modelServiceId` has no `modelApplied` key at all.
 
 ```bash
 curl -N http://daemon:4170/session/$SID/events \
-  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" \
+  -H @<(printf 'Authorization: Bearer %s\n' "$QWEN_SERVER_TOKEN") \
   -H 'Accept: text/event-stream' -H 'Last-Event-ID: 0'
 ```
 
 Each `data:` line is a full envelope on one line; the envelope's `type` matches
 the `event:` line.
 
+Replay is limited by the event ring and a per-subscription byte budget. If the
+stream emits `state_resync_required`, recover through `POST /session/:id/load`
+instead of treating the replay as complete.
+
 **4. Prompt.** `202` means admitted, not finished. Correlate `turn_complete` /
-`turn_error` on the stream by `promptId`, and read `stopReason` for why the turn
-ended — see
+`turn_error` on the stream by `promptId`. Read `stopReason` on `turn_complete`;
+on `turn_error`, read `message` and any optional `code` / `errorKind` — see
 [`POST /session/:id/prompt`](./qwen-serve-protocol.md#post-sessionidprompt).
 
 ```bash
 curl -sX POST http://daemon:4170/session/$SID/prompt \
-  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -H @<(printf 'Authorization: Bearer %s\n' "$QWEN_SERVER_TOKEN") -H 'Content-Type: application/json' \
   -d '{"prompt":[{"type":"text","text":"What does src/main.ts do?"}]}'
 # → 202 {"promptId":"…","lastEventId":42}
 ```
@@ -197,7 +213,7 @@ session, so it works whatever the workspace configuration.
 
 ```bash
 curl -sX POST http://daemon:4170/session/$SID/permission/$REQUEST_ID \
-  -H "Authorization: Bearer $QWEN_SERVER_TOKEN" -H 'Content-Type: application/json' \
+  -H @<(printf 'Authorization: Bearer %s\n' "$QWEN_SERVER_TOKEN") -H 'Content-Type: application/json' \
   -d '{"outcome":{"outcome":"selected","optionId":"proceed_once"}}'
 ```
 
@@ -205,13 +221,13 @@ curl -sX POST http://daemon:4170/session/$SID/permission/$REQUEST_ID \
 
 ## Operations
 
-| Concern          | Where                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Memory           | `--child-heap-mode` — **observe-only**: reports a modelled per-child partition, sizes no child and refuses no spawn. `--memory-budget-mb` sizes no child and refuses no spawn either, but it does set the daemon-wide adaptive live-journal growth pool (5% of the effective budget, capped at 1024 MB, and 0 — growth disabled — below the 1024 MB minimum), which bounds how much SSE history `Last-Event-ID` replay can return; see `--max-journal-bytes`. Neither flag governs the heap ceiling ACP children are actually spawned with (`--max-old-space-size`, derived from host memory) |
-| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| Observability    | [Observability](./daemon/19-observability.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Concern          | Where                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Memory           | `--child-heap-mode` is observe-only. `--memory-budget-mb` controls the adaptive live-journal growth pool for `POST /session/:id/load`, not SSE replay; pinning either `--max-journal-bytes` or `--max-journal-events` disables growth. Neither flag sizes children or refuses spawns, nor governs their actual heap ceiling (`--max-old-space-size`, derived from host memory). See [Configuration](./daemon/17-configuration.md) for budget calculation. SSE replay is separately bounded by `--event-ring-size` and a byte budget; an omitted tail produces `state_resync_required` with `reason: "replay_budget_exceeded"` |
+| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| Observability    | [Observability](./daemon/19-observability.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -13,36 +13,47 @@ This page is the entry point. The full route reference is
 Six ways to build on the daemon, separated by one question — **how much of the
 front end do you own?**
 
-| Path                                 | You own                           | Status                                                                                                                                                                                                     |
-| ------------------------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| daemon + bundled Web Shell           | nothing — use it as shipped       | ships today ([user guide](../users/qwen-serve.md))                                                                                                                                                         |
-| daemon `--no-web` + your own UI      | the entire front end              | ships today — **this page**                                                                                                                                                                                |
-| daemon + branded Web Shell           | branding, not code                | not built ([#11357](https://github.com/QwenLM/qwen-code/issues/11357))                                                                                                                                     |
-| daemon + self-hosted Web Shell build | the front-end build               | not built ([#11358](https://github.com/QwenLM/qwen-code/issues/11358))                                                                                                                                     |
-| daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Java](./sdk-java.md)) — the [Python SDK](./sdk-python.md) is process-transport-only and has no daemon client, so a Python integration drives path 2 over raw HTTP |
-| daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk`                                                                                                                                                              |
+| Path                                 | You own                           | Status                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| daemon + bundled Web Shell           | nothing — use it as shipped       | ships today ([user guide](../users/qwen-serve.md))                                                                                                                                                                                                                                                                                    |
+| daemon `--no-web` + your own UI      | the entire front end              | ships today — **this page**                                                                                                                                                                                                                                                                                                           |
+| daemon + branded Web Shell           | branding, not code                | not built ([#11357](https://github.com/QwenLM/qwen-code/issues/11357))                                                                                                                                                                                                                                                                |
+| daemon + self-hosted Web Shell build | the front-end build               | not built ([#11358](https://github.com/QwenLM/qwen-code/issues/11358))                                                                                                                                                                                                                                                                |
+| daemon via SDK `DaemonClient`        | client code, never raw HTTP       | ships today ([TS](./sdk-typescript.md), [Java](./sdk-java.md)) — the [Python SDK](./sdk-python.md) is process-transport-only and has no daemon client, so a Python integration drives path 2 over raw HTTP                                                                                                                            |
+| daemon via MCP bridge                | nothing — another agent drives it | ships as `qwen-serve-mcp` in `@qwen-code/sdk` — see the [bridge README](../../packages/sdk-typescript/src/daemon-mcp/serve-bridge/README.md) (repo-only, Chinese until promoted); configure `QWEN_DAEMON_URL`, `QWEN_DAEMON_TOKEN`, `QWEN_WORKSPACE_CWD`, and `QWEN_BRIDGE_ALLOW_GLOBAL_SCOPE` to permit global-scope write mutations |
 
 Integration paths that do not involve the daemon — headless `qwen -p`, ACP over
-stdio for editors, channels, extensions — are covered by their own guides.
+stdio for editors — are covered by their own guides. Channels and extensions
+have both standalone and daemon-hosted modes (`qwen serve --channel`,
+`/extensions`); see the [channel guide](../users/features/channels/overview.md).
 
 ## Two things to know before designing
 
 **The daemon does not run inference in-process.** It spawns `qwen --acp` child
-processes and brokers between them and HTTP, so **the `qwen` executable must be
-installed on the daemon host**. A missing entry point surfaces as
-`MissingCliEntryError`.
+processes and brokers between them and HTTP. The daemon re-runs its own CLI
+entry under the same Node binary with `--acp`, resolved as `QWEN_CLI_ENTRY`
+else the entry it was started from — so an embedded launch must set
+`QWEN_CLI_ENTRY` to the absolute path of the qwen entry script. A missing entry
+point surfaces as `MissingCliEntryError`.
 
 There is **at most one child per workspace runtime**, not one per session. Every
 session in a workspace multiplexes onto that child and shares its process, OAuth
 state, file cache and hierarchy-memory parse. So the fault domain is the
 workspace: if the child exits, every session multiplexed onto it is torn down
 together. Size the container for the daemon plus one child per registered
-workspace, and when sessions must fail independently, run separate daemons —
+workspace in steady state, with headroom for one extra child per runtime during
+a channel replacement — the terminating child is counted until it actually
+exits, and the grace window is seconds, not milliseconds. When sessions must
+fail independently, run separate daemons —
 `--max-sessions` caps concurrency, not blast radius.
 
-**Authentication is single-operator.** One bearer token grants the whole API,
-and a trusted loopback caller gets full authority including code execution as
-the daemon user. There is no per-end-user principal model. If you are putting
+**Authentication is single-operator.** One bearer token grants the whole
+bearer-gated API, and a trusted loopback caller gets full authority including
+code execution as the daemon user. The one exception is channel webhook ingress
+(`POST /channels/:channelName/webhooks/:source`), mounted ahead of the bearer
+gate in every mode and authenticated by its own `x-qwen-webhook-secret`; it is
+inert until you configure a channel webhook source. There is no per-end-user
+principal model. If you are putting
 this behind a multi-user product, your backend owns user identity and must not
 hand the daemon token to browsers. Containerised and multi-tenant deployment
 are explicitly deferred — see "v0.16-alpha known limits" in the
@@ -58,9 +69,11 @@ qwen serve --no-web --require-auth \
   --workspace /srv/project
 ```
 
-`--no-web` drops the Web Shell assets; it does **not** narrow the API. Pass the
-token by environment rather than `--token`, which is readable by any local user
-through `/proc/<pid>/cmdline`.
+`--no-web` drops the Web Shell assets and the Web-Shell-only surfaces built on
+them — on macOS the `/live/*` routes and the `/live/host` socket, and on every
+platform `GET /mcp-app-sandbox`. It does not narrow any of the REST routes
+listed on this page. Pass the token by environment rather than `--token`, which
+is readable by any local user through `/proc/<pid>/cmdline`.
 
 ## The routes an integration actually uses
 
@@ -109,18 +122,25 @@ These are the ones a REST integration needs. Treat the rest as internal.
 
 ### Read-only workspace context
 
-| Route                                                                                                      | Purpose                                                              |
-| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [`GET /file`](./qwen-serve-protocol.md#get-file) · [`/file/bytes`](./qwen-serve-protocol.md#get-filebytes) | Read a file, or a byte range                                         |
-| `GET /stat` · `GET /list` · `GET /glob`                                                                    | Path metadata, directory listing, glob — _no dedicated sections yet_ |
-| `GET /workspace/tools`                                                                                     | Available tools — _no dedicated section yet_                         |
+| Route                                                                                                      | Purpose                                                                                                                                                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`GET /file`](./qwen-serve-protocol.md#get-file) · [`/file/bytes`](./qwen-serve-protocol.md#get-filebytes) | Read a file, or a byte range                                                                                                                                                                                                                              |
+| `GET /stat` · `GET /list` · `GET /glob`                                                                    | Path metadata, directory listing, glob — _no dedicated sections yet_                                                                                                                                                                                      |
+| `GET /workspace/tools`                                                                                     | Available tools — empty whenever the workspace runtime has no live ACP child; the response then carries `acpChannelLive: false` and an `errors[]` cell with `status: "not_started"` and `hint: "spawn a session to populate"`. _no dedicated section yet_ |
 
 > **Reference coverage.** 17 of the 25 routes above have a dedicated section in
-> the protocol reference; the 8 marked otherwise are reachable and stable but
-> currently documented only in passing. Closing that is tracked in
+> the protocol reference. Of the 8 marked otherwise, five are mentioned in
+> passing there; three — `GET /session/:id/pending-prompts`,
+> `POST /session/:id/permission/:requestId` and `GET /workspace/tools` — do not
+> appear in the reference at all and need authoring rather than a section.
+> Closing that is tracked in
 > [#11359](https://github.com/QwenLM/qwen-code/issues/11359).
 
 ## Minimal flow
+
+The snippets below pass the token in `curl`'s argv, which is world-readable
+through `/proc/<pid>/cmdline` while each request runs. In production use the
+SDK, or a client that sets the header in-process.
 
 **1. Preflight.** Read `workspaceCwd` (so you can omit `cwd` on create) and
 `policy.permission` (so you know who may answer permission requests).
@@ -159,11 +179,13 @@ curl -N http://daemon:4170/session/$SID/events \
 ```
 
 Each `data:` line is a full envelope on one line; the envelope's `type` matches
-the `event:` line.
+the `event:` line. If replay exceeds the per-subscribe budget, the stream emits
+`state_resync_required` (`reason: "replay_budget_exceeded"`); recover via
+`POST /session/:id/load`.
 
 **4. Prompt.** `202` means admitted, not finished. Correlate `turn_complete` /
-`turn_error` on the stream by `promptId`, and read `stopReason` for why the turn
-ended — see
+`turn_error` on the stream by `promptId`, and read why the turn ended from
+`stopReason` on `turn_complete` or `code` / `errorKind` on `turn_error` — see
 [`POST /session/:id/prompt`](./qwen-serve-protocol.md#post-sessionidprompt).
 
 ```bash
@@ -205,13 +227,13 @@ curl -sX POST http://daemon:4170/session/$SID/permission/$REQUEST_ID \
 
 ## Operations
 
-| Concern          | Where                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Memory           | `--child-heap-mode` — **observe-only**: reports a modelled per-child partition, sizes no child and refuses no spawn. `--memory-budget-mb` sizes no child and refuses no spawn either, but it does set the daemon-wide adaptive live-journal growth pool (5% of the effective budget, capped at 1024 MB, and 0 — growth disabled — below the 1024 MB minimum), which bounds how much SSE history `Last-Event-ID` replay can return; see `--max-journal-bytes`. Neither flag governs the heap ceiling ACP children are actually spawned with (`--max-old-space-size`, derived from host memory) |
-| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| Observability    | [Observability](./daemon/19-observability.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Concern          | Where                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Concurrency caps | `--max-sessions`, `--max-total-sessions`; over-cap creates return `503` with `Retry-After`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Rate limiting    | `--rate-limit` plus the per-class `--rate-limit-*` flags                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Idle cleanup     | `--session-idle-timeout-ms`; keep alive with `POST /session/:id/heartbeat`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Memory           | `--child-heap-mode` — **observe-only**: reports a modelled per-child partition, sizes no child and refuses no spawn. `--memory-budget-mb` sizes no child and refuses no spawn either, but it does set the daemon-wide adaptive live-journal growth pool, which bounds the `POST /session/:id/load` live-journal window; see `--max-journal-bytes` and `--max-journal-events` (pinning either disables growth). SSE `Last-Event-ID` replay is bounded separately — by `--event-ring-size` plus a fixed 8 MiB per-subscribe burst, past which the newest frames are dropped and the stream emits `state_resync_required` (`reason: "replay_budget_exceeded"`); recover via `POST /session/:id/load`. Neither flag governs the heap ceiling ACP children are actually spawned with (`--max-old-space-size`, derived from host memory) |
+| Prompt deadlines | `--prompt-deadline-ms`; expiry emits `turn_error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Errors           | [Error taxonomy](./daemon/18-error-taxonomy.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Observability    | [Observability](./daemon/19-observability.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Full flag list   | [Configuration](./daemon/17-configuration.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |

--- a/docs/developers/rest-api-integration.md
+++ b/docs/developers/rest-api-integration.md
@@ -146,10 +146,11 @@ retained event, which is how you catch events fired between create and
 subscribe — notably `model_switch_failed`. On an **attach** (the default
 `sessionScope: "single"` reusing an existing session) that event is the only
 signal that a bad `modelServiceId` was rejected, because the failure is
-deliberately not propagated as an HTTP error. On a **fresh create** — which is
-what `sessionScope: "thread"` in step 2 forces — the `200` body also carries
-`modelApplied: false`, and that is the deterministic one to act on rather than
-an event on a bounded ring.
+deliberately not propagated as an HTTP error. On a **fresh create** that carries
+`modelServiceId` — which step 2's body does not — the `200` body also carries
+`modelApplied`, `false` when the switch was rejected, and that is the
+deterministic one to act on rather than an event on a bounded ring. A create
+without `modelServiceId` has no `modelApplied` key at all.
 
 ```bash
 curl -N http://daemon:4170/session/$SID/events \
@@ -172,13 +173,24 @@ curl -sX POST http://daemon:4170/session/$SID/prompt \
 # → 202 {"promptId":"…","lastEventId":42}
 ```
 
-**5. Answer permission requests.** When the agent wants to run a tool it emits
-`permission_request` and the turn blocks until someone answers or you cancel —
-**by default there is no timeout** (`--permission-response-timeout-ms` defaults
-to `0` = wait indefinitely), so an unanswered request keeps holding a slot in
-the session's prompt queue until you cancel or close the session. Arm your own
-deadline if the flow needs one. Decide up front how your integration answers —
-an auto-approve policy is a security decision, not a default.
+**5. Answer permission requests.** When the agent wants to run a tool _and its
+approval mode asks for confirmation_, it emits `permission_request` and the turn
+blocks until someone answers or you cancel — **by default there is no timeout**
+(`--permission-response-timeout-ms` defaults to `0` = wait indefinitely), so an
+unanswered request keeps holding a slot in the session's prompt queue until you
+cancel or close the session. Arm your own deadline if the flow needs one.
+
+The mode is the child's own Qwen setting `tools.approvalMode`, resolved from the
+daemon host's and the `--workspace` directory's settings; the daemon pins
+nothing at spawn. Its default is `auto`, which approves one class of tool calls
+without asking — those publish no `permission_request` at all — and still asks
+for the rest. An untrusted workspace folder is forced down to `default` (ask),
+which is why one deployment sees these events and another sees none, and
+`GET /capabilities` reports the vote-mediation policy rather than the approval
+mode, so preflight will not tell you which posture you are in. If your
+integration depends on approval gating, pin `tools.approvalMode` explicitly and
+decide up front how it answers: auto-approval can already be in effect without
+anyone having chosen it.
 
 Answer on the session-scoped route: it is routed to the runtime that owns the
 session, so it works whatever the workspace configuration.

--- a/packages/cli/src/serve/rest-integration-docs-contract.test.ts
+++ b/packages/cli/src/serve/rest-integration-docs-contract.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `docs/developers/rest-api-integration.md` tells integrators that a specific
+ * 25-route subset is the surface they should build on. That claim has no
+ * mechanical backing: the daemon registers 237 routes, and a rename upstream
+ * would leave the guide promising a route that no longer answers, with nothing
+ * failing.
+ *
+ * This is the same shape as `capabilities-docs-contract.test.ts`, which guards
+ * the protocol doc's conditional-tag table against the capability registry.
+ * Scope is deliberately the guide's own promises rather than all 237 routes: a
+ * full inventory would need a ~174-entry "known undocumented" baseline, which
+ * is bulk in service of a problem nobody has reported. Widen it when that
+ * changes.
+ */
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
+const GUIDE = path.join(REPO_ROOT, 'docs/developers/rest-api-integration.md');
+const PROTOCOL = path.join(REPO_ROOT, 'docs/developers/qwen-serve-protocol.md');
+const SERVE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Routes the guide presents as the integration surface. */
+const GUIDE_ROUTES: readonly string[] = [
+  '/health',
+  '/capabilities',
+  '/session',
+  '/session/:id',
+  '/session/:id/prompt',
+  '/session/:id/cancel',
+  '/session/:id/events',
+  '/session/:id/status',
+  '/session/:id/transcript',
+  '/session/:id/context',
+  '/session/:id/export',
+  '/session/:id/pending-prompts',
+  '/session/:id/heartbeat',
+  '/session/:id/metadata',
+  '/session/:id/model',
+  '/session/:id/load',
+  '/session/:id/resume',
+  '/session/:id/permission/:requestId',
+  '/permission/:requestId',
+  '/workspace/tools',
+  '/file',
+  '/file/bytes',
+  '/stat',
+  '/list',
+  '/glob',
+];
+
+/**
+ * Collect every path the serve tree registers on an Express app or router.
+ * Reading the sources rather than instantiating the app keeps this independent
+ * of the bridge/deps wiring `createServeApp` needs, and covers route groups
+ * that only mount under specific options.
+ */
+function registeredPaths(): Set<string> {
+  const found = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.ts') || entry.name.includes('.test.')) {
+        continue;
+      }
+      const src = readFileSync(full, 'utf8');
+      // The path literal is often on its own line after the method call.
+      const re =
+        /\b(?:app|router)\.(?:get|post|patch|put|delete|all)\(\s*\n?\s*'([^']+)'/g;
+      for (const match of src.matchAll(re)) {
+        // Workspace-qualified routes mirror their primary-workspace form.
+        found.add(match[1].replace(/^\/workspaces\/:workspace/, '/workspace'));
+      }
+    }
+  };
+  walk(SERVE_DIR);
+  return found;
+}
+
+/** GitHub/Nextra heading slug, so anchor links in the guide can be checked. */
+function slug(heading: string): string {
+  return heading
+    .replace(/`/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+describe('REST integration guide contract', () => {
+  it('promises only routes the daemon still registers', () => {
+    const registered = registeredPaths();
+    expect(GUIDE_ROUTES.filter((route) => !registered.has(route))).toEqual([]);
+  });
+
+  it('links only to anchors the protocol reference actually has', () => {
+    const anchors = new Set(
+      [...readFileSync(PROTOCOL, 'utf8').matchAll(/^#{1,6} (.+)$/gm)].map(
+        (match) => slug(match[1]),
+      ),
+    );
+    const broken = [
+      ...readFileSync(GUIDE, 'utf8').matchAll(
+        /\]\(\.\/qwen-serve-protocol\.md#([a-z0-9-]+)\)/g,
+      ),
+    ]
+      .map((match) => match[1])
+      .filter((anchor) => !anchors.has(anchor));
+    expect(broken).toEqual([]);
+  });
+
+  it('keeps its "no dedicated section yet" notes honest', () => {
+    // The guide marks 8 of the 25 as lacking a reference section. When someone
+    // writes one, this fails so the note gets removed instead of going stale.
+    const protocol = readFileSync(PROTOCOL, 'utf8');
+    const documented = new Set(
+      [
+        ...protocol.matchAll(
+          /^#{3,4} `(?:GET|POST|PATCH|PUT|DELETE) ([^`]+)`/gm,
+        ),
+      ].map((match) => match[1]),
+    );
+    const undocumented = GUIDE_ROUTES.filter((route) => !documented.has(route));
+    expect(undocumented.sort()).toEqual(
+      [
+        '/glob',
+        '/list',
+        '/session/:id/export',
+        '/session/:id/pending-prompts',
+        '/session/:id/permission/:requestId',
+        '/session/:id/status',
+        '/stat',
+        '/workspace/tools',
+      ].sort(),
+    );
+  });
+
+  it('still sees the bulk of the route surface', () => {
+    // Guards the walker itself: if registrations move to a style this regex
+    // cannot match, the route check above would pass vacuously on an empty set.
+    expect(registeredPaths().size).toBeGreaterThan(100);
+  });
+});

--- a/packages/cli/src/serve/rest-integration-docs-contract.test.ts
+++ b/packages/cli/src/serve/rest-integration-docs-contract.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -104,6 +104,54 @@ function slug(heading: string): string {
 }
 
 describe('REST integration guide contract', () => {
+  it('matches the routes and missing-section notes in the guide tables', () => {
+    const rows = readFileSync(GUIDE, 'utf8')
+      .split('\n')
+      .filter((line) => /^\| .*`(?:GET|POST|PATCH|DELETE) \//.test(line));
+    const routes = rows.flatMap((row) =>
+      [
+        ...row
+          .split('|')[1]
+          .matchAll(/`(?:GET |POST |PATCH |DELETE )?(\/[^`]+)`/g),
+      ].map((match) => ({
+        route: match[1] === '/resume' ? '/session/:id/resume' : match[1],
+        undocumented: /no dedicated/i.test(row),
+      })),
+    );
+    expect(routes.map(({ route }) => route).sort()).toEqual(
+      [...GUIDE_ROUTES].sort(),
+    );
+    expect(
+      routes
+        .filter(({ undocumented }) => undocumented)
+        .map(({ route }) => route)
+        .sort(),
+    ).toEqual([
+      '/glob',
+      '/list',
+      '/session/:id/export',
+      '/session/:id/pending-prompts',
+      '/session/:id/permission/:requestId',
+      '/session/:id/status',
+      '/stat',
+      '/workspace/tools',
+    ]);
+  });
+
+  it('links only to documentation files that exist', () => {
+    const targets = [
+      ...readFileSync(GUIDE, 'utf8').matchAll(
+        /\]\((\.\.?\/[^)#\s]+\.md)(?:#[^)]*)?\)/g,
+      ),
+    ].map((match) => match[1]);
+    expect(targets.length).toBeGreaterThan(0);
+    expect(
+      targets.filter(
+        (target) => !existsSync(path.resolve(path.dirname(GUIDE), target)),
+      ),
+    ).toEqual([]);
+  });
+
   it('promises only routes the daemon still registers', () => {
     const registered = registeredPaths();
     expect(GUIDE_ROUTES.filter((route) => !registered.has(route))).toEqual([]);


### PR DESCRIPTION
## What this PR does

Adds `docs/developers/rest-api-integration.md` — one page answering "I am putting Qwen Code inside my product over HTTP; which path do I take and what do I own?" — plus a contract test so the page cannot quietly go stale.

Closes the documentation half of #11427; contributes the partner-surface table to #11359.

## Why it's needed

The daemon REST surface is not missing. It is 3.5k lines of route reference plus 21 published deep-dive pages. The problem is the way in:

- The daemon registers **237** routes. An integrator has no signal about which are meant for them and which are Web Shell internals that change with that UI.
- `users/overview.md` answers "how do I start using the CLI in 30 seconds", not the integration question.
- Two facts that are load-bearing at design time are buried: the daemon spawns `qwen --acp` children (so the CLI must be on the daemon host), and the auth model is single-operator with no per-end-user principal.

## Reviewer Test Plan

### How to verify

`npx vitest run packages/cli/src/serve/rest-integration-docs-contract.test.ts` — four checks, described below.

Then read the page and follow the "Minimal flow" section against a local daemon: `qwen serve --no-web --require-auth`.

### Evidence (Before & After)

Before: the integration surface is 237 routes with no annotation; 63 have a dedicated reference section, and nothing says which of those an outside caller should depend on.

After: 25 routes named as the integration surface, grouped by job, 17 linked to their reference sections, and the remaining 8 marked plainly as lacking one rather than papered over.

### Tested on

Not run locally — this box is memory-constrained, so no build, typecheck, or vitest run. `eslint` and `prettier --check` pass on every touched file, and I dry-ran all four assertions with a standalone script against this tree: all pass, walker sees 213 routes, and the undocumented set matches the test's expected 8 exactly. The vitest run itself is CI's to confirm.

## Risk & Scope

- **Main risk / tradeoff**: the 25-route subset is a judgment call, not a mechanically derived set. It came from an audit done for the (since reverted) `--api-profile` work, where each route was checked against its handler. If a reviewer thinks a route belongs in or out, that is a one-line change to `GUIDE_ROUTES` plus the page — the test keeps the two in step.
- **Not validated / out of scope**: this does not document the 8 routes that lack a reference section, and does not touch the other 174. It also does not attempt the generated route↔capability↔SDK index that #11359's triage recommends — that is a larger piece and this page is useful without it. The test's scope is deliberately the guide's own promises, not a full coverage ratchet, which would need a ~174-entry baseline.
- **Breaking changes / migration**: none. Documentation plus one test file.

## Linked Issues

Refs #11427, #11359.

Note the page will not appear in the published site's sidebar until `qwen-code-docs` mirrors the nav entry — `_meta.*` is never synced (#11399, QwenLM/qwen-code-docs#263). The page itself syncs and translates normally.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `docs/developers/rest-api-integration.md` —— 一页回答「我要把 Qwen Code 通过 HTTP 放进自己的产品，该走哪条路、我负责什么」，外加一个契约测试防止这页悄悄过期。

## 为什么需要

daemon 的 REST 文档并不缺：3.5k 行路由参考 + 21 篇已发布的深入文档。缺的是入口——

- daemon 注册了 **237** 条路由，集成方无从判断哪些是给自己的、哪些是随 Web Shell 变动的内部件。
- `users/overview.md` 回答的是「30 秒上手 CLI」，不是集成问题。
- 两个设计阶段就必须知道的事实被埋着：daemon 会 spawn `qwen --acp` 子进程（所以主机必须装 CLI）；认证是单操作者模型，没有按终端用户区分的主体。

## 验证

`npx vitest run packages/cli/src/serve/rest-integration-docs-contract.test.ts`，四项检查。再照「Minimal flow」一节对着本地 daemon 走一遍。

本机没跑（内存受限，无 build / typecheck / vitest）。`eslint` 和 `prettier --check` 全过，四个断言我用独立脚本对着本树预演过：全部通过，walker 看到 213 条路由，未文档化集合与测试预期的 8 条精确匹配。vitest 本身交给 CI。

## 风险与范围

- **主要取舍**：那 25 条是判断，不是机械推导。它来自（已回退的）`--api-profile` 工作中逐条对照 handler 的审计。reviewer 若认为某条该进该出，改 `GUIDE_ROUTES` 和页面各一行即可，测试会保证两者同步。
- **未验证 / 超出范围**：不补那 8 条缺失的参考小节，不碰其余 174 条；也不做 #11359 triage 建议的生成式 route↔capability↔SDK 索引——那是更大的一块，而这页没有它也有用。测试范围有意限定为「这页自己的承诺」，而非全量覆盖 ratchet（那需要约 174 条基线）。
- **破坏性变更**：无。文档 + 一个测试文件。

注意：在 `qwen-code-docs` 镜像导航条目之前，这页不会出现在已发布站点的侧栏里——`_meta.*` 从不同步（#11399、QwenLM/qwen-code-docs#263）。页面本身同步和翻译正常。

</details>
