### PR TITLE
fix(core): preserve Responses stream error details

### DIFF
--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -18,6 +18,10 @@ import { LoggingContentGenerator } from './index.js';
 import { OpenAIContentConverter } from '../openaiContentGenerator/converter.js';
 import { openaiRequestCaptureContext } from '../openaiContentGenerator/requestCaptureContext.js';
 import {
+  convertResponsesEventToGemini,
+  ResponsesStreamState,
+} from '../openaiResponsesContentGenerator/responses-converter.js';
+import {
   logApiRequest,
   logApiResponse,
   logApiError,
@@ -2343,6 +2347,73 @@ describe('LoggingContentGenerator', () => {
       outputTokens: 3,
     });
     expect(spanRecord.ended).toBe(true);
+  });
+
+  it('reports nested Responses stream errors with provider details', async () => {
+    const message =
+      'Your requests to gpt-6-astra in eastus have exceeded rate limit.';
+    const expectedMessage = `Responses API error: rate_limit_exceeded: ${message}`;
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockResolvedValue(
+        (async function* () {
+          const chunk = convertResponsesEventToGemini(
+            {
+              event: 'error',
+              data: {
+                type: 'error',
+                error: {
+                  message,
+                  type: 'too_many_requests',
+                  code: 'rate_limit_exceeded',
+                },
+              },
+            },
+            'gpt-6-astra',
+            new ResponsesStreamState(),
+          );
+          if (chunk) yield chunk;
+        })(),
+      ),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'gpt-6-astra',
+      authType: AuthType.USE_OPENAI_RESPONSES,
+      enableOpenAILogging: true,
+    });
+    const stream = await generator.generateContentStream(
+      { model: 'gpt-6-astra', contents: 'Hello' },
+      'prompt-responses-error',
+    );
+    await expect(async () => {
+      for await (const _item of stream) {
+        // Consume the stream to reach the provider error.
+      }
+    }).rejects.toThrow(expectedMessage);
+
+    expect(logApiResponse).not.toHaveBeenCalled();
+    expect(logApiError).toHaveBeenCalledTimes(1);
+    const [, errorEvent] = vi.mocked(logApiError).mock.calls[0];
+    expect(errorEvent).toMatchObject({
+      error_message: expectedMessage,
+      error_type: 'too_many_requests',
+      status_code: 429,
+      auth_type: AuthType.USE_OPENAI_RESPONSES,
+    });
+    const openaiLoggerInstance = vi.mocked(OpenAILogger).mock.results[0]
+      ?.value as { logInteraction: ReturnType<typeof vi.fn> };
+    const [, , loggedError] = openaiLoggerInstance.logInteraction.mock.calls[0];
+    expect(loggedError).toMatchObject({
+      message: expectedMessage,
+      code: 'rate_limit_exceeded',
+      type: 'too_many_requests',
+      status: 429,
+    });
+    expect(getStreamSpanRecord().endMetadata).toMatchObject({
+      success: false,
+      errorType: 'too_many_requests',
+      errorStatusCode: 429,
+    });
   });
 
   it('keeps a real partial-stream failure as an error when it races an abort', async () => {

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-converter.test.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-converter.test.ts
@@ -919,6 +919,60 @@ describe('convertResponsesEventToGemini', () => {
     expect((thrown as { code?: string }).code).toBe('server_error');
   });
 
+  it.each([
+    {
+      data: {
+        type: 'error',
+        error: {
+          message: 'Requests in eastus have exceeded rate limit.',
+          code: 'rate_limit_exceeded',
+          type: 'too_many_requests',
+        },
+      },
+      message:
+        'rate_limit_exceeded: Requests in eastus have exceeded rate limit.',
+      code: 'rate_limit_exceeded',
+      type: 'too_many_requests',
+      status: 429,
+    },
+    {
+      data: {
+        type: 'error',
+        message: 'Server unavailable',
+        code: 'server_error',
+      },
+      message: 'server_error: Server unavailable',
+      code: 'server_error',
+      type: 'server_error',
+      status: 500,
+    },
+    {
+      data: { type: 'error', error: { code: 'invalid_request' } },
+      message: 'invalid_request',
+      code: 'invalid_request',
+      type: 'invalid_request',
+      status: undefined,
+    },
+  ])('preserves $code details for display and telemetry', (testCase) => {
+    let thrown: unknown;
+    try {
+      convertResponsesEventToGemini(
+        { event: 'error', data: testCase.data },
+        'gpt-6-astra',
+        new ResponsesStreamState(),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toMatchObject({
+      message: `Responses API error: ${testCase.message}`,
+      code: testCase.code,
+      type: testCase.type,
+    });
+    expect((thrown as { status?: number }).status).toBe(testCase.status);
+  });
+
   describe('response.incomplete', () => {
     it('extracts usage and maps incomplete_details.reason to MAX_TOKENS', () => {
       const state = new ResponsesStreamState();

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-converter.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-converter.ts
@@ -69,13 +69,16 @@ const RESPONSES_ERROR_CODE_TO_STATUS: Record<string, number> = {
 interface ResponsesStreamError extends Error {
   status?: number;
   code?: string;
+  type?: string;
 }
 
 function makeResponsesStreamError(
   message: string,
   code?: string,
+  type?: string,
 ): ResponsesStreamError {
   const err: ResponsesStreamError = new Error(message);
+  err.type = type ?? code;
   if (code) {
     err.code = code;
     const status = RESPONSES_ERROR_CODE_TO_STATUS[code];
@@ -335,7 +338,7 @@ export function convertResponsesEventToGemini(
     case 'response.failed': {
       const raw = event.data as Record<string, unknown>;
       const envelope = (raw['response'] ?? raw) as {
-        error?: { code?: string; message?: string };
+        error?: { code?: string; message?: string; type?: string };
       };
       const errMsg = envelope.error
         ? `${envelope.error.code}: ${envelope.error.message}`
@@ -343,6 +346,7 @@ export function convertResponsesEventToGemini(
       throw makeResponsesStreamError(
         `Responses API failed: ${errMsg}`,
         envelope.error?.code,
+        envelope.error?.type,
       );
     }
 
@@ -366,10 +370,21 @@ export function convertResponsesEventToGemini(
     }
 
     case 'error': {
-      const data = event.data as { message?: string; code?: string };
+      const data = event.data as {
+        message?: string;
+        code?: string;
+        error?: { message?: string; code?: string; type?: string };
+      };
+      const code = data.error?.code ?? data.code;
+      const message = data.error?.message ?? data.message;
+      const detail =
+        [code, message].filter(Boolean).join(': ') ||
+        data.error?.type ||
+        'Unknown error';
       throw makeResponsesStreamError(
-        `Responses API error: ${data.message ?? 'Unknown error'}`,
-        data.code,
+        `Responses API error: ${detail}`,
+        code,
+        data.error?.type,
       );
     }
 


### PR DESCRIPTION
## What this PR does

Preserves upstream error details from Responses streams so users see the provider's error code and message, and API error telemetry receives the error type and mapped status. Supports both nested and top-level error payloads, and preserves the provider error type in `response.failed` events.

## Why it's needed

A provider can return HTTP 200 and then report a failure inside the SSE stream. When an `error` event contains a nested `error` object, Qwen Code currently reads only the top-level fields and displays `Responses API error: Unknown error`. The original message and code are lost, and telemetry reports a generic error without the mapped status.

This was reproduced with an upstream rate-limit error containing `code: rate_limit_exceeded` and `type: too_many_requests`. Preserving those details makes the failure actionable and lets the existing error classification recognize it as status 429.

## Reviewer Test Plan

### How to verify

1. Use a local Responses endpoint that returns HTTP 200 followed by an SSE `error` event containing nested `error.message`, `error.code: rate_limit_exceeded`, and `error.type: too_many_requests`. Disable retries to inspect the final error directly.
2. Confirm the CLI displays the upstream code and message. Inspect the recorded API error event for `error_type: too_many_requests` and `status_code: 429`, and confirm the OpenAI log retains the detailed error message.
3. Check that top-level error payloads still retain their code and message, nested code-only errors display the available code, and `response.failed` preserves its provider error type when supplied.

### Evidence (Before & After)

The same captured SSE response was replayed through a localhost mock against the CLI bundles before and after the fix, using isolated settings and sessions. Each run made one request with retries disabled.

Before — final CLI error:

```text
[API Error: Responses API error: Unknown error]
```

After — final CLI error:

```text
[API Error: Responses API error: rate_limit_exceeded: Your requests to gpt-6-astra for gpt-6-astra in eastus have exceeded rate limit.]
```

| Observation | Before | After |
| --- | --- | --- |
| API error type | `Error` | `too_many_requests` |
| API error status | Missing | `429` |
| OpenAI log error message | `Responses API error: Unknown error` | Full error code and provider message shown above |

All four new regression cases failed before the fix. After the fix, all 298 tests across the three relevant suites passed, including assertions for API error telemetry and request span metadata. Full build, bundle, typecheck, targeted lint and formatting checks, and the whitespace check passed.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | ✅ Tested |
| 🪟 Windows | ⚠️ Not tested |
| 🐧 Linux | ⚠️ Not tested |

### Environment (optional)

Local bundled CLI in headless mode, with an isolated Qwen home and a localhost mock replaying captured SSE events. The before/after verification did not call a live model or upload remote telemetry.

## Risk & Scope

- Main risk or tradeoff: Recognizing nested error codes allows existing status-based handling, including rate-limit retries, to apply. Top-level error messages now also include the provider code when present.
- Not validated / out of scope: Retry timing, remote telemetry delivery, and interactive TUI rendering were not exercised. The provider's rate limit is unchanged. OpenAI logs retain their existing schema; the code is preserved in the message rather than added as a separate field.
- Breaking changes / migration notes: No settings or telemetry schema changes; no migration required.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

保留 Responses 流中的上游错误详情，让用户看到服务提供方的错误码和消息，并让 API 错误遥测获得错误类型及映射后的状态码。兼容嵌套和顶层错误结构，同时保留 `response.failed` 事件中的上游错误类型。

## 为什么需要

服务提供方可能先返回 HTTP 200，再在 SSE 流中报告失败。当 `error` 事件包含嵌套的 `error` 对象时，Qwen Code 当前只读取顶层字段，因此显示 `Responses API error: Unknown error`。原始消息和错误码丢失，遥测也只记录没有映射状态码的通用错误。

已通过包含 `code: rate_limit_exceeded` 和 `type: too_many_requests` 的上游限流错误复现。保留这些详情后，用户可以据此处理问题，现有错误分类也能将其识别为状态码 429。

## Reviewer 测试计划

### 如何验证

1. 使用本地 Responses 端点，先返回 HTTP 200，再发送 SSE `error` 事件，其中包含嵌套的 `error.message`、`error.code: rate_limit_exceeded` 和 `error.type: too_many_requests`。禁用重试，直接检查最终错误。
2. 确认 CLI 显示上游错误码和消息。检查记录的 API 错误事件包含 `error_type: too_many_requests` 和 `status_code: 429`，并确认 OpenAI 日志保留详细错误消息。
3. 检查顶层错误结构仍保留错误码和消息、只有错误码的嵌套错误会显示该错误码，以及 `response.failed` 在提供上游错误类型时能保留该类型。

### 证据（修改前后）

通过 localhost mock，将同一份捕获的 SSE 响应分别重放给修复前后的 CLI bundle，使用隔离的配置和会话。每次运行均禁用重试，只发送一个请求。

修改前——CLI 最终错误：

```text
[API Error: Responses API error: Unknown error]
```

修改后——CLI 最终错误：

```text
[API Error: Responses API error: rate_limit_exceeded: Your requests to gpt-6-astra for gpt-6-astra in eastus have exceeded rate limit.]
```

| 观察项 | 修改前 | 修改后 |
| --- | --- | --- |
| API 错误类型 | `Error` | `too_many_requests` |
| API 错误状态码 | 缺失 | `429` |
| OpenAI 日志错误消息 | `Responses API error: Unknown error` | 上述完整错误码及上游消息 |

新增的四个回归用例在修复前均失败。修复后，三个相关测试套件的 298 项测试全部通过，其中包含 API 错误遥测和请求 span 元数据的断言。全量构建、bundle、类型检查、相关文件的 lint 和格式检查，以及空白字符检查均通过。

### 已测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境（可选）

本地 CLI bundle，以 headless 模式运行，使用隔离的 Qwen home 和重放已捕获 SSE 事件的 localhost mock。前后对照验证未调用真实模型，也未向远端上传遥测。

## 风险与范围

- 主要风险或权衡：识别嵌套错误码后，现有依赖状态码的处理逻辑（包括限流重试）可以生效。顶层错误消息在包含上游错误码时，也会显示该错误码。
- 未验证或范围之外：未验证重试时序、远端遥测送达及交互式 TUI 渲染。上游限流本身没有变化。OpenAI 日志保持原有格式；错误码保存在消息中，没有新增独立字段。
- 破坏性变更或迁移说明：配置和遥测 schema 均无变化，无需迁移。

## 关联 Issue

无。

</details>
