### PR TITLE
feat(cli): support exact-version updates without npm discovery

### DIFF
--- a/docs/design/explicit-update-version.md
+++ b/docs/design/explicit-update-version.md
@@ -1,0 +1,11 @@
+# Explicit standalone update versions
+
+`qwen update` currently discovers a release through npm before downloading it. An operator who already selected an exact release cannot install it when registry access is unavailable, even if release artifacts are reachable.
+
+Add `--target-version` to the CLI update command. Validate and normalize the concrete version locally, skip version discovery, and reuse the standalone updater with that target. Without the option, preserve discovery and existing installation instructions. The existing `--version` option keeps its display-only meaning.
+
+Explicit selection permits same-version reinstalls and downgrades: it is a request to install exactly that release, not to find a newer release. Stable and concrete prerelease versions are accepted, with an optional leading `v`; mutable tags and malformed versions are rejected. Unsupported installation methods return an error directing the user to install the exact version manually, without registry discovery or suggesting an unpinned upgrade.
+
+Artifact routing continues to honor `QWEN_UPDATE_BASE_URL`. The archive, checksums and signature use the same resolved release root. The updater checks the new executable's version against the requested version before replacing the installation. Existing integrity checks, locking, extraction safeguards, atomic replacement and rollback remain unchanged.
+
+Changes are limited to the CLI command and its tests, standalone version validation and smoke testing, and user documentation. No daemon/UI endpoints, automatic update policies, registry mirrors or release infrastructure are introduced. No open design questions remain.

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -839,6 +839,15 @@ The URL must use HTTPS and cannot contain credentials, a query string, or a frag
 
 Configure this variable in the launching shell or a user-level `.env` file. It is rejected from project `.env` and `.qwen/.env` files and from the top-level `settings.json` `env` section at every scope. A user-level `.env` value is loaded at startup; restart Qwen Code after changing it.
 
+To install a selected release without querying the npm registry, combine the download source with an exact target version:
+
+```bash
+QWEN_UPDATE_BASE_URL="https://downloads.example.com/qwen-code" \
+  qwen update --target-version 0.23.1
+```
+
+`--target-version` accepts a concrete stable or prerelease version, optionally prefixed with `v`. It rejects mutable tags such as `latest` and `nightly`. Explicit targets permit same-version reinstalls and downgrades; the downloaded executable must report the requested version before activation. For non-standalone installations, the command returns an error directing you to install the selected version manually using your installation method. Omitting the option preserves normal version discovery.
+
 This setting applies to `qwen update`, `/update`, and automatic standalone updates. It does not change npm registry version discovery. It is separate from the installer's `QWEN_INSTALL_BASE_URL`, which points directly to a version-specific directory.
 
 ## Command-Line Arguments

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -52,7 +52,10 @@ vi.mock('../utils/installationInfo.js', () => ({
   getInstallationInfo,
   resolveUpdateCommand,
 }));
-vi.mock('../ui/standalone-update.js', () => ({ performStandaloneUpdate }));
+vi.mock('../ui/standalone-update.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/standalone-update.js')>()),
+  performStandaloneUpdate,
+}));
 vi.mock('../utils/package.js', () => ({ getPackageJson }));
 vi.mock('../utils/stdioHelpers.js', () => ({
   writeStdoutLine,
@@ -107,6 +110,54 @@ describe('update command', () => {
       isStandalone: false,
       updateCommand: 'npm install -g @qwen-code/qwen-code@latest',
     });
+  });
+
+  it.each(['1.2.3', 'v1.2.3', '1.2.3-preview.1', '1.2.3-nightly.20260909'])(
+    'installs exact version %s without discovery',
+    async (version) => {
+      getInstallationInfo.mockReturnValue({
+        isStandalone: true,
+        standaloneDir: '/test/qwen',
+      });
+      performStandaloneUpdate.mockResolvedValue('done');
+      await updateCommand.handler({ ...updateArgs, targetVersion: version });
+      expect(checkForUpdatesDetailed).not.toHaveBeenCalled();
+      expect(performStandaloneUpdate).toHaveBeenCalledWith(
+        '/test/qwen',
+        version.replace(/^v/, ''),
+      );
+    },
+  );
+
+  it.each([
+    '',
+    'latest',
+    'nightly',
+    '../1.2.3',
+    '1.2',
+    '01.2.3',
+    '1.2.3-01',
+    '1.2.3?x=1',
+  ])(
+    'rejects invalid target %s before discovery or installation',
+    async (targetVersion) => {
+      await updateCommand.handler({ ...updateArgs, targetVersion });
+      expect(process.exitCode).toBe(1);
+      expect(checkForUpdatesDetailed).not.toHaveBeenCalled();
+      expect(getInstallationInfo).not.toHaveBeenCalled();
+      expect(performStandaloneUpdate).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects an unmanaged exact target without suggesting an unpinned upgrade', async () => {
+    await updateCommand.handler({ ...updateArgs, targetVersion: 'v1.2.3' });
+    expect(checkForUpdatesDetailed).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('Install version 1.2.3 manually'),
+    );
+    expect(formatUpdateInstructions).not.toHaveBeenCalled();
+    expect(performStandaloneUpdate).not.toHaveBeenCalled();
   });
 
   it('prints the package-manager update command even when auto-update is disabled', async () => {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -7,12 +7,22 @@
 import type { CommandModule } from 'yargs';
 import { initializeI18n, resolveLanguageSetting, t } from '../i18n/index.js';
 
-export const updateCommand: CommandModule = {
+interface UpdateArgs {
+  targetVersion?: string;
+}
+
+export const updateCommand: CommandModule<object, UpdateArgs> = {
   command: 'update',
   get describe() {
     return t('Check for Qwen Code updates and install if available');
   },
-  handler: async () => {
+  builder: (yargs) =>
+    yargs.option('target-version', {
+      type: 'string',
+      requiresArg: true,
+      description: t('Install an exact version without querying npm'),
+    }),
+  handler: async (argv) => {
     const [
       { loadSettings },
       { checkForUpdatesDetailed, describeUpdateCheckFailure },
@@ -31,7 +41,7 @@ export const updateCommand: CommandModule = {
 
     const { formatUpdateInstructions, getInstallationInfo } =
       installationInfoModule;
-    const { performStandaloneUpdate } = standaloneUpdate;
+    const { performStandaloneUpdate, normalizeVersion } = standaloneUpdate;
     const { writeStdoutLine, writeStderrLine } = stdioHelpers;
 
     const cwd = process.cwd();
@@ -40,40 +50,55 @@ export const updateCommand: CommandModule = {
       resolveLanguageSetting(settings.merged.general?.language as string),
     );
 
-    const updateCheck = await checkForUpdatesDetailed();
+    let targetVersion: string;
+    if (argv.targetVersion !== undefined) {
+      try {
+        targetVersion = normalizeVersion(argv.targetVersion).slice(1);
+      } catch (err) {
+        writeStderrLine(
+          t('Update failed: {{error}}', {
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+        process.exitCode = 1;
+        return;
+      }
+    } else {
+      const updateCheck = await checkForUpdatesDetailed();
 
-    if (updateCheck.status === 'up-to-date') {
-      writeStdoutLine(
-        t('Qwen Code {{version}} is up to date!', {
-          version: updateCheck.currentVersion,
-        }),
-      );
-      return;
+      if (updateCheck.status === 'up-to-date') {
+        writeStdoutLine(
+          t('Qwen Code {{version}} is up to date!', {
+            version: updateCheck.currentVersion,
+          }),
+        );
+        return;
+      }
+
+      if (updateCheck.status === 'error') {
+        writeStderrLine(
+          t(
+            'Failed to check for updates ({{reason}}). Please check your network or registry configuration.',
+            { reason: describeUpdateCheckFailure(updateCheck.error) },
+          ),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      if (updateCheck.status === 'skipped') {
+        writeStderrLine(
+          t('Unable to check for updates: {{reason}}', {
+            reason: updateCheck.reason,
+          }),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      targetVersion = updateCheck.info.update.latest;
+      writeStdoutLine(updateCheck.info.message);
     }
-
-    if (updateCheck.status === 'error') {
-      writeStderrLine(
-        t(
-          'Failed to check for updates ({{reason}}). Please check your network or registry configuration.',
-          { reason: describeUpdateCheckFailure(updateCheck.error) },
-        ),
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    if (updateCheck.status === 'skipped') {
-      writeStderrLine(
-        t('Unable to check for updates: {{reason}}', {
-          reason: updateCheck.reason,
-        }),
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    const info = updateCheck.info;
-    writeStdoutLine(info.message);
 
     const installationInfo = getInstallationInfo(cwd, true);
 
@@ -86,7 +111,7 @@ export const updateCommand: CommandModule = {
         writeStdoutLine(t('Downloading update...'));
         const result = await performStandaloneUpdate(
           installationInfo.standaloneDir,
-          info.update.latest,
+          targetVersion,
         );
         if (result === 'done') {
           writeStdoutLine(
@@ -114,9 +139,20 @@ export const updateCommand: CommandModule = {
       return;
     }
 
+    if (argv.targetVersion !== undefined) {
+      writeStderrLine(
+        t(
+          'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.',
+          { version: targetVersion },
+        ),
+      );
+      process.exitCode = 1;
+      return;
+    }
+
     for (const line of formatUpdateInstructions(
       installationInfo,
-      info.update.latest,
+      targetVersion,
     )) {
       writeStdoutLine(t(line));
     }

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -2132,6 +2132,10 @@ export default {
   'History collapsed: {{n}} messages hidden. Use /history expand-now to show.':
     'Història reduïda: {{n}} missatges ocults. Utilitzeu /history expand-now per mostrar.',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'Les actualitzacions a una versió concreta requereixen una instal·lació independent. Instal·leu manualment la versió {{version}} amb el vostre mètode d’instal·lació.',
+  'Install an exact version without querying npm':
+    'Instal·la una versió concreta sense consultar npm',
   'Check for Qwen Code updates and install if available':
     'Comprova les actualitzacions de Qwen Code i instal·la si estan disponibles',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -2180,6 +2180,10 @@ export default {
   out: 'aus',
   'In/Out': 'Ein/Aus',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'Updates auf eine bestimmte Version erfordern eine Standalone-Installation. Installieren Sie Version {{version}} manuell mit Ihrer Installationsmethode.',
+  'Install an exact version without querying npm':
+    'Eine bestimmte Version ohne npm-Abfrage installieren',
   'Check for Qwen Code updates and install if available':
     'Auf Qwen Code-Updates prüfen und installieren, falls verfügbar',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -2686,6 +2686,10 @@ export default {
   out: 'out',
 
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.',
+  'Install an exact version without querying npm':
+    'Install an exact version without querying npm',
   'Check for Qwen Code updates and install if available':
     'Check for Qwen Code updates and install if available',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -2183,6 +2183,10 @@ export default {
   out: 'sort.',
   'In/Out': 'Ent/Sort',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'La mise à jour vers une version précise nécessite une installation autonome. Installez manuellement la version {{version}} avec votre méthode d’installation.',
+  'Install an exact version without querying npm':
+    'Installer une version précise sans interroger npm',
   'Check for Qwen Code updates and install if available':
     'Vérifier les mises à jour de Qwen Code et installer si disponible',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1947,6 +1947,10 @@ export default {
   out: '出力',
   'In/Out': '入力/出力',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    '指定バージョンへの更新にはスタンドアロン版が必要です。現在のインストール方法でバージョン {{version}} を手動インストールしてください。',
+  'Install an exact version without querying npm':
+    'npm に問い合わせずに指定したバージョンをインストール',
   'Check for Qwen Code updates and install if available':
     'Qwen Codeのアップデートを確認し、利用可能な場合はインストールします',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -2166,6 +2166,10 @@ export default {
   out: 'saída',
   'In/Out': 'Ent/Saída',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'Atualizações para uma versão específica exigem uma instalação independente. Instale a versão {{version}} manualmente usando seu método de instalação.',
+  'Install an exact version without querying npm':
+    'Instalar uma versão específica sem consultar o npm',
   'Check for Qwen Code updates and install if available':
     'Verificar atualizações do Qwen Code e instalar se disponível',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -2154,6 +2154,10 @@ export default {
   out: 'вых.',
   'In/Out': 'Вх/Вых',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    'Обновление до указанной версии требует автономной установки. Установите версию {{version}} вручную, используя текущий способ установки.',
+  'Install an exact version without querying npm':
+    'Установить указанную версию без запроса к npm',
   'Check for Qwen Code updates and install if available':
     'Проверить обновления Qwen Code и установить при наличии',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -2275,6 +2275,9 @@ export default {
   'start server': '啟動伺服器',
   'No compression needed.': '無需壓縮。',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    '指定版本升級需要獨立安裝。請使用目前的安裝方式手動安裝 {{version}} 版本。',
+  'Install an exact version without querying npm': '安裝指定版本，不查詢 npm',
   'Check for Qwen Code updates and install if available':
     '檢查 Qwen Code 更新並安裝（如果可用）',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -2477,6 +2477,9 @@ export default {
   '阿里云百炼 (aliyun.com)': '阿里云百炼（aliyun.com）',
   'No compression needed.': '无需压缩。',
   // Update command
+  'Exact-version updates require a standalone installation. Install version {{version}} manually using your installation method.':
+    '指定版本升级需要独立安装。请使用当前安装方式手动安装 {{version}} 版本。',
+  'Install an exact version without querying npm': '安装指定版本，不查询 npm',
   'Check for Qwen Code updates and install if available':
     '检查 Qwen Code 更新并安装（如果可用）',
   'Qwen Code update available! {{current}} → {{latest}}':

--- a/packages/cli/src/ui/standalone-update.test.ts
+++ b/packages/cli/src/ui/standalone-update.test.ts
@@ -418,10 +418,24 @@ describe('standalone-update', () => {
       ).toBe(false);
     }
 
-    async function serveArchive(options: { badChecksum?: boolean } = {}) {
+    async function serveArchive(
+      options: { badChecksum?: boolean; reportedVersion?: string } = {},
+    ) {
       const fixture = path.join(tempDir, 'fixture');
       fs.mkdirSync(path.join(fixture, 'qwen-code'), { recursive: true });
       fs.writeFileSync(path.join(fixture, 'qwen-code', 'manifest.json'), '{}');
+      if (options.reportedVersion) {
+        const root = path.join(fixture, 'qwen-code');
+        fs.mkdirSync(path.join(root, 'node', 'bin'), { recursive: true });
+        fs.mkdirSync(path.join(root, 'lib'));
+        fs.writeFileSync(path.join(root, 'lib', 'cli.js'), '');
+        fs.writeFileSync(
+          path.join(root, 'node', 'bin', 'node'),
+          `#!/bin/sh\nprintf '%s\\n' '${options.reportedVersion}'\n`,
+          { mode: 0o755 },
+        );
+      }
+
       const archivePath = path.join(tempDir, 'release.tar.gz');
       await tar.c({ gzip: true, cwd: fixture, file: archivePath }, [
         'qwen-code',
@@ -440,6 +454,20 @@ describe('standalone-update', () => {
         return new Response('', { status: 404 });
       });
     }
+
+    it.skipIf(process.platform === 'win32')(
+      'preserves the installation when a verified archive reports the wrong version',
+      async () => {
+        vi.stubEnv('QWEN_UPDATE_BASE_URL', baseUrl);
+        await serveArchive({ reportedVersion: '9.9.9' });
+        await expect(
+          performStandaloneUpdate(standaloneDir, '1.2.3'),
+        ).rejects.toThrow(
+          'Smoke test failed: expected version 1.2.3, got 9.9.9',
+        );
+        expectInstallationPreserved();
+      },
+    );
 
     it.each([baseUrl, `${baseUrl}/`, `  ${baseUrl}///  `])(
       'downloads and verifies every resource from the configured root %s',

--- a/packages/cli/src/ui/standalone-update.ts
+++ b/packages/cli/src/ui/standalone-update.ts
@@ -14,6 +14,7 @@ import { pipeline } from 'node:stream/promises';
 import type { Stats } from 'node:fs';
 import type { Response as UndiciResponse } from 'undici';
 import * as tar from 'tar';
+import semver from 'semver';
 import type { ReadEntry } from 'tar';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { loadUndici } from '../utils/load-undici.js';
@@ -41,8 +42,8 @@ const SEMVER_RE = /^v?\d+\.\d+\.\d+(-[\w.]+)?$/;
 
 type TarFilterEntry = Stats | ReadEntry | { type?: string; linkpath?: unknown };
 
-function normalizeVersion(version: string): string {
-  if (!SEMVER_RE.test(version)) {
+export function normalizeVersion(version: string): string {
+  if (!SEMVER_RE.test(version) || !semver.valid(version)) {
     throw new Error(`Invalid version format: ${version}`);
   }
   return version.startsWith('v') ? version : `v${version}`;
@@ -468,7 +469,11 @@ function spawnAndCapture(
  * Verifies the new installation can actually run by invoking --version.
  * Prevents replacing a working install with a broken binary.
  */
-async function smokeTest(newInstallDir: string, target: string): Promise<void> {
+async function smokeTest(
+  newInstallDir: string,
+  target: string,
+  expectedVersion: string,
+): Promise<void> {
   const resolvedInstallDir = path.resolve(newInstallDir);
   const nodeBin = target.startsWith('win')
     ? path.join(resolvedInstallDir, 'node', 'node.exe')
@@ -497,6 +502,11 @@ async function smokeTest(newInstallDir: string, target: string): Promise<void> {
   if (!SEMVER_RE.test(version)) {
     throw new Error(
       `Smoke test failed: unexpected version output "${version}"`,
+    );
+  }
+  if (normalizeVersion(version) !== normalizeVersion(expectedVersion)) {
+    throw new Error(
+      `Smoke test failed: expected version ${expectedVersion}, got ${version}`,
     );
   }
   debugLogger.info(`Smoke test passed: ${version}`);
@@ -1090,7 +1100,7 @@ export async function performStandaloneUpdate(
     }
 
     debugLogger.info('Running smoke test...');
-    await smokeTest(newInstallDir, target);
+    await smokeTest(newInstallDir, target, newVersion);
 
     debugLogger.info('Replacing installation...');
     updateResult = atomicReplace(standaloneDir, newInstallDir, lockPath);


### PR DESCRIPTION
## What this PR does

Adds `qwen update --target-version <version>` for standalone installations. An explicit target skips npm version discovery and installs that exact release through the existing download and verification flow, including `QWEN_UPDATE_BASE_URL`. Omitting the option preserves normal update discovery.

Concrete stable and prerelease versions accept an optional leading `v`. Explicit requests allow same-version reinstalls and downgrades. Invalid targets are rejected before downloading, and a downloaded executable reporting a different version is rejected before activation. Unsupported installation methods return an actionable error instead of suggesting an unpinned upgrade. Help and error text are localized.

## Why it's needed

Operators may already have selected a release while npm registry access is unavailable. Configuring a reachable artifact source alone does not help because the current update command performs registry discovery first. Explicit selection makes that dependency unnecessary and prevents discovery from choosing a different release.

## Reviewer Test Plan

### How to verify

- Run an explicit-version update with a custom HTTPS release root while npm registry access is unavailable. It should install exactly the selected version without invoking npm or contacting a registry.
- Try a concrete prerelease, a same-version reinstall and an explicit downgrade. Each should use the specified version and retain the previous installation for rollback.
- Try a mutable tag, malformed version, missing argument, unavailable archive, incorrect checksum or an archive whose executable reports a different version. Failures must preserve the original installation and clean up update locks and temporary files.
- For a non-standalone installation, expect a nonzero exit and instructions to install the selected version manually, without an unpinned package-manager command.
- Omit the target option and confirm that normal version discovery remains in use.

### Evidence (Before & After)

Before: the installed CLI's update help has no target-version option; source always runs version discovery before downloading.

After: focused unit tests pass, and isolated CLI tests use a local HTTPS release source with registry access unavailable to verify exact installation and failure preservation. Detailed E2E evidence is posted separately.

Validation: full build, workspace typecheck, bundle, 170 focused tests, changed-file ESLint and Prettier checks passed. The npm lockfile was used for final validation; the optional pnpm layout exceeded an unrelated document-export asset budget, while the npm build passed that gate.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | Tested: build, typecheck, unit tests and isolated CLI E2E |
| Windows | Not tested locally |
| Linux | Baseline update help only; new implementation not tested locally |

### Environment (optional)

Node.js 22.23.1. E2E runs use isolated home directories and disposable installations, a local HTTPS server with a temporary trusted CA, and network/subprocess guards. Downloaded fixtures contain a real Node runtime and a small version-reporting CLI; this verifies updater behavior, not the functionality of a complete new release. No real installation was updated.

## Risk & Scope

- Main risk or tradeoff: explicit requests intentionally permit reinstalls and downgrades. Version equality is now checked before activation for all standalone update entrypoints.
- Not validated / out of scope: Windows deferred replacement, full release-package acceptance, daemon/UI upgrade orchestration and release approval policies.
- Breaking changes / migration notes: existing calls without the option retain version discovery; malformed versions are rejected more strictly.

## Linked Issues

Closes #11484

<details>
<summary>中文说明</summary>

## 本 PR 的改动

为独立安装新增 `qwen update --target-version <version>`。指定目标时跳过 npm 版本查询，通过现有下载与校验流程安装该精确版本，并继续支持 `QWEN_UPDATE_BASE_URL`。不指定参数时保留原有版本查询行为。

支持具体稳定版和预发布版本，以及可选的 `v` 前缀。显式请求允许同版本重装和降级。非法目标在下载前拒绝；下载后若程序报告的版本与目标不一致，则在激活前拒绝。不支持的安装方式返回可操作的错误提示，避免建议一个未固定版本的升级命令。帮助与错误文案已本地化。

## 需求背景

用户可能已经确定要安装的版本，但无法访问 npm registry。仅配置可访问的制品源仍然不够，因为当前升级命令会先查询 registry。指定版本可以移除这个依赖，并避免版本发现选择另一个版本。

## 审查者验证计划

### 验证方法

- 在 npm registry 不可用时，结合自定义 HTTPS 下载源执行指定版本升级。应准确安装目标版本，不调用 npm，也不访问 registry。
- 验证具体预发布版本、同版本重装和显式降级。每种情况均应使用指定版本，并保留旧安装以供回退。
- 验证可变标签、非法版本、缺少参数、制品不存在、校验不匹配和包内程序版本不匹配。失败必须保留旧安装，并清理锁与临时文件。
- 非独立安装应返回非零退出码，提示手动安装指定版本，不输出未固定版本的包管理器升级命令。
- 不提供目标参数时，应继续执行原有版本查询。

### 修改前后证据

修改前：已安装 CLI 的升级帮助中没有指定版本参数；源码在下载前始终查询版本。

修改后：相关单测通过；隔离 CLI 测试使用本地 HTTPS 制品源，在 registry 不可用的条件下验证准确安装及失败保护。详细 E2E 证据单独评论发布。

验证通过：完整构建、工作区类型检查、bundle、170 项相关测试，以及改动文件的 ESLint 和 Prettier 检查。最终验证使用 npm 锁文件；可选 pnpm 布局触发了无关的文档导出体积限制，npm 构建通过了同一门禁。

### 测试平台

- macOS：构建、类型检查、单测和隔离 CLI E2E 已验证。
- Windows：未在本地验证。
- Linux：仅检查基线升级帮助，未在本地验证新实现。

### 验证环境

Node.js 22.23.1。E2E 使用隔离 HOME、临时安装、本地 HTTPS 服务、临时受信 CA，以及网络和子进程监测。下载制品由真实 Node 运行时和精简的版本输出 CLI 组成，证明的是升级器行为，而非完整新版本的功能验收。未升级任何真实安装。

## 风险与范围

- 显式指定版本允许重装和降级；所有独立升级入口都会在激活前核对版本一致性。
- 未覆盖 Windows 延迟替换、完整发布包验收、daemon/UI 升级编排或版本审核策略。
- 未指定参数时保留现有行为；非法版本校验更加严格。

关联并关闭 #11484。

</details>
