### PR TITLE
fix(core): reject pre-aborted queued tool requests

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2628,6 +2628,59 @@ describe('CoreToolScheduler', () => {
     }
   });
 
+  it('rejects a pre-aborted queued request without waiting for the active batch', async () => {
+    let resolveFirstCall: (result: ToolResult) => void;
+    const firstCallPromise = new Promise<ToolResult>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+    const tool = new MockTool({
+      name: 'read_file',
+      execute: vi.fn().mockReturnValue(firstCallPromise),
+    });
+    const { scheduler, onToolCallsUpdate } = createSchedulerForLegacyToolTests({
+      toolsByName: new Map([[tool.name, tool]]),
+    });
+    const firstSchedule = scheduler.schedule(
+      [
+        {
+          callId: 'active-call',
+          name: tool.name,
+          args: { file_path: 'a.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-active',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await waitForStatus(onToolCallsUpdate, 'executing');
+
+    const queuedController = new AbortController();
+    queuedController.abort();
+    const queuedSchedule = scheduler.schedule(
+      [
+        {
+          callId: 'pre-aborted-call',
+          name: tool.name,
+          args: { file_path: 'b.ts' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-pre-aborted',
+        },
+      ],
+      queuedController.signal,
+    );
+    const result = await Promise.race([
+      queuedSchedule.then(() => 'resolved').catch(() => 'rejected'),
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve('pending'), 50),
+      ),
+    ]);
+
+    expect(result).toBe('rejected');
+    resolveFirstCall!({ llmContent: 'done', returnDisplay: 'done' });
+    await firstSchedule;
+  });
+
   it('propagates a tool rejection even when timeout is active', async () => {
     const previousTimeout = process.env['QWEN_CODE_TOOL_EXECUTION_TIMEOUT_MS'];
     process.env['QWEN_CODE_TOOL_EXECUTION_TIMEOUT_MS'] = '5000';

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -2339,6 +2339,9 @@ export class CoreToolScheduler {
     runtimeView?: RuntimeContentGeneratorView,
   ): Promise<void> {
     if (this.isRunning() || this.isScheduling) {
+      if (signal.aborted) {
+        return Promise.reject(new Error('Tool call cancelled while in queue.'));
+      }
       return new Promise((resolve, reject) => {
         const abortHandler = () => {
           // Find and remove the request from the queue


### PR DESCRIPTION
## What this PR does

Rejects a tool request immediately when its abort signal is already cancelled and the scheduler is busy, instead of placing it behind the active batch.

## Why it's needed

A pre-aborted signal does not replay its abort event to a listener registered later, so the request could remain queued behind unrelated work. Checking cancellation before queue admission restores immediate rejection without changing later queued-cancellation handling.

## Reviewer Test Plan

Suggested reviewers: @qqqys, @yiliang114, @ytahdn

### How to verify

Hold one tool call active, then schedule a second request whose signal was aborted beforehand. The second request should reject immediately before the first call is released, while the active call still completes normally.

### Evidence (Before & After)

N/A - internal scheduler behavior fix with no user-interface change. The colocated regression test fails on the base behavior and passes after the queue admission check.

### Tested on

|     OS     | Status |
| :--------: | :----: |
| macOS | not tested |
| Windows | not tested |
| Linux | tested |

### Environment (optional)

Node.js v22.22.1; focused Vitest, ESLint, Prettier, core build, and core typecheck checks.

## Risk & Scope

- Main risk or tradeoff: already-cancelled requests now receive the existing cancellation rejection immediately instead of waiting in the busy scheduler queue.
- Not validated / out of scope: platform-specific CI and the full repository preflight were not run locally.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11146

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当调度器繁忙且工具请求的取消信号已经触发时，立即拒绝该请求，而不是让它排在活动批次之后。

## 为什么需要

取消信号预先触发后，不会向稍后注册的监听器重放取消事件，因此请求可能一直排在无关工作之后。队列接收前检查取消状态可以恢复立即拒绝，同时不改变请求入队后的取消处理。

## 评审者验证计划

建议评审者：@qqqys、@yiliang114、@ytahdn

### 如何验证

让一个工具调用保持活动状态，再使用已经提前触发取消信号的请求发起第二个调用。第一个调用释放前，第二个请求应立即拒绝，同时第一个活动调用仍应正常完成。

### 证据（修改前后）

不适用 - 这是内部调度器行为修复，不涉及用户界面。随附回归测试在基线行为下失败，在加入队列接收检查后通过。

### 测试平台

| 系统 | 状态 |
| :--: | :--: |
| macOS | 未测试 |
| Windows | 未测试 |
| Linux | 已测试 |

### 运行环境（可选）

Node.js v22.22.1；已运行聚焦 Vitest、ESLint、Prettier、core 构建和 core 类型检查。

## 风险与范围

- 主要风险或取舍：已取消的请求会立即收到现有的取消拒绝，而不是在繁忙调度器队列中等待。
- 未验证 / 范围外：本地未运行平台相关 CI 和完整仓库 preflight。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #11146

</details>