### PR TITLE
docs: highlight Qwen Code interfaces in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="center">
 
-![Qwen Code in the terminal, desktop app, browser, editor, and chat, with VS Code, Zed, JetBrains, Telegram, DingTalk, WeChat, and Feishu integrations](https://img.alicdn.com/imgextra/i3/O1CN01l5GyhGuOPGC3XHtt_!!6000000005884-2-tps-1742-903.png)
-
 [![npm version](https://img.shields.io/npm/v/@qwen-code/qwen-code.svg)](https://www.npmjs.com/package/@qwen-code/qwen-code)
 [![License](https://img.shields.io/github/license/QwenLM/qwen-code.svg)](./LICENSE)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -20,6 +18,8 @@
 <a href="https://qwenlm.github.io/qwen-code-docs/ko/users/overview">한국어</a>
 
 </div>
+
+![Qwen Code in the terminal, desktop app, browser, editor, and chat, with VS Code, Zed, JetBrains, Telegram, DingTalk, WeChat, and Feishu integrations](https://img.alicdn.com/imgextra/i3/O1CN01l5GyhGuOPGC3XHtt_!!6000000005884-2-tps-1742-903.png)
 
 ## Why Qwen Code?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+![Qwen Code in the terminal, desktop app, browser, editor, and chat, with VS Code, Zed, JetBrains, Telegram, DingTalk, WeChat, and Feishu integrations](https://img.alicdn.com/imgextra/i3/O1CN01l5GyhGuOPGC3XHtt_!!6000000005884-2-tps-1742-903.png)
+
 [![npm version](https://img.shields.io/npm/v/@qwen-code/qwen-code.svg)](https://www.npmjs.com/package/@qwen-code/qwen-code)
 [![License](https://img.shields.io/github/license/QwenLM/qwen-code.svg)](./LICENSE)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -7,7 +9,7 @@
 
 <a href="https://trendshift.io/repositories/15287" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15287" alt="QwenLM%2Fqwen-code | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-**The open-source AI coding agent that lives in your terminal.**
+**The open-source AI coding agent for your terminal, editor, desktop, browser, and chat.**
 
 <a href="https://qwenlm.github.io/qwen-code-docs/zh/users/overview">中文</a> |
 <a href="https://qwenlm.github.io/qwen-code-docs/de/users/overview">Deutsch</a> |
@@ -24,7 +26,7 @@
 - **Agentic out of the box** — Auto-Memory, Auto-Skills, SubAgents, Agent Teams, and MCP. Dynamic workflows, zero setup.
 - **Open-source, inside and out** — The framework and the Qwen models are open-source. They evolve together. No vendor lock-in.
 - **Multi-protocol** — Supports OpenAI, Anthropic, Gemini, and Qwen APIs. Any third-party provider or local model (Ollama / vLLM). Switch at runtime.
-- **Beyond the terminal** — IDE plugins, Desktop app, daemon mode, SDKs, and IM bots (Telegram / DingTalk / WeChat / Feishu).
+- **Beyond the terminal** — IDE plugins, Desktop app, Web UI, SDKs, and chat integrations (Telegram / DingTalk / WeChat / Feishu).
 
 > [!TIP]
 > Qwen Code is actively iterating on itself — using its own agent and models to file issues, submit PRs, review code, and run tests. Powered by the community, driven by AI.
@@ -64,27 +66,45 @@ brew install qwen-code
 
 ## Quick Start
 
+Open a terminal in your project and start Qwen Code:
+
 ```bash
-qwen          # Launch interactive terminal UI
-# Inside the session:
-/auth         # Configure your provider and API key
+cd /path/to/your-project
+qwen
+```
+
+Inside the session, run `/auth` to configure your provider and API key. Then try:
+
+```text
+Explain this repository and show me where to start.
 ```
 
 See the [Authentication Guide](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/auth/) and [Settings Reference](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/) for detailed setup.
 
-![Qwen Code](https://img.alicdn.com/imgextra/i2/O1CN01K0nwj41RM1Il8kB0t_!!6000000002096-2-tps-1544-1060.png)
+<details>
+<summary>See the terminal interface</summary>
+
+![Qwen Code terminal interface](https://img.alicdn.com/imgextra/i2/O1CN01K0nwj41RM1Il8kB0t_!!6000000002096-2-tps-1544-1060.png)
+
+</details>
 
 ## How to Use Qwen Code
 
-| Mode            | Command         | Use Case                                                                                                                                                                                                                                        |
-| --------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Interactive** | `qwen`          | Terminal UI with rich rendering, `@file` references, slash commands                                                                                                                                                                             |
-| **Headless**    | `qwen -p "..."` | Scripts, CI/CD, batch processing — no UI                                                                                                                                                                                                        |
-| **IDE**         | —               | [VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/), [Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/), [JetBrains](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/) |
-| **Desktop**     | —               | [Qwen Code Desktop](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — GUI for macOS, Windows, Linux                                                                                                                            |
-| **Daemon**      | `qwen serve`    | Shared agent session over HTTP+SSE (ACP). Multiple clients, one agent. _(experimental)_ [Docs](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve)                                                                                     |
-| **SDK**         | —               | [TypeScript](./packages/sdk-typescript/README.md), [Python](./packages/sdk-python/README.md), [Java](./packages/sdk-java/qwencode/README.md)                                                                                                    |
-| **IM Bot**      | `qwen channel`  | Connect to Telegram, DingTalk, WeChat, or Feishu                                                                                                                                                                                                |
+Choose the interface that fits your workflow:
+
+| Interface    | Get started                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Terminal** | Run `qwen` in your project — see [Quick Start](#quick-start).                                                                                                                                                                                                                                                                                                                                             |
+| **Desktop**  | [Download Qwen Code Desktop](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) for macOS, Windows, and Linux.                                                                                                                                                                                                                                                                              |
+| **Web**      | Run `qwen serve --open` to open the [Web UI](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve/) in your browser. _(experimental)_                                                                                                                                                                                                                                                              |
+| **Editor**   | Set up [VS Code](https://qwenlm.github.io/qwen-code-docs/en/users/integration-vscode/), [Zed](https://qwenlm.github.io/qwen-code-docs/en/users/integration-zed/), or [JetBrains](https://qwenlm.github.io/qwen-code-docs/en/users/integration-jetbrains/).                                                                                                                                                |
+| **Chat**     | Connect [Telegram](https://qwenlm.github.io/qwen-code-docs/en/users/features/channels/telegram/), [DingTalk](https://qwenlm.github.io/qwen-code-docs/en/users/features/channels/dingtalk/), [WeChat](https://qwenlm.github.io/qwen-code-docs/en/users/features/channels/weixin/), or [Feishu](https://qwenlm.github.io/qwen-code-docs/en/users/features/channels/feishu/), then run `qwen channel start`. |
+
+For automation and custom integrations:
+
+- **Headless** — Run `qwen -p "..."` in scripts, CI/CD, or batch jobs.
+- **SDKs** — Build with [TypeScript](./packages/sdk-typescript/README.md), [Python](./packages/sdk-python/README.md), or [Java](./packages/sdk-java/qwencode/README.md).
+- **Daemon** — Run `qwen serve` to connect clients over HTTP + SSE (ACP). _(experimental)_ [Daemon guide](https://qwenlm.github.io/qwen-code-docs/en/users/qwen-serve/).
 
 <details>
 <summary>SDK example (Python)</summary>


### PR DESCRIPTION
## What this PR does

Makes Qwen Code's terminal, desktop, browser, editor, and chat interfaces visible from the top of the project page. A CDN-hosted hero illustration appears after the badges, introduction, and language links, immediately above “Why Qwen Code?”, and a compact setup table provides direct platform links and the `qwen serve --open` browser command. Quick Start separates shell commands from in-session authentication and includes a first repository question; the existing terminal screenshot remains available as a collapsed example.

## Why it's needed

The terminal-only tagline and mixed mode table made the other interfaces easy to miss. New users can now see where Qwen Code works, find the setup instructions for their preferred interface, and try a concrete first task.

## Reviewer Test Plan

### How to verify

1. Open the rendered project introduction. The new illustration should appear after the badges, introduction, and language links, immediately above “Why Qwen Code?”, with a single “Desktop & Web” heading and no extra command subtitle in the image.
2. Check “How to Use Qwen Code.” It should list Terminal, Desktop, Web, Editor, and Chat, with working download/setup links. The Web row should show `qwen serve --open` and retain its experimental label; Headless, SDKs, and Daemon should remain available below the table.
3. Read Quick Start. Project navigation and `qwen` should be shell commands, `/auth` should be an instruction inside the session, and a repository question should follow. Expanding “See the terminal interface” should reveal the existing screenshot.

Validation performed:
- `prettier README.md --check` and `git diff --check` passed.
- Local Markdown previews at 1024px and 390px loaded the 1742 × 903 CDN image, rendered all five interface rows, and had no horizontal page overflow.
- All six relative file links and the Quick Start anchor resolved. The CDN image, three IDE guides, four chat guides, and Web guide returned HTTP 200; the Desktop release was verified with `gh release view`.
- `npm run build` and `npm run typecheck` were attempted but did not pass. Worktree dependency bootstrap encountered repeated registry download failures; using the existing shared dependencies exposed missing OpenTelemetry packages and Ajv type errors outside this documentation change.

### Evidence (Before & After)

N/A — documentation-only change. No product UI or runtime behavior changes.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | ✅ Documentation formatting, links, and local browser previews; build/typecheck unsuccessful |
| 🪟 Windows | N/A |
| 🐧 Linux | N/A |

### Environment (optional)

macOS; Node.js 22.22.2 for build/typecheck attempts. Markdown rendered locally with Chromium; the previews approximate GitHub's layout.

## Risk & Scope

- Main risk or tradeoff: the hero illustration depends on the supplied external CDN URL. It is a product illustration, not a screenshot.
- Not validated / out of scope: fresh installations and live sessions across all interfaces; the complete build and typecheck did not pass in this environment. No production code, dependency manifests, or image binaries are changed.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

在项目首页顶部展示 Qwen Code 的终端、桌面、浏览器、编辑器和聊天入口。CDN 主视觉图位于徽章、简介和语言链接之后，紧接在 “Why Qwen Code?” 上方，精简后的使用表格提供各平台的直接链接，以及浏览器启动命令 `qwen serve --open`。快速开始将 shell 命令与会话内认证步骤分开，并补充第一个仓库问题；原有终端截图保留在折叠示例中。

## 为什么需要

原来的终端定位文案和混排的模式表格容易让用户忽略其他使用形态。现在新用户可以先看到 Qwen Code 能在哪里使用，再找到自己偏好入口的配置说明，并尝试一个具体任务。

## 审阅者验证计划

### 如何验证

1. 打开渲染后的项目介绍。新图应当位于徽章、简介和语言链接之后，紧接在 “Why Qwen Code?” 上方，中央仅保留 “Desktop & Web” 标题，图中没有额外的命令副标题。
2. 检查 “How to Use Qwen Code”。表格应列出 Terminal、Desktop、Web、Editor 和 Chat，且下载及配置链接可用。Web 一行应显示 `qwen serve --open` 并保留实验性标注；Headless、SDKs 和 Daemon 入口应保留在表格下方。
3. 阅读快速开始。进入项目和 `qwen` 应是 shell 命令，`/auth` 应明确为会话内操作，随后提供一个仓库问题。展开 “See the terminal interface” 后应显示原有截图。

已执行的验证：
- `prettier README.md --check` 和 `git diff --check` 通过。
- 1024px 和 390px 的本地 Markdown 预览均加载了 1742 × 903 的 CDN 图片、渲染了五个使用入口，页面没有横向溢出。
- 六个相对文件链接及 Quick Start 锚点均可解析。CDN 图片、三个 IDE 指南、四个聊天平台指南和 Web 指南均返回 HTTP 200；Desktop 发布页通过 `gh release view` 验证。
- 已尝试 `npm run build` 和 `npm run typecheck`，但均未通过。worktree 依赖初始化遇到多次 registry 下载失败；复用已有依赖后出现 OpenTelemetry 依赖缺失和 Ajv 类型错误，均在本次文档改动范围之外。

### 前后对比证据

不适用——仅文档变更，没有产品界面或运行行为变更。

### 验证平台

| 系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ✅ 文档格式、链接及本地浏览器预览；构建和类型检查未成功 |
| 🪟 Windows | 不适用 |
| 🐧 Linux | 不适用 |

### 环境（可选）

macOS；构建及类型检查使用 Node.js 22.22.2。本地使用 Chromium 渲染 Markdown，预览近似 GitHub 布局。

## 风险与范围

- 主要风险或取舍：主视觉依赖所提供的外部 CDN 地址；图片是产品示意图，并非真实截图。
- 未验证或范围之外：所有入口的全新安装及真实会话；完整构建和类型检查在当前环境中未通过。没有修改生产代码、依赖清单或图片二进制文件。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>

