### PR TITLE
fix(release): pin Debian 11 repositories to a coherent snapshot

### DIFF
--- a/.github/workflows/cd-cua-driver.yml
+++ b/.github/workflows/cd-cua-driver.yml
@@ -206,6 +206,14 @@ jobs:
     steps:
       - name: 'Install base tooling (container is bare)'
         run: |
+          # Debian 11 is intentionally retained for glibc 2.31 compatibility.
+          # Pin all repositories to one coherent end-of-LTS snapshot: the live
+          # security mirror can retain an expired index after removing its .debs.
+          printf '%s\n' \
+            'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260831T000000Z bullseye main' \
+            'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260831T000000Z bullseye-updates main' \
+            'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260831T000000Z bullseye-security main' \
+            > /etc/apt/sources.list
           apt-get -o Acquire::Retries=3 update
           apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             git ca-certificates curl build-essential pkg-config \


### PR DESCRIPTION
## Summary

- keep the Linux release builders on Debian 11 for glibc 2.31 compatibility
- pin Debian, updates, and security repositories to the same end-of-LTS snapshot
- avoid expired live metadata and package-index/file-pool mismatches that blocked both Linux architectures in the 0.20.5 release

## Validation

- `actionlint .github/workflows/cd-cua-driver.yml`
- recovery dry-run: https://github.com/QwenLM/qwen-code/actions/runs/34359448180
- both Linux architectures passed the previously failing `Install base tooling (container is bare)` step on real GitHub-hosted runners
- Windows x86_64 and arm64 completed successfully; Linux builds and macOS remain in progress at PR creation time

## Failed release evidence

Production run https://github.com/QwenLM/qwen-code/actions/runs/34357246099 failed before checkout on both Linux architectures because the Debian 11 security metadata had expired. Ignoring `Valid-Until` alone was insufficient because the live index referenced `.deb` files already removed from the mirror, so the workflow now uses one coherent official snapshot.