### PR TITLE
fix(core): host Windows shell PTYs via bundled ConPTY to stop orphaning conhost.exe

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1842,9 +1842,10 @@ describe('ShellExecutionService', () => {
   });
 
   describe('Windows bundled ConPTY backend (#11303)', () => {
-    // The inbox ConPTY backend orphans one `conhost.exe --headless` per PTY on
-    // natural shell exit (microsoft/node-pty#965); the bundled backend hosts
-    // the pseudo console in-process, leaving nothing to orphan.
+    // With the inbox ConPTY backend a natural shell exit orphans the
+    // `conhost.exe --headless` it spawned (microsoft/node-pty#965); #11303
+    // measured that growth gone once node-pty loads the conpty.dll it ships
+    // instead of the one built into Windows.
 
     let capturedReplyListener: ((data: string) => void) | undefined;
 
@@ -1877,6 +1878,63 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('falls back to child_process when the bundled ConPTY spawn throws on Windows', async () => {
+      // node-pty throws synchronously out of spawn when the conpty.dll it
+      // ships is missing or cannot be loaded, and none of those messages
+      // contain `posix_spawnp failed`. Without the spawn-phase branch in
+      // executeWithPty's catch this resolved exitCode 1 / executionMethod
+      // 'none', so the child_process fallback in execute() never ran.
+      mockPlatform.mockReturnValue('win32');
+      mockPtySpawn.mockImplementationOnce(() => {
+        throw new Error('Failed to load conpty.dll, error code: 126');
+      });
+      const fallbackChild = new EventEmitter() as EventEmitter &
+        Partial<ChildProcess>;
+      fallbackChild.stdout = new EventEmitter() as Readable;
+      fallbackChild.stderr = new EventEmitter() as Readable;
+      fallbackChild.kill = vi.fn();
+      Object.defineProperty(fallbackChild, 'pid', {
+        value: 4242,
+        configurable: true,
+      });
+      mockCpSpawn.mockReturnValue(fallbackChild);
+
+      try {
+        const handle = await ShellExecutionService.execute(
+          'echo hi',
+          '/test/dir',
+          onOutputEventMock,
+          new AbortController().signal,
+          true,
+          shellExecutionConfig,
+        );
+
+        await new Promise((resolve) => process.nextTick(resolve));
+        fallbackChild.stdout?.emit('data', Buffer.from('FALLBACK_MARKER'));
+        fallbackChild.emit('exit', 0, null);
+        fallbackChild.emit('close', 0, null);
+        const result = await handle.result;
+
+        expect(mockCpSpawn).toHaveBeenCalled();
+        expect(result.executionMethod).toBe('child_process');
+        expect(result.exitCode).toBe(0);
+        expect(result.output).toContain('FALLBACK_MARKER');
+        // The sandbox-specific PTY warning is POSIX wording and must not be
+        // emitted for a Windows DLL-load failure.
+        expect(
+          onOutputEventMock.mock.calls.some(
+            ([event]) =>
+              event.type === 'data' &&
+              String(event.chunk).includes('sandbox restrictions'),
+          ),
+        ).toBe(false);
+      } finally {
+        // vi.clearAllMocks() does not drop implementations, so restore the
+        // default (undefined) this describe block's other tests rely on.
+        mockCpSpawn.mockReturnValue(undefined);
+      }
+    });
+
     it('leaves the inbox ConPTY backend alone off Windows', async () => {
       // beforeEach pins the platform to linux.
       await simulateExecution('echo hi', (pty) => {
@@ -1903,6 +1961,28 @@ describe('ShellExecutionService', () => {
         expect(mockPtyProcess.write).toHaveBeenCalledWith('\x1b[?64;1;22c');
         pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
       });
+    });
+
+    it('drops a terminal query reply whose PTY write throws on Windows', async () => {
+      // A reply racing shell exit finds a dead PTY. The forwarder's try/catch
+      // has to contain that throw: deleting it lets the error escape the
+      // terminal's onData listener and this test goes red.
+      mockPlatform.mockReturnValue('win32');
+      mockLoadXtermHeadless.mockResolvedValueOnce({
+        Terminal: ReplyCapturingTerminal,
+      });
+      mockPtyProcess.write.mockImplementationOnce(() => {
+        throw new Error('pty gone');
+      });
+
+      const { result } = await simulateExecution('echo hi', (pty) => {
+        capturedReplyListener!('\x1b[?64;1;22c');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(mockPtyProcess.write).toHaveBeenCalledWith('\x1b[?64;1;22c');
+      expect(result.exitCode).toBe(0);
+      expect(result.error).toBeNull();
     });
 
     it('registers no terminal reply forwarder off Windows', async () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1841,6 +1841,86 @@ describe('ShellExecutionService', () => {
     });
   });
 
+  describe('Windows bundled ConPTY backend (#11303)', () => {
+    // The inbox ConPTY backend orphans one `conhost.exe --headless` per PTY on
+    // natural shell exit (microsoft/node-pty#965); the bundled backend hosts
+    // the pseudo console in-process, leaving nothing to orphan.
+
+    let capturedReplyListener: ((data: string) => void) | undefined;
+
+    // The forwarder under test subscribes through the terminal's public onData
+    // event; capture every listener a spawned terminal hands to it. The
+    // instance field shadows Terminal's prototype getter, so the service's
+    // subscription lands here instead of xterm's core emitter — the listener
+    // is invoked manually, and the returned disposable stands in for
+    // xterm's own so the cleanup path has something to dispose.
+    class ReplyCapturingTerminal extends pkg.Terminal {
+      override onData: pkg.IEvent<string> = (listener) => {
+        capturedReplyListener = listener;
+        return { dispose: () => undefined };
+      };
+    }
+
+    beforeEach(() => {
+      capturedReplyListener = undefined;
+    });
+
+    it('spawns PTYs with the bundled ConPTY backend on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(mockPtySpawn.mock.calls[0][2]).toMatchObject({
+        useConptyDll: true,
+      });
+    });
+
+    it('leaves the inbox ConPTY backend alone off Windows', async () => {
+      // beforeEach pins the platform to linux.
+      await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(mockPtySpawn.mock.calls[0][2]).toMatchObject({
+        useConptyDll: false,
+      });
+    });
+
+    it('writes the emulated terminal query replies back to the PTY on Windows', async () => {
+      // Bundled ConPTY answers no queries itself, so an unanswered DA probe
+      // stalls the shell for its full ~2s timeout; the forwarder must carry
+      // the emulated terminal's replies to the PTY.
+      mockPlatform.mockReturnValue('win32');
+      mockLoadXtermHeadless.mockResolvedValueOnce({
+        Terminal: ReplyCapturingTerminal,
+      });
+
+      await simulateExecution('echo hi', (pty) => {
+        expect(capturedReplyListener).toBeDefined();
+        capturedReplyListener!('\x1b[?64;1;22c');
+        expect(mockPtyProcess.write).toHaveBeenCalledWith('\x1b[?64;1;22c');
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+    });
+
+    it('registers no terminal reply forwarder off Windows', async () => {
+      // The gate must not change POSIX behavior at all: no onData
+      // subscription, so nothing can reach pty.write.
+      mockLoadXtermHeadless.mockResolvedValueOnce({
+        Terminal: ReplyCapturingTerminal,
+      });
+
+      await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      expect(capturedReplyListener).toBeUndefined();
+      expect(mockPtyProcess.write).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Binary Output', () => {
     it('should detect binary output and switch to progress events', async () => {
       mockIsBinary.mockReturnValueOnce(true);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1478,6 +1478,11 @@ export class ShellExecutionService {
       // This should not happen, but as a safeguard...
       throw new Error('PTY implementation not found');
     }
+    // Records whether pty.spawn returned. The catch at the end of this method
+    // needs it to tell a spawn-phase failure — no child exists yet, so handing
+    // the command to the child_process fallback cannot run it twice — from
+    // anything raised after the PTY is live.
+    let ptySpawned = false;
     try {
       const cols = shellExecutionConfig.terminalWidth ?? 80;
       const rows = shellExecutionConfig.terminalHeight ?? 30;
@@ -1515,16 +1520,21 @@ export class ShellExecutionService {
           ...getShellContextEnvVars(),
         },
         handleFlowControl: true,
-        // Windows: the inbox ConPTY backend spawns one `conhost.exe
-        // --headless` per PTY, and a natural shell exit orphans it — the
-        // native exit watcher erases the pty baton before JS can reach
-        // ClosePseudoConsole (microsoft/node-pty#965), so the host lives
-        // until the CLI exits (#11303's `+7 conhost for 7 tool commands`).
-        // The bundled-ConPTY backend hosts the pseudo console in-process
-        // instead, leaving no conhost.exe to orphan. Off Windows the option
-        // is inert.
+        // Windows: with the inbox ConPTY backend a natural shell exit orphans
+        // the `conhost.exe --headless` that backend spawned — the native exit
+        // watcher erases the pty baton before JS can reach ClosePseudoConsole
+        // (microsoft/node-pty#965), so hosts accumulate until the CLI exits
+        // (#11303: `+7 conhost for 7 tool commands`). This option makes
+        // node-pty load the conpty.dll shipped with the package instead of the
+        // one built into Windows — that swap is all @lydell/node-pty documents
+        // the option as, and its typings mark it EXPERIMENTAL. #11303 measured
+        // the per-command host growth gone with
+        // @lydell/node-pty-win32-x64 1.2.0-beta.10 on Windows Server 2025 (30
+        // commands: 30 orphaned hosts before, 0 after). Off Windows the option
+        // is inert: `useConptyDll` appears nowhere in the POSIX prebuilds.
         useConptyDll: os.platform() === 'win32',
       });
+      ptySpawned = true;
 
       const result = new Promise<ShellExecutionResult>((resolve) => {
         const headlessTerminal = new Terminal({
@@ -2437,6 +2447,23 @@ export class ShellExecutionService {
       return { pid: ptyProcess.pid, result };
     } catch (e) {
       const error = e as Error;
+      if (!ptySpawned && os.platform() === 'win32') {
+        // The bundled ConPTY backend (useConptyDll above) adds throw sites
+        // node-pty reaches synchronously out of spawn — the conpty.dll it
+        // ships being missing or unloadable among them — and none of those
+        // messages contain `posix_spawnp failed`. Resolving below would report
+        // exitCode 1 with empty output and skip the child_process fallback
+        // that execute() already has for a PTY that cannot start, so rethrow
+        // into it. Nothing was spawned, so the command cannot run twice. The
+        // sandbox warning below does not apply here: this is not a sandbox
+        // restriction, and it must not be worded as one.
+        debugLogger.warn(
+          `Windows PTY spawn failed, falling back to child_process: ${
+            error instanceof Error ? error.message : String(e)
+          }`,
+        );
+        throw e;
+      }
       if (error.message.includes('posix_spawnp failed')) {
         onOutputEvent({
           type: 'data',

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1515,6 +1515,15 @@ export class ShellExecutionService {
           ...getShellContextEnvVars(),
         },
         handleFlowControl: true,
+        // Windows: the inbox ConPTY backend spawns one `conhost.exe
+        // --headless` per PTY, and a natural shell exit orphans it — the
+        // native exit watcher erases the pty baton before JS can reach
+        // ClosePseudoConsole (microsoft/node-pty#965), so the host lives
+        // until the CLI exits (#11303's `+7 conhost for 7 tool commands`).
+        // The bundled-ConPTY backend hosts the pseudo console in-process
+        // instead, leaving no conhost.exe to orphan. Off Windows the option
+        // is inert.
+        useConptyDll: os.platform() === 'win32',
       });
 
       const result = new Promise<ShellExecutionResult>((resolve) => {
@@ -1527,6 +1536,27 @@ export class ShellExecutionService {
           logLevel: 'off',
         });
         headlessTerminal.scrollToTop();
+
+        // Bundled ConPTY (useConptyDll above) answers no terminal queries
+        // itself, so a shell that probes the terminal — PowerShell's DA query
+        // at startup — stalls for its full ~2s timeout unless the emulated
+        // terminal's auto-generated reply is written back (measured 3.22s →
+        // 0.23s per command). Scoped to Windows to keep the POSIX path
+        // byte-identical; the hook dies with headlessTerminal.dispose() in
+        // both the foreground and background-promote cleanups.
+        const queryResponseDisposable =
+          os.platform() === 'win32'
+            ? headlessTerminal.onData((data) => {
+                try {
+                  ptyProcess.write(data);
+                } catch (e) {
+                  // A reply racing shell exit finds a dead PTY — drop it.
+                  debugLogger.warn(
+                    `writing terminal query reply to PTY threw: ${e instanceof Error ? e.message : String(e)}`,
+                  );
+                }
+              })
+            : null;
 
         this.activePtys.set(ptyProcess.pid, { ptyProcess, headlessTerminal });
 
@@ -1813,6 +1843,13 @@ export class ShellExecutionService {
           } catch (e) {
             debugLogger.warn(
               `ptyProcess.removeListener('error') threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
+            queryResponseDisposable?.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `queryResponseDisposable.dispose() threw during PTY cleanup: ${e instanceof Error ? e.message : String(e)}`,
             );
           }
           try {
@@ -2291,6 +2328,13 @@ export class ShellExecutionService {
                 (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
             });
           } finally {
+            try {
+              queryResponseDisposable?.dispose();
+            } catch (e) {
+              debugLogger.warn(
+                `queryResponseDisposable.dispose() threw during background-promote cleanup: ${e instanceof Error ? e.message : String(e)}`,
+              );
+            }
             try {
               headlessTerminal.dispose();
             } catch (e) {


### PR DESCRIPTION
## What this PR does

On Windows, shell-tool PTYs use the `conpty.dll` shipped with `@lydell/node-pty` instead of the ConPTY backend built into Windows. The emulated headless terminal's generated query replies are also written back to the PTY, preventing PowerShell's startup device-attributes probe from waiting for its full timeout.

The change is limited to shell execution. Web terminals keep the Windows inbox backend, and non-Windows platforms do not register the reply forwarder or enable the bundled backend.

## Why it's needed

With the Windows inbox ConPTY backend, node-pty removes its native PTY record before JavaScript receives a natural-exit event, leaving the console host alive until the owning Qwen process exits (microsoft/node-pty#965). #11303 reproduced the leak at one surviving `conhost.exe --headless` per shell command.

The bundled backend has a different lifetime mechanism: node-pty calls `ConptyReleasePseudoConsole` after spawning the client, releasing the reference that otherwise keeps the bundled console host alive after the last client exits. Real-hardware testing on Windows Server 2025 with Node 22.23.1 and the exact 1.2.0-beta.10 packages confirmed correct output and exit status and showed 0 surviving `conhost.exe` after a 30-command bundled run. That `conhost.exe`-only count is supporting evidence, not proof of zero host children, because bundled ConPTY uses `OpenConsole.exe`; the reviewer plan below therefore requires counting both host names or all attributable child processes.

Without terminal-query forwarding, a short PowerShell command on the same machine took 3.22 seconds. Feeding the query through the emulated terminal and writing its generated reply back reduced it to 0.23 seconds.

## Reviewer Test Plan

### How to verify

1. On Windows, record all `conhost.exe` and `OpenConsole.exe` processes attributable to the Qwen process (or enumerate all direct/descendant child processes), run a batch of shell tool commands, and recount. No console-host process attributable to completed commands should remain.
2. With PowerShell as the shell, confirm a short command does not wait roughly two seconds for its device-attributes query.
3. Cancel a running shell command and confirm its process tree is reaped and no console host remains attributable to the cancelled PTY.

### Evidence (Before & After)

N/A — no UI change. The focused unit file passed 141/141 tests at the reviewed head, including the Windows spawn option, spawn-failure fallback, reply forwarding, write-failure containment, and non-Windows isolation cases. Real-hardware evidence is described above; the `OpenConsole.exe`/full-child count and cancellation spot-check were not captured in that run.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ unit tests   |
| 🪟 Windows |   ⚠️ partial process-level validation; full host census pending   |
|  🐧 Linux  |   ⚠️ not tested (option inert off win32)   |

### Environment (optional)

Local unit verification: macOS, Node 22.22.0. Real-hardware behavior: Windows Server 2025, Node 22.23.1, `@lydell/node-pty` and `@lydell/node-pty-win32-x64` 1.2.0-beta.10.

## Risk & Scope

- Main risk or tradeoff: bundled ConPTY can differ from the inbox backend. Exposure is limited to headless shell execution, and terminal-query replies are forwarded to preserve startup behavior.
- Not validated / out of scope: a full real-Windows census that includes `OpenConsole.exe`, attached-survivor and cancellation process-tree spot-checks, and web-terminal interactive sessions. Focused follow-up regression tests are being prepared after #11313 closes to avoid another conflict in the same test file.
- Breaking changes / migration notes: none. Runtimes without a PTY implementation keep the existing child-process fallback.

## Linked Issues

References #11303 without closing the whole issue. Related worker cleanup: #11313. Upstream inbox-backend defect: microsoft/node-pty#965.

<details>
<summary>中文说明</summary>

## 本 PR 做什么

在 Windows 上，shell tool PTY 改用 `@lydell/node-pty` 自带的 `conpty.dll`，而不是 Windows 内置的 ConPTY 后端。同时把无头终端仿真生成的查询应答写回 PTY，避免 PowerShell 启动时的设备属性探测等待完整超时。

改动仅限 shell 执行。Web terminal 继续使用 Windows inbox 后端；非 Windows 平台既不会注册应答转发器，也不会启用 bundled 后端。

## 为什么需要

使用 Windows inbox ConPTY 后端时，node-pty 会在 JavaScript 收到自然退出事件之前移除原生 PTY 记录，导致 console host 一直存活到持有它的 Qwen 进程退出（microsoft/node-pty#965）。#11303 已按每条 shell 命令残留一个 `conhost.exe --headless` 稳定复现该泄漏。

Bundled 后端使用不同的生命周期机制：node-pty 在 spawn 客户端后调用 `ConptyReleasePseudoConsole`，释放那个会让 bundled console host 在最后一个客户端退出后继续存活的引用。使用 Windows Server 2025、Node 22.23.1 和精确的 1.2.0-beta.10 包进行真机测试，确认输出与退出码正确，且 30 条 bundled 命令后残留 `conhost.exe` 为 0。由于 bundled ConPTY 使用 `OpenConsole.exe`，只统计 `conhost.exe` 只能作为支持性证据，不能证明 host 子进程为 0；因此下面的审阅计划要求同时统计两种 host 名称，或统计所有可归因的子进程。

在同一台机器上，如果不转发终端查询，一条短 PowerShell 命令需要 3.22 秒；让仿真终端处理查询并把生成的应答写回后，降到 0.23 秒。

## 审阅者测试计划

### 如何验证

1. 在 Windows 上记录所有可归因于 Qwen 进程的 `conhost.exe` 和 `OpenConsole.exe`（或者枚举全部直接/后代子进程），批量运行 shell tool 命令后重新统计。已完成命令不应留下可归因的 console host 进程。
2. 使用 PowerShell 作为 shell，确认短命令不会因设备属性查询等待约两秒。
3. 取消一条运行中的 shell 命令，确认其进程树被回收，并且被取消的 PTY 没有留下可归因的 console host。

### 证据（前后对比）

N/A——没有 UI 变化。评审 head 的定向单测文件 141/141 通过，覆盖 Windows spawn 选项、spawn 失败回退、应答转发、写入失败隔离以及非 Windows 隔离。真机证据见上；该轮没有记录 `OpenConsole.exe`/完整子进程计数，也没有记录取消抽查。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 单元测试   |
| 🪟 Windows |   ⚠️ 部分进程级验证；完整 host 统计待补   |
|  🐧 Linux  |   ⚠️ 未测试（该选项在非 win32 上无效）   |

### 环境（可选）

本地单元验证：macOS，Node 22.22.0。真机行为验证：Windows Server 2025，Node 22.23.1，`@lydell/node-pty` 与 `@lydell/node-pty-win32-x64` 1.2.0-beta.10。

## 风险与范围

- 主要风险或取舍：bundled ConPTY 与 inbox 后端可能存在差异。暴露面仅限无头 shell 执行，并通过转发终端查询应答来保持启动行为。
- 未验证 / 超出范围：包含 `OpenConsole.exe` 的完整 Windows 真机统计、attached-survivor 与取消进程树抽查，以及 web terminal 交互会话。为了避免同一测试文件再次冲突，定向补充回归测试会在 #11313 收尾后准备。
- 破坏性变更 / 迁移说明：无。没有 PTY 实现的运行时继续使用现有 child-process 回退。

## 关联 Issue

引用 #11303，但不关闭整个 issue。相关 worker 清理：#11313。inbox 后端上游缺陷：microsoft/node-pty#965。

</details>
