### PR TITLE
fix(desktop): unblock macOS and Linux desktop packaging

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -363,30 +363,50 @@ jobs:
           APPLE_SIGNING_IDENTITY: '${{ env.APPLE_SIGNING_IDENTITY }}'
         run: |
           set -euo pipefail
-          # Sign all native macOS executables in the bundled runtime so
-          # notarization does not reject them. Tauri only signs the main
-          # app binary; resources like ripgrep and the Node.js runtime are
-          # embedded verbatim and must be signed beforehand.
+          # Sign every native macOS binary in the bundled runtime so
+          # notarization does not reject them. Tauri only signs the main app
+          # binary; the runtime is embedded verbatim and must be signed
+          # beforehand.
+          #
+          # Enumerate the Mach-O files instead of listing the known ones. The
+          # runtime is a copy of the CLI's dist tree, so its native payload
+          # changes whenever a CLI dependency does, without anything in this
+          # package changing. An unsigned renderer library arrived exactly
+          # that way and failed release 0.2.3-preview.0 in the notary service,
+          # twenty minutes into the job, against a list that had covered every
+          # binary the runtime carried when it was written.
           runtime_dir="runtime/qwen-code"
-          # ripgrep vendor binaries
-          rg_dir="$runtime_dir/lib/vendor/ripgrep"
-          if [ -d "$rg_dir" ]; then
-            find "$rg_dir" -type f -name 'rg' -path '*-darwin/*' -exec \
-              codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
-              --options runtime --timestamp \
-              {} +
-          else
-            echo "::warning::Ripgrep vendor directory not found at $rg_dir; no ripgrep binaries signed."
+          mach_o=()
+          while IFS= read -r -d '' file; do
+            if [ "$(file -b --mime-type "$file")" = 'application/x-mach-binary' ]; then
+              mach_o+=("$file")
+            fi
+          done < <(find "$runtime_dir" -type f -print0)
+          if [ "${#mach_o[@]}" -eq 0 ]; then
+            echo "::error::No Mach-O binary found under $runtime_dir. The runtime is not staged as expected."
+            exit 1
           fi
-          # Node.js runtime binary
+          # Node.js runs the CLI's JIT; nothing else in the runtime needs an
+          # entitlement of its own, and libraries inherit the host process's.
           node_bin="$runtime_dir/node/bin/node"
-          if [ -f "$node_bin" ]; then
-            codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
-              --options runtime --timestamp \
-              --entitlements src-tauri/NodeEntitlements.plist "$node_bin"
-          else
-            echo "::warning::Node.js runtime binary not found at $node_bin; no Node.js binary signed."
+          for file in "${mach_o[@]}"; do
+            if [ "$file" = "$node_bin" ]; then
+              codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+                --options runtime --timestamp \
+                --entitlements src-tauri/NodeEntitlements.plist "$file"
+            else
+              codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+                --options runtime --timestamp "$file"
+            fi
+          done
+          if [ ! -f "$node_bin" ]; then
+            echo "::warning::Node.js runtime binary not found at $node_bin."
           fi
+          # Verify here rather than learning it from the notary service.
+          for file in "${mach_o[@]}"; do
+            codesign --verify --strict "$file"
+          done
+          echo "Signed and verified ${#mach_o[@]} Mach-O binaries under $runtime_dir."
 
       - name: 'Refresh bundled runtime checksums after signing (macOS)'
         if: "runner.os == 'macOS' && inputs.dry_run == false"

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -292,6 +292,36 @@ function stampReviewSourceDigest(root, distDir) {
 }
 
 /**
+ * Whether this host's Node.js links against musl rather than glibc. The
+ * report header only carries `glibcVersionRuntime` on a glibc runtime.
+ */
+function hostUsesMusl() {
+  if (process.platform !== 'linux') return false;
+  try {
+    return !process.report?.getReport?.()?.header?.glibcVersionRuntime;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether an `@opentui/core-*` package holds a native library this host
+ * cannot load: the Linux packages ship one library per libc, and npm
+ * installs both flavors on a glibc host because only `libc` (not `os`/`cpu`)
+ * separates them.
+ *
+ * Shipping the foreign one is not merely dead weight. Both are ELF files, so
+ * AppImage packaging walks them with `ldd` while deploying dependencies; the
+ * musl library needs `libc.so`, which no glibc system resolves, so `ldd`
+ * exits non-zero and aborts linuxdeploy. That is what broke the Linux job of
+ * desktop release 0.2.3-preview.0, which bundles this dist tree verbatim.
+ */
+function isForeignLibcPackage(entry, musl = hostUsesMusl()) {
+  if (!entry.startsWith('core-linux-')) return false;
+  return entry.endsWith('-musl') !== musl;
+}
+
+/**
  * OpenTUI renderer runtime assets (tree-sitter grammars, the parser worker,
  * `web-tree-sitter` runtime and the native render library) relocated next to
  * the bundle.
@@ -314,7 +344,11 @@ function stampReviewSourceDigest(root, distDir) {
  * callers/tests can assert on it. Never fails the bundle: a missing
  * @opentui/core (e.g. an install without the renderer) only warns.
  */
-export function copyOpenTuiAssets({ root = defaultRoot, distDir } = {}) {
+export function copyOpenTuiAssets({
+  root = defaultRoot,
+  distDir,
+  musl = hostUsesMusl(),
+} = {}) {
   distDir ??= join(root, 'dist');
   const destRoot = join(distDir, 'opentui-assets');
   // Start from a clean tree: the runtime gate below checks key existence
@@ -402,17 +436,19 @@ export function copyOpenTuiAssets({ root = defaultRoot, distDir } = {}) {
   }
 
   // 4. Native render libraries for every installed @opentui platform package
-  //    (core-darwin-arm64, core-linux-x64-musl, …). The runtime only needs
-  //    the current platform's, but shipping the installed set keeps the
-  //    completeness check satisfiable wherever the bundle runs next. The
-  //    platform packages live beside @opentui/core or hoisted at the repo
-  //    root; scan both scope directories.
+  //    (core-darwin-arm64, core-win32-x64, …), minus the Linux packages built
+  //    for the other libc (see isForeignLibcPackage). The runtime only needs
+  //    the current platform's, but shipping the rest of the installed set
+  //    keeps the completeness check satisfiable wherever the bundle runs
+  //    next. The platform packages live beside @opentui/core or hoisted at
+  //    the repo root; scan both scope directories.
   const scopeDirs = [dirname(coreDir), join(root, 'node_modules', '@opentui')];
   const seenPackages = new Set();
   for (const scopeDir of scopeDirs) {
     if (!existsSync(scopeDir)) continue;
     for (const entry of fs.readdirSync(scopeDir)) {
       if (!entry.startsWith('core-') || seenPackages.has(entry)) continue;
+      if (isForeignLibcPackage(entry, musl)) continue;
       const packageDir = join(scopeDir, entry);
       if (!statSync(packageDir).isDirectory()) continue;
       let copiedFromPackage = false;

--- a/scripts/tests/copy-bundle-openTui-assets.test.js
+++ b/scripts/tests/copy-bundle-openTui-assets.test.js
@@ -70,6 +70,18 @@ function seedOpentuiPackages(root) {
   writeFileSync(join(treeSitterDir, 'tree-sitter.wasm'), 'wasm');
 }
 
+function seedLinuxPlatformPackages(root) {
+  for (const name of ['core-linux-x64', 'core-linux-x64-musl']) {
+    const platformDir = join(root, 'node_modules', '@opentui', name);
+    mkdirSync(platformDir, { recursive: true });
+    writeFileSync(
+      join(platformDir, 'package.json'),
+      JSON.stringify({ name: `@opentui/${name}` }),
+    );
+    writeFileSync(join(platformDir, 'libopentui.so'), 'native');
+  }
+}
+
 describe('copyOpenTuiAssets', () => {
   it('copies the runtime assets under the exact OTUI_ASSET_ROOT keys', () => {
     const root = mkdtempSync(join(tmpdir(), 'opentui-bundle-assets-'));
@@ -145,4 +157,33 @@ describe('copyOpenTuiAssets', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // npm installs both Linux flavors on a glibc host — only `libc` separates
+  // them — and the musl library then aborts AppImage packaging, because
+  // linuxdeploy runs `ldd` over every ELF in the tree and no glibc system
+  // resolves its `libc.so`.
+  it.each([
+    { musl: false, kept: 'core-linux-x64', dropped: 'core-linux-x64-musl' },
+    { musl: true, kept: 'core-linux-x64-musl', dropped: 'core-linux-x64' },
+  ])(
+    'copies only the Linux library for this host libc (musl: $musl)',
+    ({ musl, kept, dropped }) => {
+      const root = mkdtempSync(join(tmpdir(), 'opentui-bundle-assets-'));
+      try {
+        writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+        seedOpentuiPackages(root);
+        seedLinuxPlatformPackages(root);
+
+        const copied = copyOpenTuiAssets({ root, musl });
+
+        expect(copied).toContain(`@opentui/${kept}/libopentui.so`);
+        expect(copied).not.toContain(`@opentui/${dropped}/libopentui.so`);
+        const dest = join(root, 'dist', 'opentui-assets', '@opentui');
+        expect(existsSync(join(dest, kept, 'libopentui.so'))).toBe(true);
+        expect(existsSync(join(dest, dropped))).toBe(false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
## What this PR does

Fixes the two independent failures that stopped desktop release 0.2.3-preview.0 on three of its four platforms (run 34361159494). They share a shape — the desktop app embeds a runtime built from this repository's dist tree, and that tree grew a native library neither the macOS signing step nor the Linux bundler was prepared for — but they need separate fixes.

**Linux.** The OpenTUI asset copier ships the native render library from every installed platform package. On Linux that is two packages rather than one — the glibc and the musl build are separated only by the `libc` field, so a glibc host installs both — and the bundle ends up carrying two ELF libraries where only one can ever load. This skips the Linux package built for the libc the host does not use.

**macOS.** The signing step walks a list: the ripgrep vendor binaries and the Node.js runtime. That list covered everything the runtime carried when it was written, but the runtime's native payload changes whenever a CLI dependency does, with nothing in the desktop package changing. This enumerates the Mach-O files under the staged runtime and signs all of them, then verifies them in the same step.

## Why it's needed

On Linux, shipping the second library is not merely dead weight. linuxdeploy walks every ELF file in the AppDir to deploy its dependencies, and the musl library needs `libc.so`, which no glibc system resolves. `ldd` exits non-zero, linuxdeploy aborts, and the only thing that reaches the build log is `failed to bundle project: failed to run linuxdeploy` — the underlying error is swallowed. The same release succeeded on Linux three weeks earlier, before the renderer dependency landed.

On macOS the library shipped unsigned, and both macOS jobs built for twenty minutes before losing the archive to the notary service with `The binary is not signed with a valid Developer ID certificate`. An allowlist cannot hold here: it is a list of what the runtime contained on the day it was written, maintained in a package that does not change when the runtime's contents do. Enumerating what is actually there, and failing the step rather than the notarization when something is unsigned, removes the class rather than this instance.

The other platforms are unaffected by the Linux change — their libraries are not ELF, so the Linux bundler ignores them, and the runtime completeness gate only ever requires the current platform's key. It also drops roughly 27 MB from every Linux bundle.

## Reviewer Test Plan

### How to verify

For the Linux fix, confirm the mechanism first: on a glibc Linux host, `npm ls @opentui/core-linux-x64 @opentui/core-linux-x64-musl` shows both packages installed, and before this change a bundle logs `Copied 15 OpenTUI runtime assets` where macOS logs 14 — the extra asset is the musl library. After this change Linux logs 14 as well. Then confirm the failure it removes by running linuxdeploy over an AppDir containing the musl library: it aborts with `terminate called after throwing an instance of 'std::runtime_error' / what(): Failed to run ldd: exited with code 1` as soon as it reaches that file, and completes normally once the file is gone.

For the macOS fix, a signed build should report the number of binaries it signed and verified, and that number should exceed what the old list covered — the renderer library and the Node.js binary and the ripgrep binaries, not the last two alone. A run that finds no Mach-O file at all now fails the step rather than quietly signing nothing.

The real verification is a desktop release run: Linux reaching deb bundling instead of dying in the AppImage stage, and both macOS targets passing notarization. A dry run covers the Linux half; the macOS half needs a publishing run, since the signing steps are gated on it.

The new unit tests pin both directions of the Linux choice by injecting the host libc, so they assert the same behavior on a glibc and on a musl runner.

### Evidence (Before & After)

N/A — build and release tooling, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ not tested  |
| 🪟 Windows |  ⚠️ not tested (unaffected)  |
|  🐧 Linux  |  ✅ mechanism reproduced, full build not run  |

The linuxdeploy abort and its fix were reproduced against the published `@opentui/core-linux-x64` and `@opentui/core-linux-x64-musl` tarballs and the linuxdeploy build the Tauri bundler downloads. The macOS signing step was checked for shell correctness only; it cannot run without the signing identity. Neither the bundle nor a desktop build was run locally — CI and the desktop release workflow are what confirm those.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: a bundle built on glibc no longer satisfies the asset gate for a run under `OPENTUI_LIBC=musl`. That run falls back to package-relative asset resolution, the same path an install without the relocated tree takes, so the renderer keeps working wherever the packages are on disk. On the macOS side, signing more binaries means a slower step and a longer dependency on the timestamp service; the verification pass is what buys back the twenty minutes a notarization round trip costs.
- Not validated / out of scope: Windows installers are still unsigned, as they have been since the first Tauri release — no code signing certificate is configured, and that is a secret to add rather than a change to make here. Also out of scope is the missing continuous coverage of this path, which is what let both failures reach release day; that is #11519.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 desktop 0.2.3-preview.0 发布中导致四个平台里三个失败的两个独立问题（run 34361159494）。它们形状相似——桌面应用内嵌的运行时来自本仓库的 dist 产物，而这份产物新增了一个原生库，macOS 签名步骤和 Linux 打包器都没有为它做好准备——但需要两个不同的修复。

**Linux.** OpenTUI 资源拷贝逻辑会把已安装的每一个平台包中的原生渲染库都打进 bundle。在 Linux 上这意味着两个包而不是一个——glibc 版和 musl 版之间只有 `libc` 字段的区别，所以 glibc 主机会同时装上两个——于是 bundle 里带了两个 ELF 库，而其中只有一个可能被加载。本 PR 跳过与当前主机 libc 不匹配的那个 Linux 包。

**macOS.** 签名步骤走的是一份清单：ripgrep 的 vendor 二进制和 Node.js 运行时。这份清单在写下时覆盖了运行时携带的全部二进制，但运行时的原生内容会随着任意一个 CLI 依赖变化而变化，而桌面包本身可以毫无改动。本 PR 改为枚举暂存运行时下的所有 Mach-O 文件并全部签名，并在同一步骤内验证。

## 为什么需要

在 Linux 上，多带的这个库不只是无用体积。linuxdeploy 会遍历 AppDir 中的每一个 ELF 文件来部署依赖，而 musl 版的库依赖 `libc.so`，任何 glibc 系统都解析不了它。`ldd` 返回非零，linuxdeploy 中止，而构建日志里只剩下 `failed to bundle project: failed to run linuxdeploy`——真正的错误被吞掉了。三周前的同一条发布流程在 Linux 上还是成功的，那时渲染器依赖尚未引入。

在 macOS 上，这个库以未签名状态被打包，两个 macOS job 各构建了二十分钟，最后在公证服务上失败：`The binary is not signed with a valid Developer ID certificate`。白名单在这里注定失效：它记录的是写下它那一天运行时的内容，而它所在的包在运行时内容变化时并不会改动。改为枚举实际存在的文件，并在发现未签名文件时让步骤失败而不是让公证失败，消除的是这一类问题而不是这一次问题。

Linux 的改动不影响其他平台：它们的库不是 ELF，Linux 打包器会忽略；运行时完整性检查也始终只要求当前平台对应的那一个键。此外这个改动让每个 Linux bundle 少了大约 27 MB。

## 评审验证计划

### 如何验证

Linux 部分，先确认机制：在 glibc 的 Linux 主机上，`npm ls @opentui/core-linux-x64 @opentui/core-linux-x64-musl` 会显示两个包都已安装；改动前 Linux 的构建日志是 `Copied 15 OpenTUI runtime assets`，而 macOS 是 14——多出来的那一个就是 musl 库。改动后 Linux 同样是 14。再确认它消除的那个失败：把 musl 库放进 AppDir 后运行 linuxdeploy，走到该文件时会以 `terminate called after throwing an instance of 'std::runtime_error' / what(): Failed to run ldd: exited with code 1` 中止；移除该文件后即可正常完成。

macOS 部分，一次签名构建应当报告它签名并验证了多少个二进制，且这个数量应当超过旧清单覆盖的范围——渲染器库、Node.js 二进制和 ripgrep 二进制，而不只是后两者。若一个文件都没找到，该步骤现在会直接失败，而不是安静地什么都不签。

最终验证是一次桌面发布运行：Linux 走到 deb 打包阶段而不是死在 AppImage 阶段，两个 macOS 目标通过公证。dry run 能覆盖 Linux 那一半；macOS 那一半需要真实发布，因为签名步骤以此为前提。

新增的单测通过注入主机 libc 固定了 Linux 侧两个方向的选择，因此在 glibc 和 musl runner 上断言的行为一致。

### 证据（Before & After）

N/A——构建与发布工具链改动，无用户可见界面。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ 未测试  |
| 🪟 Windows |  ⚠️ 未测试（不受影响）  |
|  🐧 Linux  |  ✅ 已复现机制，未跑完整构建  |

linuxdeploy 的中止以及修复效果，是针对 npm 上发布的 `@opentui/core-linux-x64` 与 `@opentui/core-linux-x64-musl` 包，以及 Tauri 打包器下载的同一份 linuxdeploy 复现的。macOS 签名步骤只做了 shell 正确性检查，没有签名身份就无法运行。bundle 本身和桌面构建都没有在本地跑，这两项由 CI 和桌面发布流程确认。

### 环境（可选）

N/A

## 风险与范围

- 主要风险/取舍：在 glibc 上构建出的 bundle 不再满足 `OPENTUI_LIBC=musl` 运行时的资源完整性检查。该情况会退回到按包路径解析资源，这与没有重定位资源目录的安装走的是同一条路径，因此只要 node_modules 中有对应包，渲染器仍然可用。macOS 一侧，签名的二进制变多意味着该步骤更慢、对时间戳服务的依赖更长；而验证环节买回来的是一次公证往返所耗的二十分钟。
- 未验证 / 不在范围内：Windows 安装包仍未签名，这从第一个 Tauri 版本起就是如此——仓库没有配置代码签名证书，那是需要补一个 secret，而不是在这里改代码。同样不在范围内的是这条链路缺失的持续覆盖，正是它让这两个问题都拖到了发布当天才暴露，那部分是 #11519。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8092。

</details>
