### PR TITLE
fix(desktop): realign the release test with the new signing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2276,7 +2276,7 @@ jobs:
             # `previous_filename` too: renaming a file out of the crate changes
             # it, and only the old path says so.
             if files="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[] | .filename, (.previous_filename // empty)')"; then
-              if grep -Eq '^(packages/desktop-shell/|\.github/scripts/create-desktop-update-manifest\.mjs|\.github/workflows/ci\.yml)' <<<"${files}"; then
+              if grep -Eq '^(packages/desktop-shell/|\.github/scripts/create-desktop-update-manifest\.mjs|\.github/workflows/ci\.yml|\.github/workflows/desktop-release\.yml)' <<<"${files}"; then
                 changed=true
               else
                 changed=false

--- a/packages/desktop-shell/scripts/test-release.js
+++ b/packages/desktop-shell/scripts/test-release.js
@@ -313,28 +313,44 @@ function testDesktopReleaseSigningWorkflow() {
     ),
     'Unsigned Windows installers are only allowed when no signing config exists',
   );
-  const ripgrepStart = workflow.indexOf('# ripgrep vendor binaries');
-  const ripgrepEnd = workflow.indexOf('# Node.js runtime binary');
-  assert.ok(
-    ripgrepStart !== -1 && ripgrepEnd > ripgrepStart,
-    'the vendor signing step must keep its ripgrep/Node section markers',
-  );
-  const ripgrepSigningBlock = workflow.slice(ripgrepStart, ripgrepEnd);
-  assert.doesNotMatch(
-    ripgrepSigningBlock,
-    /--entitlements/,
-    'ripgrep must not inherit the app entitlements',
+  // The step used to name the binaries it signed. It now discovers them,
+  // because the runtime is a copy of the CLI's dist tree and gains native
+  // payload without this package changing — an unsigned renderer library
+  // reached the notary service that way. These assertions pin the discovery
+  // and the properties the old list guaranteed by construction.
+  assert.match(
+    workflow,
+    /if \[ "\$\(file -b --mime-type "\$file"\)" = 'application\/x-mach-binary' \]; then/,
+    'the vendor signing step must discover Mach-O binaries rather than list them',
   );
   assert.match(
     workflow,
-    /--options runtime --timestamp \\\n\s+\{\} \+/,
-    'ripgrep codesign failures must fail the signing step',
+    /done < <\(find "\$runtime_dir" -type f -print0\)/,
+    'Mach-O discovery must cover the whole staged runtime',
   );
   assert.ok(
     workflow.includes(
-      '--entitlements src-tauri/NodeEntitlements.plist "$node_bin"',
+      '--entitlements src-tauri/NodeEntitlements.plist "$file"',
     ),
     'Node.js must use its minimal helper entitlements',
+  );
+  const entitlementFlags = workflow
+    .slice(
+      workflow.indexOf("name: 'Sign bundled vendor binaries (macOS)'"),
+      workflow.indexOf(
+        "name: 'Refresh bundled runtime checksums after signing",
+      ),
+    )
+    .match(/--entitlements/g);
+  assert.deepStrictEqual(
+    entitlementFlags,
+    ['--entitlements'],
+    'only the Node.js branch may pass entitlements; everything else signs without them',
+  );
+  assert.match(
+    workflow,
+    /codesign --verify --strict "\$file"/,
+    'the signing step must verify what it signed instead of leaving it to the notary service',
   );
   const nodeEntitlements = fs.readFileSync(
     path.join(packageDir, 'src-tauri', 'NodeEntitlements.plist'),
@@ -370,8 +386,8 @@ function testDesktopReleaseSigningWorkflow() {
   );
   assert.match(
     workflow,
-    /Ripgrep vendor directory not found at \$rg_dir/,
-    'missing ripgrep binaries must be visible in release logs',
+    /No Mach-O binary found under \$runtime_dir/,
+    'a runtime with no native binary must fail rather than silently sign nothing',
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## What this PR does

Realigns the desktop release test with the macOS signing step it guards, and closes the gap that let them drift apart.

The test pins the shape of that step, and it still described the allowlist the step used to be: the ripgrep and Node section markers, the `find -exec … {} +` form, and the Node binary as the signed path. Signing now discovers the Mach-O files under the staged runtime rather than naming them, so those assertions describe code that no longer exists. The new ones assert what the step does now while keeping every property the old list guaranteed by construction — discovery spans the whole runtime, only the Node.js branch passes entitlements, and the step verifies what it signed. A guard against an empty runtime replaces the ripgrep warning that was retired.

The second change is why this reached a release at all. The job that runs this test fires only when the desktop package, the update-manifest script, or the main CI workflow change — but the file the test reads is the desktop release workflow, which is not in that list. A workflow-only edit therefore gets a green desktop job in seconds without running the test that guards it. The release workflow is now in the filter.

## Why it's needed

Release 0.3.0-preview.0 failed on all four platforms in this test, after each runner had already built the CLI bundle and staged the runtime — roughly six minutes per platform spent to discover a stale string comparison. The release that preceded it merged with this job green, because the job never looked.

The pairing is the point: a test that reads a file outside its own package needs that file inside its trigger, or it becomes a test that only runs when it cannot fail.

## Reviewer Test Plan

### How to verify

Run the desktop release tests against the current workflow and confirm they pass, then confirm they still bite: change the signed path in the signing step, or drop the verification loop, and the corresponding assertion should fail. The entitlements assertion is the one worth poking hardest — it counts the flag across the whole step, so adding `--entitlements` to the non-Node branch must fail even though the Node branch is untouched.

For the filter, open a PR that touches only the desktop release workflow and confirm the desktop job now runs the release tests instead of reporting done in under twenty seconds.

### Evidence (Before & After)

N/A — CI and test-only change, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ✅ release tests run against the current workflow  |

The rewritten assertions were run against the workflow as it stands on main and all pass; the surrounding suite needs an installed package to run in full.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: these assertions pin shell text, so ordinary edits to the signing step will keep breaking them — that is the intended cost of pinning a step no unit test can execute, but it means the step is now slightly harder to refactor. The filter change also means every workflow-only edit to the release pipeline pays for a Rust compile.
- Not validated / out of scope: whether the signing step itself works. That still needs a publishing release run, which is what turned this failure up.
- Breaking changes / migration notes: none.

## Linked Issues

Follows #11518.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让桌面发布测试与它所守护的 macOS 签名步骤重新对齐，并堵上导致两者脱节的缺口。

该测试固定了签名步骤的形态，而它描述的仍是那个步骤过去的白名单形式：ripgrep 与 Node 的分节标记、`find -exec … {} +` 的写法，以及把 Node 二进制作为被签名路径。现在签名改为枚举暂存运行时下的 Mach-O 文件而不是逐个点名，因此这些断言描述的是已经不存在的代码。新的断言针对该步骤当前的行为，同时保留旧清单原本靠结构保证的全部性质——枚举覆盖整个运行时、只有 Node.js 分支传入 entitlements、步骤会验证自己签过的东西。此外用"运行时中没有任何原生二进制"的硬失败，替代了已被移除的 ripgrep 警告。

第二处改动才是它为什么会一路走到发布的原因。运行该测试的 job 只在桌面包、更新清单脚本或主 CI workflow 变更时触发——但测试读取的文件是桌面发布 workflow，而它不在这个列表里。因此一次只改 workflow 的提交会在几秒内拿到绿色的桌面 job，却根本没跑守护它的测试。现在发布 workflow 已加入过滤条件。

## 为什么需要

0.3.0-preview.0 发布在四个平台上全部失败于这个测试，而此时每个 runner 都已经构建完 CLI bundle 并暂存好运行时——每个平台约六分钟，只为发现一处过时的字符串比较。而它前一个 PR 是带着这个 job 的绿色合入的，因为这个 job 压根没看。

这两处改动是配套的：一个读取自身包之外文件的测试，必须把那个文件纳入自己的触发条件，否则它就变成一个"只在不可能失败时才运行"的测试。

## 评审验证计划

### 如何验证

针对当前 workflow 运行桌面发布测试，确认通过；然后确认它仍然有咬合力：修改签名步骤中被签名的路径，或删掉验证循环，对应断言应当失败。最值得多试的是 entitlements 那条——它统计整个步骤中该 flag 的出现次数，因此即使 Node 分支原封不动，只要给非 Node 分支加上 `--entitlements` 也必须失败。

过滤条件方面，提一个只改动桌面发布 workflow 的 PR，确认桌面 job 现在会真正运行发布测试，而不是二十秒内就报完成。

### 证据（Before & After）

N/A——仅 CI 与测试改动，无用户可见界面。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ✅ 已针对当前 workflow 运行发布测试  |

重写后的断言已针对 main 上现有的 workflow 全部跑通；整套测试的其余部分需要已安装的依赖才能完整运行。

### 环境（可选）

N/A

## 风险与范围

- 主要风险/取舍：这些断言固定的是 shell 文本，因此对签名步骤的常规改动仍会打断它们——这是固定一个无法被单测执行的步骤所必须付出的代价，但也意味着该步骤重构起来会稍微更麻烦。过滤条件的改动也意味着此后每次只改发布 workflow 的提交都要付一次 Rust 编译的成本。
- 未验证 / 不在范围内：签名步骤本身是否有效。那仍需要一次真实发布运行才能确认，而正是那次运行暴露了本次失败。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

承接 #11518。

</details>
