### PR TITLE
fix(web-shell): restore standalone header and scroll button styles

### DIFF
--- a/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.transcript-composer-alignment.spec.ts
@@ -70,7 +70,9 @@ for (const navigation of [true, false]) {
         },
       });
     });
-    await page.goto(`/session/${encodeURIComponent(scenario.sessionId)}`);
+    await page.goto(
+      `/session/${encodeURIComponent(scenario.sessionId)}?theme=light`,
+    );
     await expect(page.locator('[data-web-shell-root]')).toBeVisible();
     const connection = await daemon.sse.waitForConnection(scenario.sessionId);
     await daemon.sendEvent(
@@ -100,6 +102,21 @@ for (const navigation of [true, false]) {
         ),
       )
       .toBeGreaterThan(0);
+    await expect
+      .soft(page.locator('[class*="chatHeaderRow"]'))
+      .toHaveCSS('border-bottom-width', '1px');
+    await messageList.hover();
+    await page.mouse.wheel(0, -400);
+    const scrollToBottom = page.getByRole('button', {
+      name: /Scroll to bottom|回到底部/,
+    });
+    await expect(scrollToBottom).toBeVisible();
+    await expect.soft(scrollToBottom).toHaveCSS('border-top-width', '1px');
+    await expect(scrollToBottom).toHaveCSS(
+      'background-color',
+      'color(srgb 1 1 1 / 0.96)',
+    );
+    await scrollToBottom.click();
     for (const width of [1440, 1300, 1261, 1260, 1259, 1000, 802, 700, 599]) {
       await page.setViewportSize({ width, height: 900 });
       await expectSameEdges(message, composer);

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -1,3 +1,5 @@
+// Load resets before any component can import CSS modules.
+import './styles/globals.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { useCallback, useEffect, useState } from 'react';


### PR DESCRIPTION
## What this PR does

Restores the standalone Web Shell's session-header divider and the scroll-to-bottom button's nearly opaque background and border by loading global resets before component styles. Adds browser regression checks for all three visible properties.

## Why it's needed

The authentication gate introduced in #11172 caused component styles to load before the global resets. Equal-specificity reset rules then removed the header's bottom border and made the scroll button fully transparent, exposing its existing backdrop blur. Loading resets first restores the intended cascade.

## Reviewer Test Plan

### How to verify

1. Open the standalone Web Shell in the light theme with a conversation long enough to scroll. Confirm the session header has a thin bottom divider.
2. Scroll upward. Confirm the scroll-to-bottom button has a nearly opaque white background and a thin border; clicking it returns to the latest messages.
3. Check the authentication gate in light and dark themes. Its card, input, and connect button should retain their normal styling.

### Evidence (Before & After)

Real Chromium computed styles and browser regression tests show:

| Property | Before | After |
| --- | --- | --- |
| Header bottom border | 0px | 1px |
| Scroll button border | 0px | 1px |
| Scroll button background | Fully transparent | White at 96% opacity |
| Scroll button backdrop blur | 8px | 8px |

The new assertions failed on the unfixed code and passed after the fix. Both navigation variants passed. All 60 focused unit/artifact tests, build, bundle, typecheck, and targeted lint/format checks passed. A separate E2E report accompanies this PR.

### Tested on

| OS | Status |
| :--- | :---: |
| macOS | ✅ |
| Windows | ⚠️ |
| Linux | ⚠️ |

### Environment (optional)

Local Vite with mocked daemon responses and Chromium; additional computed-style checks against production CSS and inspection of a live browser session.

## Risk & Scope

- Main risk or tradeoff: changes the standalone stylesheet evaluation order, so the authentication gate was checked in both themes as well as the chat UI.
- Not validated / out of scope: no authentication-policy changes. Embedded library entry points already had the correct order; their built CSS was checked for compatibility. Windows and Linux were not tested locally.
- Breaking changes / migration notes: none.

## Linked Issues

Regression introduced by #11172.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让独立 Web Shell 的全局重置先于组件样式加载，恢复会话 header 的底部分隔线，以及回到底部按钮的近乎不透明背景和边框。增加浏览器回归检查，覆盖这三个可见属性。

## 为什么需要

#11172 新增的认证页面让组件样式先于全局重置加载。同优先级的重置规则随后清除了 header 底部边框，并让回到底部按钮完全透明，从而显露出原有的背景模糊。优先加载全局重置可以恢复预期的层叠顺序。

## 审阅测试计划

### 如何验证

1. 使用浅色主题打开独立 Web Shell，进入一段足够长、可以滚动的会话。确认会话 header 下方有细分隔线。
2. 向上滚动。确认回到底部按钮有近乎不透明的白色背景和细边框，点击后回到最新消息。
3. 检查浅色和深色主题的认证页面，卡片、输入框和连接按钮应保持正常样式。

### 证据（前后对比）

真实 Chromium 计算样式和浏览器回归测试的结果如下：

| 属性 | 修复前 | 修复后 |
| --- | --- | --- |
| Header 底部边框 | 0px | 1px |
| 回到底部按钮边框 | 0px | 1px |
| 回到底部按钮背景 | 完全透明 | 96% 不透明白色 |
| 回到底部按钮背景模糊 | 8px | 8px |

新增断言在未修复代码上失败，修复后通过；两种导航模式均通过。60 项相关单元及构建产物测试，以及构建、打包、类型检查和针对改动的 lint/格式检查全部通过。另附独立 E2E 测试报告评论。

### 测试平台

| 操作系统 | 状态 |
| :--- | :---: |
| macOS | ✅ |
| Windows | ⚠️ |
| Linux | ⚠️ |

### 环境（可选）

本地 Vite、模拟 daemon 响应及 Chromium；另检查了生产 CSS 的计算样式和真实浏览器会话。

## 风险与范围

- 主要风险或权衡：调整独立网页的样式加载顺序，因此除聊天界面外，也检查了两种主题的认证页面。
- 未验证或超出范围：不修改认证策略。宿主嵌入的库入口原本顺序正确，已检查其构建 CSS 的兼容性。未在 Windows 和 Linux 本地测试。
- 破坏性变更或迁移说明：无。

## 关联 Issue

修复 #11172 引入的回归。

</details>
