### PR TITLE
ci(desktop): exercise desktop packaging on a schedule

### DIFF
--- a/.github/workflows/desktop-packaging-check.yml
+++ b/.github/workflows/desktop-packaging-check.yml
@@ -1,0 +1,47 @@
+name: 'Desktop Packaging Check'
+
+run-name: "Desktop packaging check (${{ inputs.qwen_code_ref || 'main' }})"
+
+# The desktop app bundles a Qwen Code runtime built from this repository's
+# `dist/`, so a change anywhere in the CLI can break desktop packaging. Until
+# this workflow existed, nothing exercised that path outside a manual release
+# dispatch: desktop release 0.2.3-preview.0 was the first run to see that a new
+# CLI dependency had shipped a native library the AppImage bundler chokes on,
+# two weeks after it landed. This runs the same jobs as a dry run so the
+# breakage surfaces on the day it lands instead of on release day.
+#
+# A dry run leaves the signing steps out (they are gated on `dry_run == false`),
+# so this does not cover macOS notarization or Windows Authenticode.
+on:
+  schedule:
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      qwen_code_ref:
+        description: 'Qwen Code branch, tag, or commit to bundle.'
+        required: true
+        default: 'main'
+        type: 'string'
+
+permissions:
+  contents: 'read'
+
+concurrency:
+  group: 'desktop-packaging-check'
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: 'Package'
+    if: "github.repository == 'QwenLM/qwen-code'"
+    # No `secrets: inherit`: every step that needs a signing secret is gated on
+    # `dry_run == false`, so this run never has to hold one.
+    uses: './.github/workflows/desktop-release.yml'
+    with:
+      version: '0.0.0-packaging-check'
+      qwen_code_ref: "${{ inputs.qwen_code_ref || 'main' }}"
+      electron_bridge: false
+      dry_run: true
+      draft: true
+      prerelease: true
+      clobber: false

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -39,6 +39,32 @@ on:
         required: true
         default: false
         type: 'boolean'
+  # Kept callable so a scheduled dry run can exercise the packaging path
+  # itself — building the runtime and the installers is the only thing that
+  # catches a bundled-runtime regression introduced outside this package.
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: 'string'
+      qwen_code_ref:
+        required: true
+        type: 'string'
+      electron_bridge:
+        required: true
+        type: 'boolean'
+      dry_run:
+        required: true
+        type: 'boolean'
+      draft:
+        required: true
+        type: 'boolean'
+      prerelease:
+        required: true
+        type: 'boolean'
+      clobber:
+        required: true
+        type: 'boolean'
 
 permissions:
   contents: 'read'


### PR DESCRIPTION
## What this PR does

Makes the desktop release workflow callable and adds a scheduled caller that runs it as a dry run once a day, so the desktop packaging path is exercised continuously instead of only when someone dispatches a release.

## Why it's needed

The desktop app bundles a Qwen Code runtime built from this repository's dist tree, so a change anywhere in the CLI can break desktop packaging. Nothing exercised that path outside a manual release dispatch: the only continuous integration job that touches the desktop package compiles the Tauri crate and runs its tests, and it runs solely when that package itself changes. A dependency added on the CLI side is invisible to it.

Desktop release 0.2.3-preview.0 is what that costs. A renderer dependency added two weeks earlier had put a native library into the bundled runtime that the AppImage bundler cannot process, and release day was the first time anyone found out — three of the four platform jobs failed at once, with the publish step queued behind them, and the failure had to be diagnosed under release pressure rather than next to the change that caused it.

A dry run builds the runtime, the installers and runs the packaged smoke tests on all four targets, which is exactly the coverage that was missing. It leaves the signing steps out, because those are gated on a real publish, so it does not cover macOS notarization or Windows Authenticode — the workflow comment says so rather than leaving the gap to be discovered.

## Reviewer Test Plan

### How to verify

Dispatch the new check manually and confirm it starts the release workflow's four build jobs against `main`, that each one reaches its packaged smoke test, and that the publish and mirror jobs are skipped. The release workflow itself should behave exactly as before when dispatched directly — the new trigger adds inputs, it does not change any existing one.

To confirm it catches the class of regression it exists for, dispatch it against a ref that carries a broken bundled runtime and check that the Linux job fails in the installer step rather than reporting success.

### Evidence (Before & After)

N/A — CI configuration, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ not tested  |

Both files were checked for YAML validity and formatting; the workflow itself can only be verified by running it, which needs a dispatch on this repository.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: a daily run of four platform jobs, roughly 25 minutes each, two of them on macOS runners. Reducing the schedule or the platform set is a reasonable call to make at review time; the value is highest on Linux and macOS, which is where the packaging path is most fragile.
- Not validated / out of scope: signed builds. A dry run cannot cover notarization or Authenticode, so a signing regression still surfaces only on release day. Covering that would mean either signing on a schedule or verifying signability separately, and neither belongs in this change.
- Breaking changes / migration notes: none. The scheduled caller never publishes — it passes a dry run, and both the publish and the mirror jobs are additionally gated on their own conditions.

## Linked Issues

Related to #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把桌面发布 workflow 改成可被调用的，并新增一个定时调用方，每天以 dry run 的方式跑一次，让桌面打包链路持续得到验证，而不是只有在有人手动触发发布时才跑一次。

## 为什么需要

桌面应用打包的运行时来自本仓库的 dist 产物，因此 CLI 侧任何一处改动都可能打断桌面打包。而在手动发布之外，没有任何流程覆盖这条链路：唯一涉及桌面包的持续集成 job 只编译 Tauri crate 并跑它自己的测试，而且仅在该包自身发生改动时才触发。CLI 侧新增的依赖对它是不可见的。

desktop 0.2.3-preview.0 就是代价。两周前引入的一个渲染器依赖，把一个 AppImage 打包器无法处理的原生库带进了自带运行时，而发布当天才第一次暴露出来——四个平台 job 中有三个同时失败，发布步骤还排在它们后面，问题只能在发布压力下排查，而不是在引入改动的当时。

一次 dry run 会在四个目标上构建运行时、构建安装包并跑打包后的冒烟测试，这正是此前缺失的覆盖。它不包含签名步骤（那些以真实发布为前提），所以不覆盖 macOS 公证和 Windows Authenticode——workflow 注释里写明了这一点，而不是留给后人踩。

## 评审验证计划

### 如何验证

手动触发新的检查 workflow，确认它针对 `main` 启动了发布 workflow 的四个构建 job，每个都跑到打包后的冒烟测试，并且 publish 与 OSS 镜像两个 job 被跳过。直接触发发布 workflow 时行为应与之前完全一致——新触发器只是增加了入口，不改变任何已有入口。

要确认它确实能拦住这类回归，可以针对一个自带运行时已损坏的 ref 触发它，检查 Linux job 是在安装包构建步骤失败，而不是报成功。

### 证据（Before & After）

N/A——CI 配置改动，无用户可见界面。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ 未测试  |

两个文件都做了 YAML 合法性与格式检查；workflow 本身只能通过实际运行验证，这需要在本仓库上触发一次。

### 环境（可选）

N/A

## 风险与范围

- 主要风险/取舍：每天四个平台 job，各约 25 分钟，其中两个跑在 macOS runner 上。是否收敛频率或平台范围，评审时可以决定；价值最高的是 Linux 和 macOS，这两个平台的打包链路最脆弱。
- 未验证 / 不在范围内：签名构建。dry run 无法覆盖公证与 Authenticode，因此签名类回归仍然只能在发布当天暴露。要覆盖这一点，要么定时做签名构建，要么单独验证可签名性，两者都不属于本次改动。
- 破坏性变更 / 迁移说明：无。定时调用方永远不会发布——它传入 dry run，而 publish 与镜像两个 job 本身还各有独立的条件门槛。

## 关联 Issue

关联 #8092。

</details>
