### PR TITLE
feat(core): opt-in SQLite sidecar index for session listing and transcript navigation

### DIFF
--- a/docs/design/session-sqlite-sidecar.md
+++ b/docs/design/session-sqlite-sidecar.md
@@ -1,0 +1,258 @@
+# SQLite Sidecar Index for Session Listing & Transcript Navigation
+
+- Status: Draft (feature-flagged, default off)
+- Issues: #11433 (design discussion), #11493 (cache-admission cliff found during the evaluation)
+- Date: 2026-09-10
+- 中文版:[session-sqlite-sidecar.zh-CN.md](./session-sqlite-sidecar.zh-CN.md)
+
+## 1. Problem statement
+
+Session reads are served by two in-memory/file mechanisms that re-derive index
+data on every process start:
+
+1. **Session listing** (`SessionService.listSessions`,
+   `packages/core/src/services/sessionService.ts:2520`): `readdirSync` +
+   per-file `statSync` + full mtime sort per call; filling a page additionally
+   opens each candidate file to read its first lines. `MAX_FILES_TO_PROCESS =
+10000` truncates enumeration beyond that.
+2. **Transcript indexing** (`SessionTranscriptReader.buildIndex`,
+   `packages/core/src/services/session-transcript-reader.ts:1939`): on an
+   index-cache miss the reader scans the whole snapshot and parses every line
+   before any paging operation can be served. The cache is process-local
+   (32 entries / 64 MiB / 5 min TTL, `:397`) and enforces its byte budget on
+   the admission path without evicting LRU entries (`:2278`), so working sets
+   whose combined index estimate exceeds ~64 MiB degrade to _every read = full
+   rescan_ (#11493). Snapshots beyond 256 MiB are refused outright (`:89`).
+
+Measured on main @ `19ba03fb70` (Node 22, realistic synthetic corpora; harness
+in `.qwen/bench-sqlite/`, methodology posted on #11433):
+
+| Workload                                        | Current                   | Cost driver                        |
+| ----------------------------------------------- | ------------------------- | ---------------------------------- |
+| First listing page, 1k / 5k / 10k sessions      | 14.9 / 28.9 / 50.7 ms     | O(N) stat + sort                   |
+| Full listing paginate, 1k / 5k / 10k (size=100) | 0.42 / 3.0 / 8.3 s        | O(N) file opens + first-line reads |
+| Turn page, 11–202 MB session, cold              | 29–365 ms (~1.8 ms/MB)    | full-file scan + parse             |
+| Turn page, warm but index cache over budget     | 350–450 ms **every read** | admission-skip, no LRU eviction    |
+| Daemon restart + resume/attach                  | full rescan per session   | process-local cache lost           |
+
+Workloads confirmed to exist in production deployments: multi-day sessions
+(hundreds of MB), one channel pinned to a single ever-growing session, frequent
+daemon restarts with resume/attach, on small 2–4 vCPU hosts where the
+in-memory index residency is doubly expensive.
+
+## 2. Proposed design
+
+JSONL transcripts remain the **sole authoritative store**. A per-project
+SQLite database is kept as a **rebuildable catalog/index sidecar** alongside
+`chats/`. It can be deleted at any time: every read path falls back to today's
+behavior, and the index is rebuilt lazily (incrementally from the JSONL tail).
+
+### 2.1 Provider abstraction
+
+```
+packages/core/src/services/session-index/
+├── types.ts            # SessionIndexProvider interface + option/result types
+├── config.ts           # module-level configuration + driver probe + provider cache
+├── sqlite/             # node:sqlite driver implementation
+```
+
+- `SessionIndexProvider` exposes two capabilities:
+  - `listSessionsPage(...)` — catalog paging (replaces the scan-based fill);
+  - `sessionTurnIndex(...)` — turn-start rows with byte offsets for one session
+    (replaces `buildIndex` for the turn-navigation path).
+- A **file-scan provider** is implicit: when no SQLite provider is available
+  the existing code paths execute unchanged. There is no separate class;
+  "provider returns null" _is_ the fallback, mirroring the `getPty.ts`
+  optional-dependency precedent (dynamic import → `null` on failure).
+- **Module-level configuration** (`configureSessionIndexing({ mode })`) called
+  once from process bootstrap where settings live (CLI config load, daemon
+  serve startup), following the `Storage.setRuntimeBaseDir()` static pattern.
+  This covers the ~40 `new SessionService(cwd)` call sites that bypass `Config`
+  without touching each one, and also covers the 5 other
+  `SessionTranscriptReader` instantiation sites via `SessionService`'s internal
+  reader (`sessionService.ts:833`) and direct reader construction.
+
+### 2.2 Settings flag
+
+```jsonc
+// settings.json
+{ "experimental": { "sessionIndex": "file" } } // "file" (default) | "sqlite"
+```
+
+- Declared in `packages/cli/src/config/settingsSchema.ts` (source of truth;
+  `experimental.agentTeam` is the pattern), schema JSON regenerated via
+  `scripts/generate-settings-schema.ts`.
+- CLI (`loadCliConfig` in `packages/cli/src/config/config.ts`) and the daemon
+  serve bootstrap (`packages/cli/src/commands/serve.ts`, which loads settings
+  directly and never goes through loadCliConfig) both translate the setting
+  into `configureSessionIndexing()`.
+- Off by default upstream. The flag selects a _provider_, not a storage
+  format: switching it either way migrates nothing.
+
+### 2.3 Driver selection
+
+`node:sqlite`, dynamically imported once per process:
+
+- Zero dependency / zero bytes / zero supply-chain diff; works unflagged on
+  Node ≥22.13 (verified 22.23) and on Bun ≥1.4 (verified 1.4.0), i.e. all
+  current runtime flavors (npm, standalone-node, standalone-bun preview).
+- Import failure (Node 22.0–22.12, an experimental-API break) → provider
+  `null` → file-scan fallback. The feature's default-off + fallback semantics
+  make the driver risk invisible to users who didn't opt in.
+- `better-sqlite3` is the documented Plan B (both distribution forms already
+  ship native addons via esbuild externals and per-arch prebuild copying in
+  `scripts/create-standalone-package.js`), deliberately not used to avoid a
+  new supply-chain surface for an optional feature.
+- wasm SQLite is rejected: Node-side persistence VFS is immature and
+  "in-memory DB + whole-file dump" negates incremental-sync write costs.
+
+### 2.4 Schema
+
+`projects/<projectDir>/sessions.index.sqlite` (WAL, `synchronous=NORMAL`):
+
+```sql
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);
+-- schema_version; mismatch => delete file and rebuild from zero.
+
+CREATE TABLE sessions(           -- session catalog, powers listSessionsPage
+  sessionId     TEXT PRIMARY KEY,
+  fileName      TEXT NOT NULL,
+  mtimeMs       INTEGER NOT NULL,
+  sizeBytes     INTEGER NOT NULL,
+  startTime     TEXT,
+  firstPrompt   TEXT,
+  customTitle   TEXT,
+  gitBranch     TEXT,
+  cwd           TEXT,            -- project-membership filtering, as today
+  recordCount   INTEGER NOT NULL,
+  indexedBytes  INTEGER NOT NULL -- byte checkpoint: index covers [0, indexedBytes)
+);
+CREATE INDEX sessions_mtime ON sessions(mtimeMs DESC);
+
+CREATE TABLE records(            -- per-session record offsets, powers turn nav
+  sessionId  TEXT NOT NULL,
+  seq        INTEGER NOT NULL,   -- line order within the file
+  uuid       TEXT NOT NULL,
+  parentUuid TEXT,
+  type       TEXT NOT NULL,
+  subtype    TEXT,
+  turnStart  INTEGER NOT NULL DEFAULT 0, -- same hint getSessionTurnRecordHint uses
+  offset     INTEGER NOT NULL,
+  length     INTEGER NOT NULL,
+  PRIMARY KEY(sessionId, seq)
+) WITHOUT ROWID;
+CREATE INDEX records_uuid ON records(sessionId, uuid);
+```
+
+Measured footprint: DB ≈ 6–24 % of the JSONL it indexes (6.4 % for
+multi-hundred-MB sessions; 24 % for a 10k-small-session corpus). Full build of
+10k sessions / 420k records = 3.9 s once; incremental re-sync of ~60 appended
+records = 2.3 ms.
+
+### 2.5 Consistency protocol
+
+The sidecar knows exactly which durable bytes it covers:
+
+1. **Append**: `indexedBytes <= size` → scan only `[indexedBytes, size)` up to
+   the last complete line; insert rows in one transaction; update checkpoint.
+   (JSONL-appended records are never rewritten in place; a partial final line
+   is excluded until completed by the next flush.)
+2. **Shrink / replace**: `indexedBytes > size` → rewind: delete the session's
+   rows and rebuild from 0. Never "repair" the sidecar against the file.
+3. **Validation before serving**: one `stat` per session file on the read
+   path (same syscall the current code already issues) compares
+   `mtimeMs/sizeBytes` with the catalog row; mismatch ⇒ incremental sync first.
+4. **Crash window**: process dies between JSONL append and index update ⇒
+   next sync sees `indexedBytes < size` and catches up. A crash mid-transaction
+   rolls back atomically; the checkpoint never claims unindexed bytes.
+5. **Derived-turn cache**: `readTurnIndexPage` also persists each session's
+   derived navigation turns (`turns_cache`), keyed by the `indexedBytes`
+   checkpoint they were computed from — later pages cost one row fetch plus
+   a handful of `pread`s. Appends past the checkpoint invalidate the cache
+   wholesale; its rows are deleted whenever the session row is (GC,
+   rewind-rebuild).
+6. **Catalog sweep** (listing only): listings reconcile file names on every
+   call (`readdir` names only, plus GC of removed files), while the per-file
+   stat sweep is gated by a TTL (default 30 s) to bound cost; brand-new
+   files are indexed immediately even inside the TTL window, and turn-read
+   paths always stat-validate their own file, so staleness is bounded and
+   never structural.
+7. **Corruption / open failure / schema mismatch**: delete the DB file, fall
+   back to file-scan for the current request, rebuild lazily. Log at debug;
+   never surface an error to the user over an index problem.
+
+Concurrency: WAL readers don't block the writer; a single writer is enforced
+per process via one shared connection with `busy_timeout`, with the daemon
+owning long-lived writes. CLI short-lived processes open their own connection;
+worst case is a brief busy retry, then fallback.
+
+### 2.6 Read-path integration
+
+| Path                                        | With provider                                                                                                                                                                                                                                                                                      | On any provider failure       |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `SessionService.listSessions`               | names-pass + windowed keyset paging over `sessions` (SQL `LIMIT` per window, mtime-desc; equal-mtime ties skipped exactly like the legacy strict-`<` convention)                                                                                                                                   | current scan exactly as today |
+| `SessionTranscriptReader.readTurnIndexPage` | `turns_cache` hit → window slice + `pread` of the selected JSONL segments (uuid/sessionId verified; `SessionTranscriptSnapshotUnavailableError` on mismatch). Miss → derive turns from `records` rows with the same rules as `buildIndex`, persist, serve. The 256 MiB cap is enforced identically | current `buildIndex` path     |
+| `SessionTranscriptReader.readPage`          | **unchanged this PR** (still in-memory index)                                                                                                                                                                                                                                                      | —                             |
+
+`readTurnIndexPage` output parity is validated record-for-record against the
+file-scan path in the parity suite (`session-index/parity.test.ts`), including
+snapshot continuation in both directions, glued-line fragments, and
+append-after-cache invalidation. Serial-sync queuing (one shared connection)
+and in-flight store memoization keep concurrent daemon routes on a single
+safe write timeline.
+
+### 2.7 Relation to daemon catalog cache & #11493
+
+- The daemon's durable JSONL catalog cache (`packages/cli/src/serve/server/
+session-list.ts`, "cache is not a filesystem transaction") is philosophically
+  the same object as the `sessions` table; when the flag is on, daemon listing
+  reads through the provider instead. The JSON cache remains the non-flag
+  default. No migration: both are rebuildable sidecars.
+- #11493 (byte-budget admission never evicts) is orthogonal and worth fixing
+  regardless; with the sidecar enabled it stops being load-bearing because the
+  hot path no longer depends on the in-memory cache (which becomes an L1 over
+  an L2 durable index).
+
+## 3. Files affected
+
+- **new**: `packages/core/src/services/session-index/{types,config}.ts`,
+  `packages/core/src/services/session-index/sqlite/*.ts` (+ collocated tests)
+- `packages/core/src/services/sessionService.ts` — provider lookup in
+  `listSessions`
+- `packages/core/src/services/session-transcript-reader.ts` — provider lookup
+  in `readTurnIndexPage` (a write-path inline sync hook was evaluated and
+  deferred: read-path stat validation already bounds staleness correctly)
+- `packages/cli/src/config/settingsSchema.ts` — `experimental.sessionIndex`
+  (+ regenerated `packages/vscode-ide-companion/schemas/settings.schema.json`)
+- `packages/cli/src/config/config.ts` (`loadCliConfig`),
+  `packages/cli/src/commands/serve.ts` (daemon bootstrap) —
+  `configureSessionIndexing()` from settings
+- `packages/core/src/config/config.ts` — pass-through where
+  `getSessionService()` is lazily constructed (parity with `runtimeBaseDir`)
+- tests: provider parity suites, fault-injection tests (corrupt DB, truncated
+  JSONL, partial line, schema mismatch), budget-cap navigation test
+
+## 4. Scope boundaries
+
+- **No** authoritative SQLite lifecycle storage (issue model 3): prompt
+  journal, state versions, undo events stay append-only JSONL.
+- **No** `readPage` / full `SessionIndex` materialization from SQL (follow-up;
+  the in-memory index cache remains for record-level paging).
+- **No** full-text search / FTS5 in this PR.
+- **No** per-workspace daemon catalog semantics changes; ACP / vscode flows
+  inherit the behavior transparently through their existing daemon routes.
+- **No** migration or backfill command — first use builds indexes lazily and
+  incrementally.
+
+## 5. Open questions
+
+1. Sweep TTL default (30 s) — tune from daemon telemetry after rollout.
+2. Whether write-path inline sync should also cover out-of-band edits by
+   _another_ CLI process in the same project (today covered by the TTL sweep;
+   a file watcher was considered and rejected as anti-KISS).
+3. Node 24 line: `node:sqlite` stability status should be re-checked before
+   flipping the default; Bun CI lane needs a sidecar smoke test if the
+   OpenTUI bun flavor graduates from preview.
+4. Telemetry: add `session_index.sync_duration_ms` /
+   `session_index.fallback_total` as a fast follow-up once the flag sees real
+   usage (answering the issue's "measure before defaults" requirement).

--- a/docs/design/session-sqlite-sidecar.zh-CN.md
+++ b/docs/design/session-sqlite-sidecar.zh-CN.md
@@ -1,0 +1,227 @@
+# 会话列表与 transcript 导航的 SQLite sidecar 索引
+
+- 状态:草案(feature flag 控制,默认关闭)
+- 关联 issue:#11433(设计讨论)、#11493(评估中发现的缓存准入悬崖)
+- 日期:2026-09-10
+- 英文版:[session-sqlite-sidecar.md](./session-sqlite-sidecar.md)
+
+## 1. 问题陈述
+
+会话读取目前由两套发生在每次进程启动时的"内存 + 文件"机制提供,索引数据每次都要重新推导:
+
+1. **会话列表**(`SessionService.listSessions`,
+   `packages/core/src/services/sessionService.ts:2520`):每次调用做
+   `readdirSync` + 逐文件 `statSync` + 全量 mtime 排序;填充一页还要逐个
+   打开候选文件读首行。`MAX_FILES_TO_PROCESS = 10000` 会在超过一万个文件
+   后直接截断枚举。
+2. **transcript 索引**(`SessionTranscriptReader.buildIndex`,
+   `packages/core/src/services/session-transcript-reader.ts:1939`):索引缓存
+   未命中时,要先把整个快照扫描并逐行解析,才能服务任何分页操作。缓存是
+   进程内的(32 条 / 64MiB / 5 分钟 TTL,`:397`),而且它的字节预算是在
+   **准入**路径上执行的、不做 LRU 淘汰(`:2278`)——一旦工作集的索引估算
+   合计超过 ~64MiB,就退化为"每次读取 = 全量重扫"(#11493)。超过 256MiB
+   的快照被直接拒绝(`:89`)。
+
+在 main @ `19ba03fb70` 实测(Node 22,形状真实的合成语料;harness 在
+`.qwen/bench-sqlite/`,方法已发到 #11433):
+
+| 负载                                 | 当前实现              | 成本根源               |
+| ------------------------------------ | --------------------- | ---------------------- |
+| 列表首页,1k / 5k / 10k 会话          | 14.9 / 28.9 / 50.7 ms | O(N) stat + 排序       |
+| 列表翻完全部,1k / 5k / 10k(size=100) | 0.42 / 3.0 / 8.3 s    | O(N) 打开文件 + 读首行 |
+| turn 页,11–202MB 会话,冷             | 29–365 ms(~1.8ms/MB)  | 全文件扫描 + 解析      |
+| turn 页,热但索引缓存超预算           | **每次** 350–450ms    | 准入拒绝,无 LRU 淘汰   |
+| daemon 重启 + resume/attach          | 每个会话全量重扫      | 进程内缓存丢失         |
+
+已被生产部署确认的负载:多天级长会话(数百 MB)、channel 单会话持续
+增长、daemon 频繁重启伴随 resume/attach、2–4 vCPU 小规格主机(内存里的
+索引驻留更加昂贵)。
+
+## 2. 方案设计
+
+JSONL transcript 保持为**唯一权威存储**。每个项目目录下放一个 SQLite
+数据库作为**可重建的 catalog/索引 sidecar**。它随时可以被删除:所有读
+路径自动回退到今天的行为,索引从 JSONL 尾部惰性增量重建。
+
+### 2.1 Provider 抽象
+
+```
+packages/core/src/services/session-index/
+├── types.ts            # SessionIndexProvider 接口 + 选项/结果类型
+├── config.ts           # 进程级配置 + 驱动探测 + store 单例
+├── sqlite.ts           # node:sqlite 驱动实现
+```
+
+- provider 提供两个能力:`listSessionsPage`(catalog 分页,替代扫描式
+  填充)与 `sessionTurnIndex`(单会话 turn 起点 + 字节偏移,替代
+  `buildIndex` 的 turn 导航路径)。
+- "文件扫描 provider"是隐式的:SQLite provider 不可用时走的就是今天的
+  代码路径——"provider 返回 null"**就是**回退,模式同
+  `getPty.ts` 可选依赖先例(动态 import,失败返回 null)。
+- **进程级配置**(`configureSessionIndexing({ mode })`)在有 settings 的
+  进程入口调用一次,模式同 `Storage.setRuntimeBaseDir()` 静态模式——覆盖
+  全部 ~40 个绕过 `Config` 的 `new SessionService(cwd)` 调用点,以及
+  `SessionService` 内自持 reader(`sessionService.ts:833`)与直接构造
+  reader 的位置。
+
+### 2.2 设置开关
+
+```jsonc
+// settings.json
+{ "experimental": { "sessionIndex": "file" } } // "file"(默认)| "sqlite"
+```
+
+- 在 `packages/cli/src/config/settingsSchema.ts` 声明(唯一真源,模式同
+  `experimental.agentTeam`),经 `scripts/generate-settings-schema.ts` 重新
+  生成 JSON schema。
+- CLI(`packages/cli/src/config/config.ts` 的 `loadCliConfig`)与 daemon
+  启动(`packages/cli/src/commands/serve.ts`,直接 loadSettings、不经过
+  loadCliConfig)都把它翻译成 `configureSessionIndexing()`。
+- 上游默认关闭。开关选择的是"provider",不是存储格式:双向切换都不迁
+  移任何数据。
+
+### 2.3 驱动选型
+
+`node:sqlite`,每进程动态 import 一次:
+
+- 零依赖、零字节、零供应链 diff;Node ≥22.13 免 flag(实测 22.23),Bun
+  ≥1.4 实测可用——即当前全部分发形态(npm、standalone-node、
+  standalone-bun preview)。
+- import 失败(Node 22.0–22.12 或实验 API 变动)→ provider 返回 null →
+  回退文件扫描。默认关闭 + 回退语义使驱动风险对未开启用户不可见。
+- `better-sqlite3` 是备案 Plan B(两种分发形态都已有原生 addon 打包先
+  例:esbuild externals + 按架构拷贝 prebuild,见
+  `scripts/create-standalone-package.js`),刻意不启用:为一个可选特性引
+  入新的供应链面不值得。
+- wasm SQLite 被否决:Node 侧持久化 VFS 不成熟,"内存库 + 整库落盘"
+  会让增量同步的写成本优势消失。
+
+### 2.4 数据模型
+
+`projects/<projectDir>/sessions.index.sqlite`(WAL,`synchronous=NORMAL`):
+
+```sql
+CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT);
+-- schema_version;不匹配 => 整库删除重建
+
+CREATE TABLE sessions(           -- 会话目录,驱动列表分页
+  sessionId     TEXT PRIMARY KEY,
+  fileName      TEXT NOT NULL,
+  mtimeMs       INTEGER NOT NULL,
+  sizeBytes     INTEGER NOT NULL,
+  startTime     TEXT,
+  firstPrompt   TEXT,
+  customTitle   TEXT,
+  gitBranch     TEXT,
+  cwd           TEXT,            -- 与今天同语义的 project 归属过滤
+  recordCount   INTEGER NOT NULL,
+  indexedBytes  INTEGER NOT NULL -- 字节检查点:索引覆盖 [0, indexedBytes)
+);
+CREATE INDEX sessions_mtime ON sessions(mtimeMs DESC);
+
+CREATE TABLE records(            -- 单会话记录偏移,驱动 turn 导航
+  sessionId  TEXT NOT NULL,
+  seq        INTEGER NOT NULL,   -- 文件内行序
+  uuid       TEXT NOT NULL,
+  parentUuid TEXT,
+  type       TEXT NOT NULL,
+  subtype    TEXT,
+  turnStart  INTEGER NOT NULL DEFAULT 0,
+  offset     INTEGER NOT NULL,
+  length     INTEGER NOT NULL,
+  PRIMARY KEY(sessionId, seq)
+) WITHOUT ROWID;
+CREATE INDEX records_uuid ON records(sessionId, uuid);
+```
+
+实测体积:DB ≈ JSONL 的 6–24%(数百 MB 长会话 6.4%;一万小会话语料
+24%)。全量构建一万会话 / 42 万记录 = 3.9s 一次性;追加 ~60 条记录的增
+量追平 = 2.3ms。
+
+### 2.5 一致性协议
+
+sidecar 精确知道自己覆盖了权威数据的哪一段:
+
+1. **追加**:`indexedBytes <= size` → 只扫 `[indexedBytes, size)` 到最后
+   一个完整行;单事务插入;推进检查点。(JSONL 追加的记录从不原地重写;
+   尾部半行在下一次 flush 补齐前被排除。)
+2. **收缩/替换**:`indexedBytes > size` → rewind:删除该会话全部行并从
+   零重建。永不尝试对着文件"修" sidecar。
+3. **服务前校验**:读路径对目标文件做一次 `stat`(与现有代码同一个系
+   统调用),比对 `mtimeMs/sizeBytes`;不一致先增量同步。
+4. **崩溃窗口**:进程死于 JSONL append 与索引更新之间 → 下次 sync 看
+   到 `indexedBytes < size` 自然追平。事务中途崩溃原子回滚;检查点永远
+   不声明未覆盖的字节。
+5. **派生 turn 缓存**:`readTurnIndexPage` 额外持久化每个会话的派生导
+   航 turns(`turns_cache`),按导出时的 `indexedBytes` 检查点键控——后
+   续翻页 = 一行读取 + 少量 `pread`。追加越过检查点即整体失效;会话行
+   被删除(GC、rewind 重建)时同步删除。
+6. **目录同步(仅列表)**:每次调用都按文件名对账(readdir 只取名,加
+   GC 删除),逐文件 stat 扫描用 TTL(默认 30s)限速;TTL 窗口内新建的
+   文件立即索引,turn 读路径总是 stat 校验自己的目标文件——陈旧有界,
+   永不结构性失控。
+7. **损坏/打开失败/schema 不匹配**:删除 DB 文件,本次请求回退文件扫
+   描,惰性重建。只记 debug 日志;索引问题永不让用户看到错误。
+
+并发:WAL 下读不阻塞写;单写者经"每进程一条共享连接 + busy_timeout"
+执行,daemon 持有长寿命写入;CLI 短进程自开连接,最坏是短暂 busy 重试
+后回退。store 内部用 promise 队列串行所有 sync,杜绝单连接上交错的
+`BEGIN … await … COMMIT`。
+
+### 2.6 读路径集成
+
+| 路径                                        | 有 provider                                                                                                                                                                                                                            | 任何 provider 故障     |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `SessionService.listSessions`               | 名称对账 + `sessions` 表窗口化 keyset 分页(每窗 SQL `LIMIT`,mtime 降序;等值 mtime 并列与 legacy 严格 `<` 同样跳过)                                                                                                                     | 与今天完全相同的扫描   |
+| `SessionTranscriptReader.readTurnIndexPage` | `turns_cache` 命中 → 窗口切片 + `pread` 选定 JSONL 段(uuid/sessionId 校验,不符抛 `SessionTranscriptSnapshotUnavailableError`);未命中 → 用与 `buildIndex` 相同的规则从 `records` 行派生、落盘、服务。256MiB 上限同样强制执行,同类型错误 | 现有 `buildIndex` 路径 |
+| `SessionTranscriptReader.readPage`          | **本 PR 不变**(仍走内存索引)                                                                                                                                                                                                           | —                      |
+
+`readTurnIndexPage` 的输出在 parity 套件(`session-index/parity.test.ts`)
+中按字段逐项对照:双向 snapshot 续页、glued-line fragments、
+append-after-cache 失效、sweep 间新建会话可见性。串行 sync 队列与
+in-flight store 单例保证 daemon 并发路由落在同一条安全写时间线上。
+
+### 2.7 与 daemon catalog cache 及 #11493 的关系
+
+- daemon 的持久 JSONL catalog cache("cache 不是文件系统事务")与本设计
+  同哲学;开关打开时 daemon 列表改走 provider,JSON catalog 仍是默认。
+  两者都是可重建 sidecar,无需迁移。
+- #11493(字节预算准入不淘汰)与本文正交、值得独立修复;开关开启后它
+  不再承重,因为热路径不再依赖进程内缓存(进程内缓存降级为 L1,s,持久
+  索引是 L2)。
+
+## 3. 涉及文件
+
+- **新增**:`packages/core/src/services/session-index/{types,config,sqlite}.ts`
+  (及 collocated 测试)
+- `packages/core/src/services/sessionService.ts` — `listSessions` 中的
+  provider 查找
+- `packages/core/src/services/session-transcript-reader.ts` —
+  `readTurnIndexPage` 中的 provider 查找(写路径内联同步 hook 评估后放
+  弃:读路径 stat 校验已把陈旧限制在正确边界内)
+- `packages/cli/src/config/settingsSchema.ts` — `experimental.sessionIndex`
+  (+ 重新生成 `packages/vscode-ide-companion/schemas/settings.schema.json`)
+- `packages/cli/src/config/config.ts`(`loadCliConfig`)与
+  `packages/cli/src/commands/serve.ts`(daemon 启动)— settings →
+  `configureSessionIndexing()`
+- 测试:provider parity 套件、故障注入(损坏 DB、截断 JSONL、半行、
+  schema 不匹配)
+
+## 4. 范围边界
+
+- **不做**权威 SQLite 生命周期存储(issue 方案三):prompt 日志、状态版
+  本、undo 事件保持 append-only JSONL。
+- **不做** `readPage` / 由 SQL 全量物化 `SessionIndex`(后续;内存索引缓
+  存继续服务记录级分页)。
+- **不做**全文搜索 / FTS5。
+- **不迁改** daemon catalog 语义;ACP / vscode 经现有 daemon 路由透明继
+  承。
+- **无迁移/回填命令**——首次使用时惰性增量建索引。
+
+## 5. 待回答问题
+
+1. sweep TTL 默认值(30s)——上线后按 daemon 遥测调整。
+2. `node:sqlite` 在 Node 24 线的稳定性声明在翻转默认值前需复查;若 bun
+   的 OpenTUI flavor 转正,需为 sidecar 加 bun CI 冒烟。
+3. 遥测:`session_index.sync_duration_ms` / `session_index.fallback_total`
+   待开关有真实用量后随快速跟进补上(回应 issue 的"先测量"要求)。

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -32,6 +32,7 @@ import {
 } from '@qwen-code/acp-bridge/daemonMemoryBudget';
 import {
   ApprovalMode,
+  configureSessionIndexing,
   MCP_BUDGET_WARN_FRACTION,
   MEMORY_PROJECT_SCOPES,
   openBrowserSecurely,
@@ -775,6 +776,14 @@ export const serveCommand: CommandModule<unknown, ServeArgs> = {
         primaryWorkspaceArg(argv.workspace) ?? process.cwd(),
       );
       const merged = loaded.merged;
+
+      // Session-index sidecar backend for daemon routes (experimental). The
+      // daemon loads settings directly (never via loadCliConfig), so the
+      // mode must be applied here as well.
+      configureSessionIndexing({
+        mode: merged.experimental?.sessionIndex ?? 'file',
+      });
+
       const approvalMode = merged.tools?.approvalMode;
       const sandbox = merged.tools?.sandbox;
       const sandboxEnv = process.env['SANDBOX'];

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1224,6 +1224,20 @@ describe('loadCliConfig', () => {
     expect(typeof factory?.create).toBe('function');
   });
 
+  it('wires experimental.sessionIndex through to the session index backend', async () => {
+    ServerConfig.resetSessionIndexingForTest();
+    try {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      await loadCliConfig({ experimental: { sessionIndex: 'sqlite' } }, argv);
+      expect(ServerConfig.getSessionIndexMode()).toBe('sqlite');
+      await loadCliConfig({}, argv);
+      expect(ServerConfig.getSessionIndexMode()).toBe('file');
+    } finally {
+      ServerConfig.resetSessionIndexingForTest();
+    }
+  });
+
   it('enables debug file logging for --debug when QWEN_DEBUG_LOG_FILE is unset', async () => {
     delete process.env['QWEN_DEBUG_LOG_FILE'];
     process.argv = ['node', 'script.js', '--debug'];

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -51,6 +51,7 @@ import {
   loadOutputStyleCatalog,
   stripAnsiAndControl,
   type OutputStyleDefinition,
+  configureSessionIndexing,
 } from '@qwen-code/qwen-code-core';
 import { extensionsCommand } from '../commands/extensions.js';
 import { hooksCommand } from '../commands/hooks.js';
@@ -1544,6 +1545,12 @@ export async function loadCliConfig(
   if (!Storage.hasRuntimeBaseDirContext()) {
     Storage.setRuntimeBaseDir(settings.advanced?.runtimeOutputDir, cwd);
   }
+
+  // Session-index sidecar backend (experimental). JSONL transcripts remain
+  // authoritative; 'file' (default) keeps the scan-based read paths.
+  configureSessionIndexing({
+    mode: settings.experimental?.sessionIndex ?? 'file',
+  });
 
   const ideMode = settings.ide?.enabled ?? false;
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3988,6 +3988,20 @@ const SETTINGS_SCHEMA = {
           'Generate a short LLM-based label after each tool batch completes. For a completed tool group the label replaces the generic `Tool × N` header; when the group is force-expanded it appears as a dim `● <label>` line below the tool group. Requires a fast model to be configured; runs in parallel with the next API call so latency is hidden. Currently affects interactive CLI rendering only — SDK / non-interactive emission of the `tool_use_summary` message is not yet wired (the message factory is exported for a follow-up PR). Can be overridden with QWEN_CODE_EMIT_TOOL_USE_SUMMARIES=0 or =1.',
         showInDialog: true,
       },
+      sessionIndex: {
+        type: 'enum',
+        label: 'Session Index Backend',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: 'file',
+        description:
+          "Index backend for session listing and transcript navigation: 'file' (default; derive indexes by scanning session JSONL on demand) or 'sqlite' (experimental; maintain a rebuildable node:sqlite sidecar per project with byte-offset checkpoints and serve reads from it). Session JSONL files remain the sole authoritative store either way; when the sidecar or the node:sqlite driver is unavailable, reads automatically fall back to file scanning.",
+        showInDialog: true,
+        options: [
+          { value: 'file', label: 'File scan (default)' },
+          { value: 'sqlite', label: 'SQLite sidecar (experimental)' },
+        ],
+      },
     },
   },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -383,6 +383,19 @@ export * from './ipc/uds-inbox.js';
 export * from './services/session-registry.js';
 export * from './services/sessionService.js';
 export {
+  configureSessionIndexing,
+  getSessionIndexMode,
+  resetSessionIndexingForTest,
+  setSessionIndexDriverForTest,
+} from './services/session-index/config.js';
+export type {
+  SessionIndexCatalogRow,
+  SessionIndexMode,
+  SessionIndexRecordRow,
+  SessionIndexSessionRow,
+  SessionIndexStore,
+} from './services/session-index/types.js';
+export {
   collectSessionTurnState,
   computeInitialTurnFromHistory,
 } from './services/session-turn-state.js';

--- a/packages/core/src/services/session-index/config.test.ts
+++ b/packages/core/src/services/session-index/config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  configureSessionIndexing,
+  getSessionIndexMode,
+  getSessionIndexStore,
+  resetSessionIndexingForTest,
+  setSessionIndexDriverForTest,
+} from './config.js';
+import {
+  SESSION_INDEX_DB_FILE,
+  sessionIndexDbPath,
+  type SqliteDriver,
+} from './sqlite.js';
+
+describe('session-index/config', () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    resetSessionIndexingForTest();
+    projectDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'session-index-cfg-'),
+    );
+  });
+
+  afterEach(async () => {
+    resetSessionIndexingForTest();
+    await fsp.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('defaults to file mode and yields no store', async () => {
+    expect(getSessionIndexMode()).toBe('file');
+    expect(await getSessionIndexStore(projectDir)).toBeNull();
+  });
+
+  it('returns null when the driver is unavailable', async () => {
+    configureSessionIndexing({ mode: 'sqlite' });
+    setSessionIndexDriverForTest(null);
+    expect(await getSessionIndexStore(projectDir)).toBeNull();
+  });
+
+  it('opens, memoizes, and closes stores per project directory', async () => {
+    let driver: SqliteDriver | undefined;
+    try {
+      const specifier = 'node:sqlite';
+      driver = (await import(specifier)) as unknown as SqliteDriver;
+    } catch {
+      // runtime without node:sqlite: probing must report unavailable
+    }
+    configureSessionIndexing({ mode: 'sqlite' });
+    if (!driver) {
+      setSessionIndexDriverForTest(null);
+      expect(await getSessionIndexStore(projectDir)).toBeNull();
+      return;
+    }
+    const first = await getSessionIndexStore(projectDir);
+    const second = await getSessionIndexStore(projectDir);
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+    first!.close();
+  });
+
+  it('recovers from a corrupted database instead of throwing', async () => {
+    let driver: SqliteDriver | undefined;
+    try {
+      const specifier = 'node:sqlite';
+      driver = (await import(specifier)) as unknown as SqliteDriver;
+    } catch {
+      // skip on runtimes without node:sqlite
+    }
+    if (!driver) return;
+    configureSessionIndexing({ mode: 'sqlite' });
+    await fsp.writeFile(
+      sessionIndexDbPath(projectDir),
+      'garbage, not sqlite',
+      'utf8',
+    );
+    const store = await getSessionIndexStore(projectDir);
+    expect(store).not.toBeNull();
+    expect(store!.catalogRows()).toEqual([]);
+  });
+
+  it('concurrent first calls share exactly one store construction', async () => {
+    let realDriver: SqliteDriver | undefined;
+    try {
+      const specifier = 'node:sqlite';
+      realDriver = (await import(specifier)) as unknown as SqliteDriver;
+    } catch {
+      // skip on runtimes without node:sqlite
+    }
+    if (!realDriver) return;
+    const Backend = realDriver.DatabaseSync;
+    let constructions = 0;
+    class CountingDatabase extends Backend {
+      constructor(dbPath: string) {
+        super(dbPath);
+        constructions++;
+      }
+    }
+    configureSessionIndexing({ mode: 'sqlite' });
+    setSessionIndexDriverForTest({ DatabaseSync: CountingDatabase });
+    const [a, b] = await Promise.all([
+      getSessionIndexStore(projectDir),
+      getSessionIndexStore(projectDir),
+    ]);
+    expect(a).not.toBeNull();
+    expect(b).toBe(a);
+    expect(constructions).toBe(1);
+  });
+
+  it('db file name is stable', () => {
+    expect(SESSION_INDEX_DB_FILE).toBe('sessions.index.sqlite');
+    expect(sessionIndexDbPath('/p')).toBe(
+      path.join('/p', 'sessions.index.sqlite'),
+    );
+  });
+});

--- a/packages/core/src/services/session-index/config.ts
+++ b/packages/core/src/services/session-index/config.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Process-level wiring for the session-index sidecar. Mode selection happens
+// once at bootstrap (CLI config load, daemon serve startup) via
+// configureSessionIndexing() — the same pattern as Storage.setRuntimeBaseDir
+// — so the many SessionService/SessionTranscriptReader construction sites
+// need no individual plumbing. Every failure mode (mode off, driver missing,
+// database corrupted) resolves to `null`, and callers fall back to file
+// scanning.
+
+import { createDebugLogger } from '../../utils/debugLogger.js';
+import type { SessionIndexMode, SessionIndexStore } from './types.js';
+
+const debugLogger = createDebugLogger('SESSION_INDEX');
+
+interface SqliteDriverModule {
+  DatabaseSync: new (path: string) => {
+    exec(sql: string): void;
+    prepare(sql: string): {
+      run(...params: unknown[]): unknown;
+      get(...params: unknown[]): unknown;
+      all(...params: unknown[]): unknown[];
+    };
+    close(): void;
+  };
+}
+
+let configuredMode: SessionIndexMode = 'file';
+let driverProbe:
+  | { state: 'unprobed' }
+  | { state: 'available'; driver: SqliteDriverModule }
+  | { state: 'unavailable' } = { state: 'unprobed' };
+let driverOverrideForTest: SqliteDriverModule | null | undefined;
+
+/** projectDir -> in-flight or settled store (null = known-unavailable). */
+const stores = new Map<string, Promise<SessionIndexStore | null>>();
+
+export function configureSessionIndexing(options: {
+  mode: SessionIndexMode;
+}): void {
+  configuredMode = options.mode;
+}
+
+export function getSessionIndexMode(): SessionIndexMode {
+  return configuredMode;
+}
+
+/**
+ * Test hook: inject a driver, or null to simulate a runtime without
+ * node:sqlite. undefined restores real probing.
+ */
+export function setSessionIndexDriverForTest(
+  driver: SqliteDriverModule | null | undefined,
+): void {
+  driverOverrideForTest = driver;
+  driverProbe = { state: 'unprobed' };
+}
+
+export function resetSessionIndexingForTest(): void {
+  for (const pending of stores.values()) {
+    void pending.then(
+      (store) => {
+        try {
+          store?.close();
+        } catch {
+          // closing a broken store is best-effort in tests
+        }
+      },
+      () => undefined,
+    );
+  }
+  stores.clear();
+  configuredMode = 'file';
+  driverOverrideForTest = undefined;
+  driverProbe = { state: 'unprobed' };
+}
+
+async function probeDriver(): Promise<SqliteDriverModule | null> {
+  if (driverOverrideForTest !== undefined) {
+    return driverOverrideForTest;
+  }
+  if (driverProbe.state === 'available') return driverProbe.driver;
+  if (driverProbe.state === 'unavailable') return null;
+  try {
+    // Dynamic specifier: packages/core pins @types/node 20.x, which predates
+    // node:sqlite type declarations; the structural SqliteDriverModule
+    // interface is the compile-time contract instead. A non-literal specifier
+    // also keeps bundlers from statically resolving the experimental builtin.
+    const specifier = 'node:sqlite';
+    const mod = (await import(specifier)) as unknown as SqliteDriverModule;
+    driverProbe = { state: 'available', driver: mod };
+    return mod;
+  } catch (error) {
+    debugLogger.debug(`session index driver unavailable: ${String(error)}`);
+    driverProbe = { state: 'unavailable' };
+    return null;
+  }
+}
+
+/**
+ * Resolve the sidecar store for one project directory, or null when the
+ * feature can serve nothing in this process. A corrupted database is deleted
+ * and rebuilt; a second failure disables the project for this process rather
+ * than crashing the caller. Concurrent first callers share one connection:
+ * the memo holds the in-flight open, not just its result.
+ */
+export function getSessionIndexStore(
+  projectDir: string,
+): Promise<SessionIndexStore | null> {
+  if (configuredMode !== 'sqlite') return Promise.resolve(null);
+  const cached = stores.get(projectDir);
+  if (cached !== undefined) return cached;
+  const opening = openStoreOnce(projectDir);
+  stores.set(projectDir, opening);
+  return opening;
+}
+
+async function openStoreOnce(
+  projectDir: string,
+): Promise<SessionIndexStore | null> {
+  const driver = await probeDriver();
+  if (!driver) return null;
+  const { openSessionIndexStore } = await import('./sqlite.js');
+  try {
+    return openSessionIndexStore(driver, projectDir);
+  } catch (error) {
+    debugLogger.warn(
+      `session index open failed, retrying after reset: ${String(error)}`,
+    );
+    try {
+      const { resetSessionIndexDatabase } = await import('./sqlite.js');
+      await resetSessionIndexDatabase(projectDir);
+      return openSessionIndexStore(driver, projectDir);
+    } catch (retryError) {
+      debugLogger.warn(
+        `session index disabled for ${projectDir}: ${String(retryError)}`,
+      );
+      return null;
+    }
+  }
+}

--- a/packages/core/src/services/session-index/nav-hints.ts
+++ b/packages/core/src/services/session-index/nav-hints.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Navigation-turn derivation shared by the in-memory transcript index
+// (session-transcript-reader.ts) and the SQLite sidecar indexer
+// (session-index/sqlite.ts). Both paths must derive identical turn
+// boundaries and assistant-preview candidates from the same record, so the
+// logic lives in this dependency-free module instead of being duplicated.
+
+import {
+  isUserPromptSubmitContextPartText,
+  projectUserTranscriptForDisplay,
+  stripGeneratedAttachmentTokens,
+} from '../../utils/transcript-records.js';
+import type { ChatRecord } from '../chatRecordingService.js';
+
+export type SessionTranscriptNavigationTurnKind =
+  | 'prompt'
+  | 'realtime'
+  | 'scheduled';
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function navigationDisplayText(
+  text: string,
+  systemPayload: unknown,
+): string {
+  const stripped = stripGeneratedAttachmentTokens(text, systemPayload);
+  return isUserPromptSubmitContextPartText(stripped) ? '' : stripped;
+}
+
+export function navigationKindForRecord(
+  record: ChatRecord,
+): SessionTranscriptNavigationTurnKind | undefined {
+  if (record.type !== 'user') return undefined;
+  if (
+    record.subtype === 'goal_runtime' ||
+    record.subtype === 'notification' ||
+    record.subtype === 'mid_turn_user_message'
+  ) {
+    return undefined;
+  }
+  if (record.subtype === 'cron') {
+    const payload = isObjectRecord(record.systemPayload)
+      ? record.systemPayload
+      : undefined;
+    const displayText =
+      typeof payload?.['displayText'] === 'string'
+        ? navigationDisplayText(payload['displayText'], record.systemPayload)
+        : '';
+    return displayText.trim().length > 0 ? 'scheduled' : undefined;
+  }
+
+  const projection = projectUserTranscriptForDisplay(record);
+  const displayText =
+    projection.displayText === undefined
+      ? undefined
+      : navigationDisplayText(projection.displayText, record.systemPayload);
+  const hasVisibleText =
+    displayText !== undefined
+      ? displayText.trim().length > 0
+      : projection.parts.some(
+          (part) =>
+            isObjectRecord(part) &&
+            typeof part['text'] === 'string' &&
+            part['text'].trim().length > 0 &&
+            !isUserPromptSubmitContextPartText(part['text']),
+        );
+  const hasVisibleAttachment =
+    projection.parts.some((part) => {
+      if (!isObjectRecord(part) || !isObjectRecord(part['inlineData'])) {
+        return false;
+      }
+      const inlineData = part['inlineData'];
+      return (
+        typeof inlineData['data'] === 'string' &&
+        typeof inlineData['mimeType'] === 'string' &&
+        inlineData['mimeType'].startsWith('image/')
+      );
+    }) ||
+    (isObjectRecord(record.systemPayload) &&
+      Array.isArray(record.systemPayload['attachmentReferences']) &&
+      record.systemPayload['attachmentReferences'].some(
+        (reference) =>
+          isObjectRecord(reference) &&
+          (reference['type'] === 'image' || reference['type'] === 'resource') &&
+          typeof reference['attachmentId'] === 'string' &&
+          typeof reference['mimeType'] === 'string' &&
+          typeof reference['size'] === 'number',
+      ));
+  if (!hasVisibleText && !hasVisibleAttachment) return undefined;
+  return record.subtype === 'realtime_message' ? 'realtime' : 'prompt';
+}
+
+export function isAssistantPreviewCandidate(record: ChatRecord): boolean {
+  return (
+    record.type === 'assistant' &&
+    (record.message?.parts ?? []).some(
+      (part) =>
+        isObjectRecord(part) &&
+        part['thought'] !== true &&
+        typeof part['text'] === 'string' &&
+        part['text'].trim().length > 0,
+    )
+  );
+}

--- a/packages/core/src/services/session-index/parity.test.ts
+++ b/packages/core/src/services/session-index/parity.test.ts
@@ -1,0 +1,827 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Output-parity suite: the SQLite sidecar mode must produce byte-identical
+// listSessions / readTurnIndexPage results to the file-scan mode across an
+// adversarial transcript corpus. This is the load-bearing guarantee for
+// enabling the feature flag.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Storage } from '../../config/storage.js';
+import {
+  SessionService,
+  type ListSessionsResult,
+  type SessionListItem,
+} from '../sessionService.js';
+import {
+  SessionTranscriptReader,
+  type SessionTranscriptTurnIndexPage,
+} from '../session-transcript-reader.js';
+import {
+  configureSessionIndexing,
+  getSessionIndexStore,
+  resetSessionIndexingForTest,
+  setSessionIndexDriverForTest,
+} from './config.js';
+import { sessionIndexDbPath } from './sqlite.js';
+import type { SessionIndexMode } from './types.js';
+
+let runtimeDir: string;
+let workspaceDir: string;
+let chatsDir: string;
+
+const BASE_MS = Date.UTC(2026, 2, 1, 12, 0, 0);
+
+interface RecOptions {
+  uuid: string;
+  parentUuid?: string | null;
+  sessionId: string;
+  ts?: number;
+  type?: string;
+  subtype?: string;
+  text?: string;
+  provenance?: string;
+  systemPayload?: unknown;
+  forkedFrom?: { pid: number; startTime: string };
+  cwd?: string;
+  parts?: unknown[];
+}
+
+function rec(o: RecOptions): string {
+  const record: Record<string, unknown> = {
+    uuid: o.uuid,
+    parentUuid: o.parentUuid ?? null,
+    sessionId: o.sessionId,
+    timestamp: new Date(o.ts ?? BASE_MS).toISOString(),
+    type: o.type ?? 'user',
+    cwd: o.cwd ?? workspaceDir,
+    version: '1.0.0',
+    gitBranch: 'main',
+    message: {
+      role: (o.type ?? 'user') === 'assistant' ? 'model' : 'user',
+      parts: o.parts ?? [{ text: o.text ?? `text-${o.uuid}` }],
+    },
+  };
+  if (o.subtype !== undefined) record['subtype'] = o.subtype;
+  if (o.provenance !== undefined) record['provenance'] = o.provenance;
+  if (o.systemPayload !== undefined) record['systemPayload'] = o.systemPayload;
+  if (o.forkedFrom !== undefined) record['forkedFrom'] = o.forkedFrom;
+  return JSON.stringify(record);
+}
+
+function turnResult(
+  uuid: string,
+  parentUuid: string,
+  sessionId: string,
+  promptId: string,
+  ts: number,
+): string {
+  return rec({
+    uuid,
+    parentUuid,
+    sessionId,
+    ts,
+    type: 'system',
+    subtype: 'turn_result',
+    systemPayload: {
+      promptId,
+      state: 'completed',
+      endedAt: ts,
+    },
+  });
+}
+
+/** A plain prompt→tools→answer chain of `turns` turns (5 records each). */
+function simpleSession(
+  sessionId: string,
+  turns: number,
+  startTs: number,
+): string[] {
+  const lines: string[] = [];
+  let parent: string | null = null;
+  for (let t = 0; t < turns; t++) {
+    const ts = startTs + t * 60_000;
+    const u = `${sessionId}-u${t}`;
+    lines.push(
+      rec({
+        uuid: u,
+        parentUuid: parent,
+        sessionId,
+        ts,
+        text: `prompt ${t} of ${sessionId}`,
+      }),
+    );
+    parent = u;
+    const a1 = `${sessionId}-a${t}`;
+    lines.push(
+      rec({
+        uuid: a1,
+        parentUuid: parent,
+        sessionId,
+        ts: ts + 1,
+        type: 'assistant',
+        text: `answer ${t}`,
+      }),
+    );
+    parent = a1;
+    const tr = `${sessionId}-tr${t}`;
+    lines.push(turnResult(tr, parent, sessionId, `prompt-${t}`, ts + 2));
+    parent = tr;
+  }
+  return lines;
+}
+
+async function writeSession(
+  sessionId: string,
+  lines: string[],
+  mtimeMs: number,
+): Promise<string> {
+  const filePath = path.join(chatsDir, `${sessionId}.jsonl`);
+  await fsp.writeFile(filePath, lines.join('\n') + '\n', 'utf8');
+  const d = new Date(mtimeMs);
+  await fsp.utimes(filePath, d, d);
+  return filePath;
+}
+
+const SID = {
+  simple1: '11111111-1111-4111-8111-111111111111',
+  simple2: '22222222-2222-4222-8222-222222222222',
+  branch: '33333333-3333-4333-8333-333333333333',
+  realtime: '44444444-4444-4444-8444-444444444444',
+  cron: '55555555-5555-4555-8555-555555555555',
+  noPrompt: '66666666-6666-4666-8666-666666666666',
+  goalOnly: '77777777-7777-4777-8777-777777777777',
+  mismatch: '88888888-8888-4888-8888-888888888888',
+  titled: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  glued: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+};
+
+async function buildCorpus(): Promise<void> {
+  await fsp.mkdir(chatsDir, { recursive: true });
+  await writeSession(
+    SID.simple1,
+    simpleSession(SID.simple1, 3, BASE_MS),
+    BASE_MS + 8 * 60_000,
+  );
+  await writeSession(
+    SID.simple2,
+    simpleSession(SID.simple2, 2, BASE_MS),
+    BASE_MS + 7 * 60_000,
+  );
+
+  // Branch: two chains share a root; the later leaf wins.
+  const b = SID.branch;
+  await writeSession(
+    b,
+    [
+      rec({
+        uuid: `${b}-root`,
+        sessionId: b,
+        ts: BASE_MS,
+        text: 'root prompt',
+      }),
+      rec({
+        uuid: `${b}-a`,
+        parentUuid: `${b}-root`,
+        sessionId: b,
+        ts: BASE_MS + 1,
+        type: 'assistant',
+        text: 'branch A',
+      }),
+      rec({
+        uuid: `${b}-u2`,
+        parentUuid: `${b}-a`,
+        sessionId: b,
+        ts: BASE_MS + 2,
+        text: 'second prompt on A',
+      }),
+      rec({
+        uuid: `${b}-fork`,
+        parentUuid: `${b}-root`,
+        sessionId: b,
+        ts: BASE_MS + 3,
+        text: 'forked prompt',
+      }),
+      rec({
+        uuid: `${b}-fork-a`,
+        parentUuid: `${b}-fork`,
+        sessionId: b,
+        ts: BASE_MS + 4,
+        type: 'assistant',
+        text: 'fork answer',
+      }),
+    ],
+    BASE_MS + 6 * 60_000,
+  );
+
+  // Realtime + inherited records.
+  const r = SID.realtime;
+  await writeSession(
+    r,
+    [
+      rec({ uuid: `${r}-u1`, sessionId: r, ts: BASE_MS, text: 'a prompt' }),
+      rec({
+        uuid: `${r}-rt`,
+        parentUuid: `${r}-u1`,
+        sessionId: r,
+        ts: BASE_MS + 1,
+        subtype: 'realtime_message',
+        text: 'realtime question',
+      }),
+      rec({
+        uuid: `${r}-rta`,
+        parentUuid: `${r}-rt`,
+        sessionId: r,
+        ts: BASE_MS + 2,
+        type: 'assistant',
+        subtype: 'realtime_message',
+        text: 'realtime answer',
+      }),
+      rec({
+        uuid: `${r}-u2`,
+        parentUuid: `${r}-rta`,
+        sessionId: r,
+        ts: BASE_MS + 3,
+        text: 'after realtime',
+        forkedFrom: { pid: 1234, startTime: new Date(BASE_MS).toISOString() },
+      }),
+    ],
+    BASE_MS + 5 * 60_000 + 0,
+  );
+
+  // Cron (scheduled) turn.
+  const c = SID.cron;
+  await writeSession(
+    c,
+    [
+      rec({
+        uuid: `${c}-cron`,
+        sessionId: c,
+        ts: BASE_MS,
+        subtype: 'cron',
+        systemPayload: { displayText: 'nightly sync job' },
+        text: '',
+      }),
+      rec({
+        uuid: `${c}-a1`,
+        parentUuid: `${c}-cron`,
+        sessionId: c,
+        ts: BASE_MS + 1,
+        type: 'assistant',
+        text: 'did the sync',
+      }),
+    ],
+    BASE_MS + 4 * 60_000,
+  );
+
+  // Assistant only (no user prompt at all).
+  const np = SID.noPrompt;
+  await writeSession(
+    np,
+    [
+      rec({
+        uuid: `${np}-a1`,
+        sessionId: np,
+        ts: BASE_MS,
+        type: 'assistant',
+        text: 'orphan answer',
+      }),
+    ],
+    BASE_MS + 3 * 60_000,
+  );
+
+  // Goal state only (kept deliberately small: the head-records goal branch).
+  const go = SID.goalOnly;
+  await writeSession(
+    go,
+    [
+      rec({
+        uuid: `${go}-gs`,
+        sessionId: go,
+        ts: BASE_MS,
+        type: 'system',
+        subtype: 'goal_state',
+        systemPayload: {
+          v: 2,
+          cause: 'proposed',
+          snapshot: { activity: 'running' },
+          checkpointPending: false,
+        },
+      }),
+    ],
+    BASE_MS + 2 * 60_000,
+  );
+
+  // Mismatched sessionId inside the file.
+  await writeSession(
+    SID.mismatch,
+    [
+      rec({
+        uuid: `${SID.mismatch}-u1`,
+        sessionId: 'another-session-entirely',
+        ts: BASE_MS,
+        text: 'foreign record',
+      }),
+    ],
+    BASE_MS + 1 * 60_000,
+  );
+
+  // Parent + source metadata + a custom title record: exercises the
+  // non-default branches of every SessionListItem label field.
+  const t = SID.titled;
+  await writeSession(
+    t,
+    [
+      rec({
+        uuid: `${t}-ps`,
+        sessionId: t,
+        ts: BASE_MS,
+        type: 'system',
+        subtype: 'parent_session',
+        systemPayload: { parentSessionId: SID.simple1 },
+      }),
+      rec({
+        uuid: `${t}-ss`,
+        sessionId: t,
+        ts: BASE_MS + 1,
+        type: 'system',
+        subtype: 'session_source',
+        systemPayload: { sourceType: 'fork', sourceId: 'source-42' },
+      }),
+      rec({
+        uuid: `${t}-u1`,
+        sessionId: t,
+        ts: BASE_MS + 2,
+        text: 'titled prompt',
+      }),
+      rec({
+        uuid: `${t}-ct`,
+        sessionId: t,
+        ts: BASE_MS + 3,
+        type: 'system',
+        subtype: 'custom_title',
+        systemPayload: { title: 'Titled session' },
+      }),
+    ],
+    BASE_MS + 45 * 60_000,
+  );
+
+  // Two complete records glued onto one physical line (torn-append shape).
+  const gl = SID.glued;
+  await writeSession(
+    gl,
+    [
+      rec({
+        uuid: `${gl}-u1`,
+        sessionId: gl,
+        ts: BASE_MS,
+        text: 'first glued prompt',
+      }) +
+        rec({
+          uuid: `${gl}-a1`,
+          parentUuid: `${gl}-u1`,
+          sessionId: gl,
+          ts: BASE_MS + 1,
+          type: 'assistant',
+          text: 'glued answer',
+        }),
+      rec({
+        uuid: `${gl}-u2`,
+        parentUuid: `${gl}-a1`,
+        sessionId: gl,
+        ts: BASE_MS + 2,
+        text: 'second glued prompt',
+      }),
+    ],
+    BASE_MS + 35 * 60_000,
+  );
+
+  // Malformed JSON mid-file.
+  await writeSession(
+    '99999999-9999-4999-8999-999999999999',
+    [
+      rec({
+        uuid: 'mal-u1',
+        sessionId: '99999999-9999-4999-8999-999999999999',
+        ts: BASE_MS,
+        text: 'before bad line',
+      }),
+      '{"not":"closed"',
+      rec({
+        uuid: 'mal-a1',
+        parentUuid: 'mal-u1',
+        sessionId: '99999999-9999-4999-8999-999999999999',
+        ts: BASE_MS + 1,
+        type: 'assistant',
+        text: 'after bad line',
+      }),
+    ],
+    BASE_MS + 30 * 60_000,
+  );
+
+  // Non-UUID-named file (listing must ignore it).
+  await writeSession(
+    'notes-scratch',
+    [rec({ uuid: 'n1', sessionId: 'notes-scratch', text: 'scratch' })],
+    BASE_MS + 40 * 60_000,
+  );
+
+  // Empty file.
+  await writeSession(
+    '00000000-0000-4000-8000-000000000000',
+    [],
+    BASE_MS + 50 * 60_000,
+  );
+}
+
+function setMode(mode: SessionIndexMode): void {
+  resetSessionIndexingForTest();
+  configureSessionIndexing({ mode });
+}
+
+async function paginateSessions(size: number): Promise<SessionListItem[]> {
+  const service = new SessionService(workspaceDir, {
+    runtimeBaseDir: runtimeDir,
+  });
+  const items: SessionListItem[] = [];
+  let cursor: number | undefined;
+  for (let guard = 0; guard < 100; guard++) {
+    const page: ListSessionsResult = await service.listSessions({
+      size,
+      cursor,
+    });
+    items.push(...page.items);
+    if (!page.hasMore || page.nextCursor === undefined) break;
+    cursor = page.nextCursor;
+  }
+  return items;
+}
+
+function comparableItems(items: SessionListItem[]): unknown {
+  return items.map((item) => ({
+    sessionId: item.sessionId,
+    cwd: item.cwd,
+    startTime: item.startTime,
+    mtime: item.mtime,
+    prompt: item.prompt,
+    gitBranch: item.gitBranch,
+    customTitle: item.customTitle,
+    goalObjective: item.goalObjective,
+    parentSessionId: item.parentSessionId,
+    sourceType: item.sourceType,
+    sourceId: item.sourceId,
+    titleSource: item.titleSource,
+    isArchived: item.isArchived,
+  }));
+}
+
+function comparablePage(page: SessionTranscriptTurnIndexPage): unknown {
+  return {
+    v: page.v,
+    sessionId: page.sessionId,
+    snapshot: page.snapshot,
+    totalTurns: page.totalTurns,
+    start: page.start,
+    startTime: page.startTime,
+    lastUpdated: page.lastUpdated,
+    turns: page.turns,
+  };
+}
+
+describe('session-index parity: sidecar vs file scan', () => {
+  beforeEach(async () => {
+    const root = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'session-index-parity-'),
+    );
+    runtimeDir = path.join(root, 'runtime');
+    workspaceDir = path.join(root, 'workspace');
+    await fsp.mkdir(workspaceDir, { recursive: true });
+    Storage.setRuntimeBaseDir(runtimeDir, workspaceDir);
+    chatsDir = path.join(
+      new Storage(workspaceDir, runtimeDir).getProjectDir(),
+      'chats',
+    );
+    await buildCorpus();
+  });
+
+  afterEach(async () => {
+    resetSessionIndexingForTest();
+    Storage.setRuntimeBaseDir(null);
+    await fsp.rm(path.dirname(runtimeDir), { recursive: true, force: true });
+  });
+
+  it('listSessions pages are identical in both modes', async () => {
+    setMode('file');
+    const baseline = comparableItems(await paginateSessions(3));
+
+    setMode('sqlite');
+    const indexed = comparableItems(await paginateSessions(3));
+    expect(indexed).toEqual(baseline);
+
+    // And the sidecar does not perturb the file mode once created.
+    setMode('file');
+    const after = comparableItems(await paginateSessions(3));
+    expect(after).toEqual(baseline);
+  });
+
+  it('listSessions first page is identical at a single call granularity', async () => {
+    setMode('file');
+    const baseline = comparableItems(
+      (
+        await new SessionService(workspaceDir, {
+          runtimeBaseDir: runtimeDir,
+        }).listSessions({ size: 5 })
+      ).items,
+    );
+    setMode('sqlite');
+    const indexed = comparableItems(
+      (
+        await new SessionService(workspaceDir, {
+          runtimeBaseDir: runtimeDir,
+        }).listSessions({ size: 5 })
+      ).items,
+    );
+    expect(indexed).toEqual(baseline);
+  });
+
+  it('readTurnIndexPage first page is identical per session', async () => {
+    const files = (await fsp.readdir(chatsDir)).filter(
+      (f) =>
+        f.endsWith('.jsonl') &&
+        !f.startsWith(SID.mismatch) &&
+        f !== 'notes-scratch.jsonl',
+    );
+    for (const file of files) {
+      const sessionId = file.replace(/\.jsonl$/, '');
+      setMode('file');
+      const baseline = comparablePage(
+        await new SessionTranscriptReader(
+          workspaceDir,
+          undefined,
+          runtimeDir,
+        ).readTurnIndexPage(sessionId, { limit: 2 }),
+      );
+      setMode('sqlite');
+      const indexed = comparablePage(
+        await new SessionTranscriptReader(
+          workspaceDir,
+          undefined,
+          runtimeDir,
+        ).readTurnIndexPage(sessionId, { limit: 2 }),
+      );
+      expect(indexed, `session ${sessionId}`).toEqual(baseline);
+    }
+  });
+
+  it('snapshot continuation pages are byte-identical across modes', async () => {
+    const sessionId = SID.simple1;
+    setMode('file');
+    const readerFile = new SessionTranscriptReader(
+      workspaceDir,
+      undefined,
+      runtimeDir,
+    );
+    const page1File = await readerFile.readTurnIndexPage(sessionId, {
+      limit: 1,
+    });
+
+    setMode('sqlite');
+    const readerSqlite = new SessionTranscriptReader(
+      workspaceDir,
+      undefined,
+      runtimeDir,
+    );
+    const page1Sqlite = await readerSqlite.readTurnIndexPage(sessionId, {
+      limit: 1,
+    });
+    expect(comparablePage(page1Sqlite)).toEqual(comparablePage(page1File));
+
+    // A legacy-mode snapshot must continue on the sidecar path and vice versa.
+    const start = page1File.start; // ordinal of the shown page
+    if (start > 0) {
+      setMode('sqlite');
+      const contA = await new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      ).readTurnIndexPage(sessionId, {
+        snapshot: page1File.snapshot,
+        start: 0,
+        limit: start,
+      });
+      setMode('file');
+      const contB = await new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      ).readTurnIndexPage(sessionId, {
+        snapshot: page1Sqlite.snapshot,
+        start: 0,
+        limit: start,
+      });
+      expect(comparablePage(contA)).toEqual(comparablePage(contB));
+    }
+  });
+
+  it('mismatched-session errors are identical in both modes', async () => {
+    for (const mode of ['file', 'sqlite'] as const) {
+      setMode(mode);
+      const reader = new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      );
+      await expect(
+        reader.readTurnIndexPage(SID.mismatch, { limit: 2 }),
+        `mode=${mode}`,
+      ).rejects.toMatchObject({
+        name: 'SessionTranscriptSnapshotUnavailableError',
+      });
+    }
+  });
+
+  it('driver-unavailable mode falls back to file scanning with identical output', async () => {
+    setMode('sqlite');
+    setSessionIndexDriverForTest(null);
+    const items = comparableItems(await paginateSessions(3));
+
+    setMode('file');
+    const baseline = comparableItems(await paginateSessions(3));
+    expect(items).toEqual(baseline);
+
+    setSessionIndexDriverForTest(undefined);
+  });
+
+  it('deleting the sidecar between calls is invisible to callers', async () => {
+    setMode('sqlite');
+    const first = comparablePage(
+      await new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      ).readTurnIndexPage(SID.simple1, { limit: 2 }),
+    );
+    resetSessionIndexingForTest();
+    configureSessionIndexing({ mode: 'sqlite' });
+    await fsp.rm(sessionIndexDbPath(path.dirname(chatsDir)), { force: true });
+    await fsp.rm(`${sessionIndexDbPath(path.dirname(chatsDir))}-wal`, {
+      force: true,
+    });
+    await fsp.rm(`${sessionIndexDbPath(path.dirname(chatsDir))}-shm`, {
+      force: true,
+    });
+    const rebuilt = comparablePage(
+      await new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      ).readTurnIndexPage(SID.simple1, { limit: 2 }),
+    );
+    expect(rebuilt).toEqual(first);
+  });
+
+  it('page metadata (hasMore/nextCursor) is identical page-by-page', async () => {
+    async function collectPages(): Promise<
+      Array<
+        Pick<ListSessionsResult, 'hasMore' | 'nextCursor'> & {
+          itemIds: string[];
+        }
+      >
+    > {
+      const service = new SessionService(workspaceDir, {
+        runtimeBaseDir: runtimeDir,
+      });
+      const pages: Array<
+        Pick<ListSessionsResult, 'hasMore' | 'nextCursor'> & {
+          itemIds: string[];
+        }
+      > = [];
+      let cursor: number | undefined;
+      for (let guard = 0; guard < 100; guard++) {
+        const page = await service.listSessions({ size: 3, cursor });
+        pages.push({
+          hasMore: page.hasMore,
+          nextCursor: page.nextCursor,
+          itemIds: page.items.map((i) => i.sessionId),
+        });
+        if (!page.hasMore || page.nextCursor === undefined) break;
+        cursor = page.nextCursor;
+      }
+      return pages;
+    }
+    setMode('file');
+    const baseline = await collectPages();
+    setMode('sqlite');
+    const indexed = await collectPages();
+    expect(indexed).toEqual(baseline);
+  });
+
+  it('the sqlite mode run actually exercised the sidecar', async () => {
+    setMode('sqlite');
+    await paginateSessions(3);
+    const projectDir = path.dirname(chatsDir);
+    const store = await getSessionIndexStore(projectDir);
+    expect(store).not.toBeNull();
+    const catalog = store!.catalogRows();
+    expect(catalog.length).toBeGreaterThan(5);
+    for (const row of catalog.slice(0, 5)) {
+      expect(store!.recordRows(row.sessionId)).not.toBeNull();
+    }
+    // Turn pages populate the durable turn cache on first derivation.
+    await new SessionTranscriptReader(
+      workspaceDir,
+      undefined,
+      runtimeDir,
+    ).readTurnIndexPage(SID.simple1, { limit: 2 });
+    expect(store!.turnIndexCache(SID.simple1)).not.toBeNull();
+  });
+
+  it('an appended turn appears identically in both modes (durable cache invalidation)', async () => {
+    const sessionId = SID.simple2;
+    async function total(): Promise<number> {
+      const page = await new SessionTranscriptReader(
+        workspaceDir,
+        undefined,
+        runtimeDir,
+      ).readTurnIndexPage(sessionId, { limit: 1 });
+      return page.totalTurns;
+    }
+    setMode('sqlite');
+    const beforeSqlite = await total();
+    setMode('file');
+    const beforeFile = await total();
+    expect(beforeFile).toBe(beforeSqlite);
+
+    // Append a fresh turn chain linked to the current leaf.
+    const filePath = path.join(chatsDir, `${sessionId}.jsonl`);
+    const raw = await fsp.readFile(filePath, 'utf8');
+    const lines = raw.trim().split('\n');
+    const last = JSON.parse(lines[lines.length - 1]) as { uuid: string };
+    const ts = Date.UTC(2026, 4, 1, 10, 0, 0);
+    const appended = [
+      rec({
+        uuid: `${sessionId}-uX`,
+        parentUuid: last.uuid,
+        sessionId,
+        ts,
+        text: 'post-cache prompt',
+      }),
+      rec({
+        uuid: `${sessionId}-aX`,
+        parentUuid: `${sessionId}-uX`,
+        sessionId,
+        ts: ts + 1,
+        type: 'assistant',
+        text: 'post-cache answer',
+      }),
+    ];
+    await fsp.appendFile(filePath, appended.join('\n') + '\n', 'utf8');
+
+    setMode('sqlite');
+    const afterSqlite = await total();
+    setMode('file');
+    const afterFile = await total();
+    expect(afterSqlite).toBe(afterFile);
+    expect(afterSqlite).toBe(beforeSqlite + 1);
+  });
+
+  it('an unparseable cursor yields an empty page in both modes', async () => {
+    for (const mode of ['file', 'sqlite'] as const) {
+      setMode(mode);
+      const page = await new SessionService(workspaceDir, {
+        runtimeBaseDir: runtimeDir,
+      }).listSessions({ size: 3, cursor: Number.NaN });
+      expect(mode, `mode=${mode}`).toBeTruthy();
+      expect(page.items, `mode=${mode}`).toEqual([]);
+      expect(page.hasMore, `mode=${mode}`).toBe(false);
+    }
+  });
+
+  it('a session created between sweeps is visible immediately in sqlite mode', async () => {
+    setMode('sqlite');
+    const service = new SessionService(workspaceDir, {
+      runtimeBaseDir: runtimeDir,
+    });
+    const before = (await service.listSessions({ size: 100 })).items.map(
+      (i) => i.sessionId,
+    );
+    // Create a brand-new session well inside the sweep TTL window.
+    const newId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    await writeSession(
+      newId,
+      [rec({ uuid: `${newId}-u1`, sessionId: newId, text: 'fresh prompt' })],
+      Date.now(),
+    );
+    const after = (await service.listSessions({ size: 100 })).items.map(
+      (i) => i.sessionId,
+    );
+    expect(before).not.toContain(newId);
+    expect(after[0]).toBe(newId);
+  });
+});

--- a/packages/core/src/services/session-index/sqlite.test.ts
+++ b/packages/core/src/services/session-index/sqlite.test.ts
@@ -1,0 +1,434 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  openSessionIndexStore,
+  resetSessionIndexDatabase,
+  sessionIndexDbPath,
+  SESSION_INDEX_DB_FILE,
+  SESSION_INDEX_SCHEMA_VERSION,
+  type SqliteDriver,
+} from './sqlite.js';
+import type { SessionIndexStore } from './types.js';
+
+let driver: SqliteDriver | undefined;
+try {
+  const specifier = 'node:sqlite';
+  driver = (await import(specifier)) as unknown as SqliteDriver;
+} catch {
+  driver = undefined;
+}
+
+const describeWithDriver = driver ? describe : describe.skip;
+
+let root: string;
+let projectDir: string;
+let chatsDir: string;
+
+function writeRecord(overrides: {
+  uuid: string;
+  parentUuid?: string | null;
+  sessionId: string;
+  timestamp?: string;
+  type?: string;
+  subtype?: string;
+  cwd?: string;
+  parts?: unknown[];
+  systemPayload?: unknown;
+  forkedFrom?: string;
+  provenance?: string;
+}): string {
+  const record: Record<string, unknown> = {
+    uuid: overrides.uuid,
+    parentUuid: overrides.parentUuid ?? null,
+    sessionId: overrides.sessionId,
+    timestamp: overrides.timestamp ?? new Date().toISOString(),
+    type: overrides.type ?? 'user',
+    cwd: overrides.cwd ?? '/tmp/workspace',
+    version: '1.0.0',
+    message: {
+      role: (overrides.type ?? 'user') === 'assistant' ? 'model' : 'user',
+      parts: overrides.parts ?? [{ text: `text-${overrides.uuid}` }],
+    },
+  };
+  if (overrides.subtype !== undefined) record['subtype'] = overrides.subtype;
+  if (overrides.systemPayload !== undefined)
+    record['systemPayload'] = overrides.systemPayload;
+  if (overrides.forkedFrom !== undefined)
+    record['forkedFrom'] = overrides.forkedFrom;
+  if (overrides.provenance !== undefined)
+    record['provenance'] = overrides.provenance;
+  return JSON.stringify(record);
+}
+
+async function writeLines(
+  filePath: string,
+  lines: string[],
+  mtime?: Date,
+): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, lines.join('\n') + '\n', 'utf8');
+  if (mtime) await fsp.utimes(filePath, mtime, mtime);
+}
+
+describeWithDriver('session-index/sqlite', () => {
+  let store: SessionIndexStore;
+
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'session-index-'));
+    projectDir = path.join(root, 'project');
+    chatsDir = path.join(projectDir, 'chats');
+    await fsp.mkdir(chatsDir, { recursive: true });
+    store = openSessionIndexStore(driver!, projectDir);
+  });
+
+  afterEach(async () => {
+    store.close();
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('indexes a file and rows round-trip with turn columns', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [
+      writeRecord({
+        uuid: 'u1',
+        sessionId: 's1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        parts: [{ text: 'hello world' }],
+        provenance: 'real_user',
+      }),
+      writeRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        sessionId: 's1',
+        type: 'assistant',
+        parts: [{ text: 'reply' }],
+      }),
+    ]);
+
+    await store.syncFile(filePath);
+
+    const session = store.sessionRow('s1');
+    expect(session).not.toBeNull();
+    expect(session!.fileName).toBe('s1.jsonl');
+    expect(session!.recordCount).toBe(2);
+    expect(session!.startTime).toBe('2026-01-01T00:00:00.000Z');
+    expect(session!.firstRecordUuid).toBe('u1');
+    expect(session!.indexedBytes).toBeGreaterThan(0);
+    expect(session!.status).toBe('ok');
+
+    const rows = store.recordRows('s1');
+    expect(rows).not.toBeNull();
+    expect(rows!.map((r) => r.uuid)).toEqual(['u1', 'a1']);
+    expect(rows![0].navKind).toBe('prompt');
+    expect(rows![0].conversation).toBe(true);
+    expect(rows![1].assistantPreview).toBe(true);
+    expect(rows![1].parentUuid).toBe('u1');
+  });
+
+  it('syncFile is a no-op when mtime and size are unchanged', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [writeRecord({ uuid: 'u1', sessionId: 's1' })]);
+    await store.syncFile(filePath);
+    const before = store.sessionRow('s1')!;
+    await store.syncFile(filePath);
+    const after = store.sessionRow('s1')!;
+    expect(after.indexedBytes).toBe(before.indexedBytes);
+    expect(after.recordCount).toBe(1);
+  });
+
+  it('incremental sync indexes only the appended tail', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [writeRecord({ uuid: 'u1', sessionId: 's1' })]);
+    await store.syncFile(filePath);
+    const first = store.sessionRow('s1')!;
+
+    await fsp.appendFile(
+      filePath,
+      writeRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        sessionId: 's1',
+        type: 'assistant',
+      }) + '\n',
+      'utf8',
+    );
+    await store.syncFile(filePath);
+    const second = store.sessionRow('s1')!;
+    expect(second.indexedBytes).toBeGreaterThan(first.indexedBytes);
+    expect(second.recordCount).toBe(2);
+    expect(store.recordRows('s1')!.map((r) => r.uuid)).toEqual(['u1', 'a1']);
+  });
+
+  it('excludes a partial trailing line until it is completed', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    const complete = writeRecord({ uuid: 'u1', sessionId: 's1' });
+    await writeLines(filePath, [complete]);
+    await store.syncFile(filePath);
+
+    await fsp.appendFile(filePath, '{"uuid":"u2","sessionId":"s1"', 'utf8');
+    await store.syncFile(filePath);
+    expect(store.recordRows('s1')!.map((r) => r.uuid)).toEqual(['u1']);
+
+    await fsp.appendFile(
+      filePath,
+      ',"parentUuid":null,"timestamp":"t","type":"user","message":{}}\n',
+      'utf8',
+    );
+    await store.syncFile(filePath);
+    expect(store.recordRows('s1')!.map((r) => r.uuid)).toEqual(['u1', 'u2']);
+  });
+
+  it('rewinds and rebuilds when the file shrinks', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [
+      writeRecord({ uuid: 'u1', sessionId: 's1' }),
+      writeRecord({ uuid: 'u2', parentUuid: 'u1', sessionId: 's1' }),
+    ]);
+    await store.syncFile(filePath);
+    expect(store.sessionRow('s1')!.recordCount).toBe(2);
+
+    await writeLines(filePath, [writeRecord({ uuid: 'v1', sessionId: 's1' })]);
+    await store.syncFile(filePath);
+    expect(store.sessionRow('s1')!.recordCount).toBe(1);
+    expect(store.recordRows('s1')!.map((r) => r.uuid)).toEqual(['v1']);
+  });
+
+  it('flags mismatched sessionId and withholds record rows', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [
+      writeRecord({ uuid: 'u1', sessionId: 'OTHER' }),
+    ]);
+    await store.syncFile(filePath);
+    expect(store.sessionRow('s1')!.status).toBe('mismatch');
+    expect(store.recordRows('s1')).toBeNull();
+  });
+
+  it('rebuilds the database when the schema version differs', async () => {
+    const dbPath = sessionIndexDbPath(projectDir);
+    store.close();
+    const raw = new driver!.DatabaseSync(dbPath);
+    raw.exec(
+      "INSERT INTO meta(key, value) VALUES ('schema_version', '999') " +
+        'ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+    );
+    raw.close();
+
+    store = openSessionIndexStore(driver!, projectDir);
+    const version = store.sessionRow('anything') === null; // store opened fine
+    expect(version).toBe(true);
+
+    const rawCheck = new driver!.DatabaseSync(dbPath);
+    const row = rawCheck
+      .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+      .get() as { value: string };
+    rawCheck.close();
+    expect(Number(row.value)).toBe(SESSION_INDEX_SCHEMA_VERSION);
+    expect(SESSION_INDEX_DB_FILE).toBe('sessions.index.sqlite');
+  });
+
+  it('syncDirectory indexes new files, skips unchanged, and GCs removed ones', async () => {
+    await writeLines(path.join(chatsDir, 'a.jsonl'), [
+      writeRecord({ uuid: 'u1', sessionId: 'a' }),
+    ]);
+    await writeLines(path.join(chatsDir, 'b.jsonl'), [
+      writeRecord({ uuid: 'u1', sessionId: 'b' }),
+    ]);
+
+    const examined = await store.syncDirectory(chatsDir, 0);
+    expect(examined).toBe(2);
+    expect(
+      store
+        .catalogRows()
+        .map((r) => r.sessionId)
+        .sort(),
+    ).toEqual(['a', 'b']);
+
+    const skipped = await store.syncDirectory(chatsDir, 60_000);
+    expect(skipped).toBe(-1);
+
+    await fsp.rm(path.join(chatsDir, 'b.jsonl'));
+    const afterGc = await store.syncDirectory(chatsDir, 0);
+    expect(afterGc).toBeGreaterThanOrEqual(1);
+    expect(store.catalogRows().map((r) => r.sessionId)).toEqual(['a']);
+    expect(store.sessionRow('b')).toBeNull();
+  });
+
+  it('extracts catalog label fields (prompt, cwd, gitBranch, creation metadata)', async () => {
+    const filePath = path.join(chatsDir, 's1.jsonl');
+    await writeLines(filePath, [
+      writeRecord({
+        uuid: 'sys1',
+        sessionId: 's1',
+        type: 'system',
+        subtype: 'parent_session',
+        cwd: '/work/proj',
+        systemPayload: { parentSessionId: 'parent-1' },
+      }),
+      writeRecord({
+        uuid: 'sys2',
+        sessionId: 's1',
+        type: 'system',
+        subtype: 'session_source',
+        cwd: '/work/proj',
+        systemPayload: { sourceType: 'fork', sourceId: 'src-1' },
+      }),
+      writeRecord({
+        uuid: 'u1',
+        sessionId: 's1',
+        cwd: '/work/proj',
+        parts: [{ text: 'the first prompt text' }],
+      }),
+      writeRecord({
+        uuid: 'a1',
+        parentUuid: 'u1',
+        sessionId: 's1',
+        type: 'assistant',
+      }),
+    ]);
+    await store.syncFile(filePath);
+
+    const row = store.catalogRows()[0];
+    expect(row.firstPrompt).toBe('the first prompt text');
+    expect(row.cwd).toBe('/work/proj');
+    expect(row.parentSessionId).toBe('parent-1');
+    expect(row.sourceType).toBe('fork');
+    expect(row.sourceId).toBe('src-1');
+  });
+
+  it('resetSessionIndexDatabase clears a corrupted database file so the store reopens empty', async () => {
+    store.close();
+    await fsp.mkdir(projectDir, { recursive: true });
+    await fsp.writeFile(
+      sessionIndexDbPath(projectDir),
+      'not a sqlite database at all',
+      'utf8',
+    );
+    await resetSessionIndexDatabase(projectDir);
+    store = openSessionIndexStore(driver!, projectDir);
+    expect(store.catalogRows()).toEqual([]);
+  });
+
+  it('drops turns_cache rows when a session file is GCed', async () => {
+    const filePath = path.join(chatsDir, 'gc.jsonl');
+    await writeLines(filePath, [writeRecord({ uuid: 'u1', sessionId: 'gc' })]);
+    await store.syncFile(filePath);
+    store.putTurnIndexCache('gc', {
+      indexedBytes: 10,
+      leafUuid: 'u1',
+      startTime: null,
+      totalTurns: 1,
+      turns: [{ turnId: 'u1', replayPosition: 0, kind: 'prompt' }],
+    });
+    expect(store.turnIndexCache('gc')).not.toBeNull();
+    await fsp.rm(filePath);
+    await store.syncDirectory(chatsDir, 0);
+    expect(store.sessionRow('gc')).toBeNull();
+    expect(store.turnIndexCache('gc')).toBeNull();
+  });
+
+  it('drops turns_cache rows when a file is rewind-rebuilt', async () => {
+    const filePath = path.join(chatsDir, 'rw.jsonl');
+    await writeLines(filePath, [
+      writeRecord({ uuid: 'u1', sessionId: 'rw' }),
+      writeRecord({ uuid: 'u2', parentUuid: 'u1', sessionId: 'rw' }),
+    ]);
+    await store.syncFile(filePath);
+    store.putTurnIndexCache('rw', {
+      indexedBytes: 10,
+      leafUuid: 'u2',
+      startTime: null,
+      totalTurns: 2,
+      turns: [{ turnId: 'u1', replayPosition: 0, kind: 'prompt' }],
+    });
+    expect(store.turnIndexCache('rw')).not.toBeNull();
+    await writeLines(filePath, [writeRecord({ uuid: 'v1', sessionId: 'rw' })]);
+    await store.syncFile(filePath);
+    expect(store.turnIndexCache('rw')).toBeNull();
+  });
+
+  it('converges firstPrompt after an empty-prompt first sync (startup race)', async () => {
+    const filePath = path.join(chatsDir, 'race.jsonl');
+    // First sync sees only the system record (a listing raced session startup)
+    await writeLines(filePath, [
+      writeRecord({
+        uuid: 'sys1',
+        sessionId: 'race',
+        type: 'system',
+        subtype: 'checkpoint',
+      }),
+    ]);
+    await store.syncFile(filePath);
+    expect(store.catalogRows()[0].firstPrompt).toBe('');
+    // The first user prompt lands afterwards — still inside the head window
+    await fsp.appendFile(
+      filePath,
+      writeRecord({
+        uuid: 'u1',
+        sessionId: 'race',
+        parts: [{ text: 'late prompt' }],
+      }) + '\n',
+      'utf8',
+    );
+    await store.syncFile(filePath);
+    expect(store.catalogRows()[0].firstPrompt).toBe('late prompt');
+  });
+
+  it('indexes later fragments of the same uuid as their own rows', async () => {
+    const filePath = path.join(chatsDir, 'frag.jsonl');
+    const base = {
+      uuid: 'shared',
+      parentUuid: null,
+      sessionId: 'frag',
+      timestamp: new Date().toISOString(),
+      type: 'assistant',
+      cwd: '/tmp/workspace',
+      version: '1.0.0',
+      message: { role: 'model', parts: [{ text: 'original' }] },
+    };
+    const amended = {
+      ...base,
+      message: { role: 'model', parts: [{ text: 'amended patch' }] },
+      usageMetadata: { outputTokenCount: 5 },
+    };
+    await writeLines(filePath, [JSON.stringify(base), JSON.stringify(amended)]);
+    await store.syncFile(filePath);
+    const rows = store.recordRows('frag')!;
+    const shared = rows.filter((r) => r.uuid === 'shared');
+    expect(shared.length).toBe(2);
+    expect(shared[0].assistantPreview).toBe(true);
+    expect(new Set(shared.map((r) => r.offset)).size).toBe(2);
+  });
+
+  it('orders catalog rows by mtime descending', async () => {
+    const t = (n: number) => new Date(Date.UTC(2026, 0, n));
+    await writeLines(
+      path.join(chatsDir, 'old.jsonl'),
+      [writeRecord({ uuid: 'u1', sessionId: 'old' })],
+      t(1),
+    );
+    await writeLines(
+      path.join(chatsDir, 'new.jsonl'),
+      [writeRecord({ uuid: 'u1', sessionId: 'new' })],
+      t(3),
+    );
+    await writeLines(
+      path.join(chatsDir, 'mid.jsonl'),
+      [writeRecord({ uuid: 'u1', sessionId: 'mid' })],
+      t(2),
+    );
+    await store.syncDirectory(chatsDir, 0);
+    expect(store.catalogRows().map((r) => r.sessionId)).toEqual([
+      'new',
+      'mid',
+      'old',
+    ]);
+  });
+});

--- a/packages/core/src/services/session-index/sqlite.ts
+++ b/packages/core/src/services/session-index/sqlite.ts
@@ -1,0 +1,1173 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// node:sqlite-backed session index sidecar. The JSONL transcripts stay the
+// sole authoritative store; this database only mirrors, per file, exactly
+// the bytes it has consumed (indexedBytes checkpoint), so it can always be
+// deleted and rebuilt. See docs/design/session-sqlite-sidecar.md.
+
+import type * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { createDebugLogger } from '../../utils/debugLogger.js';
+import * as jsonl from '../../utils/jsonl-utils.js';
+import {
+  isTranscriptConversationRecord,
+  validateTranscriptRecord,
+} from '../../utils/transcript-records.js';
+import { readSessionTitleInfoFromFileSync } from '../../utils/sessionStorageUtils.js';
+import {
+  isTurnResultRecordPayload,
+  type ChatRecord,
+} from '../chatRecordingService.js';
+import { parseGoalStateRecordPayloadV2 } from '../../goals/goal-reducer.js';
+import { recoverGoalFromRecords } from '../../goals/goal-persistence.js';
+import {
+  isAssistantPreviewCandidate,
+  navigationKindForRecord,
+  type SessionTranscriptNavigationTurnKind,
+} from './nav-hints.js';
+import type {
+  SessionIndexCatalogRow,
+  SessionIndexRecordRow,
+  SessionIndexSessionRow,
+  SessionIndexSegment,
+  SessionIndexStore,
+  SessionIndexTurnCache,
+  SessionIndexTurnHint,
+} from './types.js';
+
+const debugLogger = createDebugLogger('SESSION_INDEX');
+
+export const SESSION_INDEX_SCHEMA_VERSION = 3;
+export const SESSION_INDEX_DB_FILE = 'sessions.index.sqlite';
+
+/** Mirrors MAX_PROMPT_SCAN_LINES in sessionService.ts (kept private there). */
+const PROMPT_SCAN_HEAD_RECORDS = 10;
+/** Mirrors TAIL_READ_SIZE in sessionService.ts (source tail fallback window). */
+const SOURCE_TAIL_WINDOW_BYTES = 64 * 1024;
+const PROMPT_DISPLAY_MAX_CODEPOINTS = 200;
+const SCAN_CHUNK_BYTES = 4 * 1024 * 1024;
+
+export function sessionIndexDbPath(projectDir: string): string {
+  return path.join(projectDir, SESSION_INDEX_DB_FILE);
+}
+
+export async function resetSessionIndexDatabase(
+  projectDir: string,
+): Promise<void> {
+  const dbPath = sessionIndexDbPath(projectDir);
+  await fsp.rm(dbPath, { force: true });
+  await fsp.rm(`${dbPath}-wal`, { force: true });
+  await fsp.rm(`${dbPath}-shm`, { force: true });
+}
+
+interface SqliteStatement {
+  run(...params: unknown[]): unknown;
+  get(...params: unknown[]): unknown;
+  all(...params: unknown[]): unknown[];
+}
+
+interface SqliteDatabase {
+  exec(sql: string): void;
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+}
+
+export interface SqliteDriver {
+  DatabaseSync: new (path: string) => SqliteDatabase;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS meta(key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE IF NOT EXISTS sessions(
+  sessionId TEXT PRIMARY KEY,
+  fileName TEXT NOT NULL UNIQUE,
+  mtimeMs INTEGER NOT NULL,
+  sizeBytes INTEGER NOT NULL,
+  startTime TEXT,
+  firstRecordUuid TEXT,
+  firstRecordTimestamp TEXT,
+  firstRecordSessionId TEXT,
+  firstPrompt TEXT,
+  cwd TEXT,
+  gitBranch TEXT,
+  customTitle TEXT,
+  titleSource TEXT,
+  goalObjective TEXT,
+  parentSessionId TEXT,
+  sourceType TEXT,
+  sourceId TEXT,
+  recordCount INTEGER NOT NULL,
+  indexedBytes INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ok'
+);
+CREATE INDEX IF NOT EXISTS sessions_mtime ON sessions(mtimeMs DESC);
+CREATE TABLE IF NOT EXISTS records(
+  sessionId TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  uuid TEXT NOT NULL,
+  parentUuid TEXT,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  timestamp TEXT,
+  offset INTEGER NOT NULL,
+  length INTEGER NOT NULL,
+  conversation INTEGER NOT NULL DEFAULT 0,
+  inherited INTEGER NOT NULL DEFAULT 0,
+  sideTaskSource INTEGER NOT NULL DEFAULT 0,
+  navKind TEXT,
+  assistantPreview INTEGER NOT NULL DEFAULT 0,
+  turnResultPromptId TEXT,
+  PRIMARY KEY(sessionId, seq)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS records_uuid ON records(sessionId, uuid);
+CREATE TABLE IF NOT EXISTS turns_cache(
+  sessionId TEXT PRIMARY KEY,
+  indexedBytes INTEGER NOT NULL,
+  leafUuid TEXT NOT NULL,
+  startTime TEXT,
+  totalTurns INTEGER NOT NULL,
+  turnsJson TEXT NOT NULL
+);
+`;
+
+function truncatePromptForDisplay(text: string): string {
+  const codePoints: string[] = [];
+  for (const codePoint of text) {
+    if (codePoints.length === PROMPT_DISPLAY_MAX_CODEPOINTS) {
+      return `${codePoints.join('')}...`;
+    }
+    codePoints.push(codePoint);
+  }
+  return text;
+}
+
+/** Mirrors SessionService.extractFirstPromptFromRecords. */
+function extractFirstPromptFromRecords(records: ChatRecord[]): string {
+  for (const record of records) {
+    if (record.type !== 'user' || record.subtype !== undefined) continue;
+    const payload = record.systemPayload as
+      | { displayText?: unknown }
+      | undefined;
+    if (payload?.displayText !== undefined) {
+      if (typeof payload.displayText === 'string' && payload.displayText) {
+        return truncatePromptForDisplay(payload.displayText);
+      }
+      continue;
+    }
+    for (const part of record.message?.parts ?? []) {
+      if (
+        typeof part === 'object' &&
+        part !== null &&
+        'text' in part &&
+        typeof (part as { text?: unknown }).text === 'string'
+      ) {
+        const text = (part as { text: string }).text;
+        const truncated = truncatePromptForDisplay(text);
+        if (truncated) return truncated;
+        break;
+      }
+    }
+  }
+  return '';
+}
+
+/** Reads [startOffset, endOffset) of a file line by line. */
+async function forEachLineInRange(
+  filePath: string,
+  startOffset: number,
+  endOffset: number,
+  onLine: (line: Buffer, offset: number, length: number) => void,
+): Promise<number> {
+  const fh = await fsp.open(filePath, 'r');
+  try {
+    const buffer = Buffer.allocUnsafe(SCAN_CHUNK_BYTES);
+    let position = startOffset;
+    let carry = Buffer.alloc(0);
+    let carryStart = startOffset;
+    let consumed = startOffset;
+    while (position < endOffset) {
+      const want = Math.min(SCAN_CHUNK_BYTES, endOffset - position);
+      const { bytesRead } = await fh.read(buffer, 0, want, position);
+      if (bytesRead === 0) break;
+      const chunk = Buffer.concat([carry, buffer.subarray(0, bytesRead)]);
+      const base = carryStart;
+      let lineStart = 0;
+      let newline: number;
+      while ((newline = chunk.indexOf(0x0a, lineStart)) >= 0) {
+        const line = chunk.subarray(lineStart, newline);
+        onLine(line, base + lineStart, line.length);
+        lineStart = newline + 1;
+      }
+      consumed = base + lineStart;
+      carry = chunk.subarray(lineStart);
+      carryStart = base + lineStart;
+      position += bytesRead;
+    }
+    return consumed;
+  } finally {
+    await fh.close();
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** First `limit` validated records of a transcript, read from byte 0. */
+async function readHeadChatRecords(
+  filePath: string,
+  sizeBytes: number,
+  limit = 10,
+): Promise<ChatRecord[]> {
+  const head: ChatRecord[] = [];
+  await forEachLineInRange(filePath, 0, sizeBytes, (line) => {
+    if (head.length >= limit) return;
+    const text = line.toString('utf8').trim();
+    if (text.length === 0) return;
+    for (const value of jsonl.parseLineTolerant<unknown>(text, filePath)) {
+      if (head.length >= limit) break;
+      const record = validateTranscriptRecord(value).record;
+      if (record) head.push(record as unknown as ChatRecord);
+    }
+  });
+  return head;
+}
+
+interface SyncedRecordRow {
+  seq: number;
+  uuid: string;
+  parentUuid: string | null;
+  type: string;
+  subtype: string | null;
+  timestamp: string | null;
+  offset: number;
+  length: number;
+  conversation: boolean;
+  inherited: boolean;
+  sideTaskSource: boolean;
+  navKind: SessionTranscriptNavigationTurnKind | null;
+  assistantPreview: boolean;
+  turnResultPromptId: string | null;
+}
+
+class SqliteSessionIndexStore implements SessionIndexStore {
+  private readonly db: SqliteDatabase;
+  private lastDirSweepMs = 0;
+  // Serializes sync operations: one shared connection must never interleave
+  // two `BEGIN … await … COMMIT` windows, so concurrent callers queue here.
+  private syncQueue: Promise<unknown> = Promise.resolve();
+
+  private enqueueSync<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.syncQueue.then(fn, fn);
+    this.syncQueue = run.catch(() => undefined);
+    return run;
+  }
+
+  constructor(driver: SqliteDriver, projectDir: string) {
+    const dbPath = sessionIndexDbPath(projectDir);
+    this.db = new driver.DatabaseSync(dbPath);
+    this.db.exec('PRAGMA journal_mode=WAL');
+    this.db.exec('PRAGMA synchronous=NORMAL');
+    this.db.exec('PRAGMA busy_timeout=2000');
+    this.db.exec(SCHEMA);
+    this.migrate();
+  }
+
+  private migrate(): void {
+    const row = this.db
+      .prepare(`SELECT value FROM meta WHERE key = 'schema_version'`)
+      .get() as { value?: unknown } | undefined;
+    const version = typeof row?.value === 'string' ? Number(row.value) : 0;
+    if (version === SESSION_INDEX_SCHEMA_VERSION) return;
+    debugLogger.debug(
+      `session index schema mismatch (${version} -> ${SESSION_INDEX_SCHEMA_VERSION}), rebuilding`,
+    );
+    this.db.exec(
+      'DROP TABLE IF EXISTS records; DROP TABLE IF EXISTS sessions; DROP TABLE IF EXISTS turns_cache;',
+    );
+    this.db.exec(SCHEMA);
+    this.db
+      .prepare(
+        `INSERT INTO meta(key, value) VALUES ('schema_version', ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(String(SESSION_INDEX_SCHEMA_VERSION));
+    this.lastDirSweepMs = 0;
+  }
+
+  syncDirectory(chatsDir: string, minIntervalMs = 30_000): Promise<number> {
+    return this.enqueueSync(async () => {
+      let entries: string[];
+      try {
+        entries = await fsp.readdir(chatsDir);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          entries = [];
+        } else {
+          throw error;
+        }
+      }
+      const fileNames = new Set(entries.filter((e) => e.endsWith('.jsonl')));
+
+      // The names pass runs on EVERY call — a session created or deleted in
+      // the TTL window must never be invisible to (or linger in) listings.
+      // Only the per-file stat sweep is throttled.
+      const known = this.db
+        .prepare('SELECT fileName FROM sessions')
+        .all() as Array<{ fileName: string }>;
+      const deleteByFileName = this.db.prepare(
+        'DELETE FROM sessions WHERE fileName = ?',
+      );
+      const deleteRecords = this.db.prepare(
+        'DELETE FROM records WHERE sessionId = (SELECT sessionId FROM sessions WHERE fileName = ?)',
+      );
+      const deleteTurnsCache = this.db.prepare(
+        'DELETE FROM turns_cache WHERE sessionId = (SELECT sessionId FROM sessions WHERE fileName = ?)',
+      );
+      this.db.exec('BEGIN');
+      try {
+        for (const { fileName } of known) {
+          if (!fileNames.has(fileName)) {
+            deleteRecords.run(fileName);
+            deleteTurnsCache.run(fileName);
+            deleteByFileName.run(fileName);
+          }
+        }
+        this.db.exec('COMMIT');
+      } catch (error) {
+        this.db.exec('ROLLBACK');
+        throw error;
+      }
+
+      // Brand-new files are indexed immediately even inside the TTL window:
+      // they have no catalog row at all, so there is nothing to throttle.
+      const now = Date.now();
+      const sweepDue =
+        this.lastDirSweepMs === 0 || now - this.lastDirSweepMs >= minIntervalMs;
+      const skipFreshness = this.db.prepare(
+        'SELECT mtimeMs, sizeBytes FROM sessions WHERE fileName = ?',
+      );
+
+      let examined = 0;
+      for (const fileName of fileNames) {
+        const filePath = path.join(chatsDir, fileName);
+        const existing = skipFreshness.get(fileName) as
+          | { mtimeMs: number; sizeBytes: number }
+          | undefined;
+        if (!sweepDue && existing) continue;
+        let stats: fs.Stats;
+        try {
+          stats = await fsp.stat(filePath);
+        } catch {
+          continue;
+        }
+        examined++;
+        if (
+          existing &&
+          existing.mtimeMs === stats.mtimeMs &&
+          existing.sizeBytes === stats.size
+        ) {
+          continue;
+        }
+        await this.syncFileInTransaction(filePath, stats);
+      }
+      if (sweepDue) this.lastDirSweepMs = Date.now();
+      return sweepDue ? examined : -1;
+    });
+  }
+
+  syncFile(filePath: string): Promise<void> {
+    return this.enqueueSync(async () => {
+      const stats = await fsp.stat(filePath);
+      const existing = this.db
+        .prepare('SELECT mtimeMs, sizeBytes FROM sessions WHERE fileName = ?')
+        .get(path.basename(filePath)) as
+        | { mtimeMs: number; sizeBytes: number }
+        | undefined;
+      if (
+        existing &&
+        existing.mtimeMs === stats.mtimeMs &&
+        existing.sizeBytes === stats.size
+      ) {
+        return;
+      }
+      await this.syncFileInTransaction(filePath, stats);
+    });
+  }
+
+  private async syncFileInTransaction(
+    filePath: string,
+    stats: fs.Stats,
+  ): Promise<void> {
+    this.db.exec('BEGIN');
+    try {
+      await this.syncFileLocked(filePath, stats);
+      this.db.exec('COMMIT');
+    } catch (error) {
+      this.db.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  private async syncFileLocked(
+    filePath: string,
+    stats: fs.Stats,
+  ): Promise<void> {
+    const fileName = path.basename(filePath);
+    if (!fileName.endsWith('.jsonl')) return;
+    const sessionId = fileName.slice(0, -'.jsonl'.length);
+    const sizeBytes = stats.size;
+
+    const existing = this.db
+      .prepare(
+        'SELECT sessionId, indexedBytes, recordCount, status FROM sessions WHERE sessionId = ?',
+      )
+      .get(sessionId) as
+      | {
+          sessionId: string;
+          indexedBytes: number;
+          recordCount: number;
+          status: string;
+        }
+      | undefined;
+
+    let startAt = 0;
+    let seq = 0;
+    let rewound = false;
+    if (existing) {
+      if (existing.indexedBytes <= sizeBytes) {
+        startAt = existing.indexedBytes;
+        seq = (
+          this.db
+            .prepare(
+              'SELECT COALESCE(MAX(seq) + 1, 0) AS nextSeq FROM records WHERE sessionId = ?',
+            )
+            .get(sessionId) as { nextSeq: number }
+        ).nextSeq;
+      } else {
+        // File shrank or was replaced: rewind and rebuild from zero. The
+        // JSONL is the only authority; sidecar bytes are never "repaired".
+        this.db
+          .prepare('DELETE FROM records WHERE sessionId = ?')
+          .run(sessionId);
+        this.db
+          .prepare('DELETE FROM turns_cache WHERE sessionId = ?')
+          .run(sessionId);
+        this.db
+          .prepare('DELETE FROM sessions WHERE sessionId = ?')
+          .run(sessionId);
+        rewound = true;
+      }
+    }
+    const priorRecordCount = rewound ? 0 : (existing?.recordCount ?? 0);
+    const priorMismatch = !rewound && existing?.status === 'mismatch';
+
+    // State accumulated over the whole file (carried across incremental scans
+    // via the previous session row where flagged as resumed below).
+    const resumed = startAt > 0;
+    const headRecords: ChatRecord[] = [];
+    const rows: SyncedRecordRow[] = [];
+    /** uuid -> index into `rows`, scoped to this file (fragment merging). */
+    const rowIndexByUuid = new Map<string, number>();
+    if (resumed) {
+      const prior = this.db
+        .prepare(
+          'SELECT seq, uuid, type, subtype, navKind, assistantPreview FROM records WHERE sessionId = ?',
+        )
+        .all(sessionId) as Array<{
+        seq: number;
+        uuid: string;
+        type: string;
+        subtype: string | null;
+        navKind: string | null;
+        assistantPreview: number;
+      }>;
+      // Fragment merging in a resumed scan only matters when a new fragment
+      // of an already-seen uuid arrives; keep the map light.
+      for (const priorRow of prior) {
+        if (!rowIndexByUuid.has(priorRow.uuid)) {
+          rowIndexByUuid.set(priorRow.uuid, -priorRow.seq - 1);
+        }
+      }
+    }
+    let recordCount = 0;
+    let sessionMismatch = false;
+    let firstRecordUuid: string | null = null;
+    let firstRecordSessionId: string | null = null;
+    let firstRecordTimestamp: string | null = null;
+    let firstConversationStartTime: string | null = null;
+    let firstPrompt = '';
+    let cwd: string | null = null;
+    let gitBranch: string | null = null;
+    let lastGoal: {
+      matched: boolean;
+      value: string | undefined;
+      offset: number;
+    } = {
+      matched: false,
+      value: undefined,
+      offset: -1,
+    };
+    // Creation metadata mirrors SessionService.extractCreationMetadataFromFile:
+    // head records first (they carry parent_session / session_source written
+    // at creation), with a last-tail-window session_source fallback only when
+    // the head carried no sourceType.
+    let headParentSessionId: string | undefined;
+    let headSource: { sourceType?: string; sourceId?: string } = {};
+    let tailSourceLast:
+      | { sourceType: string; sourceId?: string; offset: number }
+      | undefined;
+
+    const consumed = await forEachLineInRange(
+      filePath,
+      startAt,
+      sizeBytes,
+      (line, offset, length) => {
+        const text = line.toString('utf8').trim();
+        if (text.length === 0) return;
+        let fragmentIndex = 0;
+        for (const value of jsonl.parseLineTolerant<unknown>(text, filePath)) {
+          const record = validateTranscriptRecord(value).record;
+          if (!record) continue;
+          const seqNow = seq++;
+          if (recordCount === 0 && !resumed && firstRecordUuid === null) {
+            firstRecordUuid = record.uuid;
+            firstRecordSessionId = record.sessionId ?? null;
+            firstRecordTimestamp = record.timestamp ?? null;
+            cwd = (record as unknown as ChatRecord).cwd ?? null;
+            gitBranch = (record as unknown as ChatRecord).gitBranch ?? null;
+          }
+          recordCount++;
+          if (record.sessionId !== sessionId) sessionMismatch = true;
+          if (headRecords.length < PROMPT_SCAN_HEAD_RECORDS) {
+            headRecords.push(record as unknown as ChatRecord);
+          }
+
+          const chatRecord = record as unknown as ChatRecord;
+          const conversation = isTranscriptConversationRecord(record);
+          if (
+            conversation &&
+            record.timestamp &&
+            firstConversationStartTime === null
+          ) {
+            firstConversationStartTime = record.timestamp;
+          }
+          const sideTaskSource =
+            record.type === 'system' &&
+            record.subtype === 'session_source' &&
+            isObjectRecord(record.systemPayload) &&
+            record.systemPayload['sourceType'] === 'side_task';
+
+          if (record.type === 'system' && record.subtype === 'goal_state') {
+            const payload = parseGoalStateRecordPayloadV2(record.systemPayload);
+            lastGoal = {
+              matched: true,
+              value: payload?.snapshot.goal?.objective,
+              offset,
+            };
+          }
+          // Head-window membership is file-global (the legacy path slices
+          // the first 10 records of the whole file), never scan-local —
+          // resumed syncs must not re-evaluate "headness" on appended rows.
+          const globalRecordIndex = priorRecordCount + recordCount - 1;
+          const inHeadWindow =
+            !resumed && globalRecordIndex < PROMPT_SCAN_HEAD_RECORDS;
+          if (
+            inHeadWindow &&
+            record.type === 'system' &&
+            record.subtype === 'parent_session' &&
+            headParentSessionId === undefined
+          ) {
+            const payload = record.systemPayload as
+              | { parentSessionId?: unknown }
+              | undefined;
+            if (typeof payload?.parentSessionId === 'string') {
+              headParentSessionId = payload.parentSessionId;
+            }
+          }
+          if (record.type === 'system' && record.subtype === 'session_source') {
+            const payload = record.systemPayload as
+              | { sourceType?: unknown; sourceId?: unknown }
+              | undefined;
+            if (typeof payload?.sourceType === 'string') {
+              const candidate = {
+                sourceType: payload.sourceType,
+                ...(typeof payload.sourceId === 'string'
+                  ? { sourceId: payload.sourceId }
+                  : {}),
+              };
+              // Head window: first source wins (legacy head path); later
+              // records: remember the last one within the tail window.
+              if (inHeadWindow && headSource.sourceType === undefined) {
+                headSource = candidate;
+              } else {
+                tailSourceLast = { ...candidate, offset };
+              }
+            }
+          }
+
+          const turnResultPromptId =
+            record.subtype === 'turn_result' &&
+            isTurnResultRecordPayload(record.systemPayload)
+              ? record.systemPayload.promptId
+              : null;
+
+          const fragmentRow: SyncedRecordRow = {
+            seq: seqNow,
+            uuid: record.uuid,
+            parentUuid: record.parentUuid ?? null,
+            type: record.type,
+            subtype: record.subtype ?? null,
+            timestamp: record.timestamp ?? null,
+            offset,
+            length,
+            conversation,
+            inherited: record.forkedFrom !== undefined,
+            sideTaskSource,
+            navKind: navigationKindForRecord(chatRecord) ?? null,
+            assistantPreview: isAssistantPreviewCandidate(chatRecord),
+            turnResultPromptId,
+          };
+          void fragmentIndex++;
+
+          const existingIndex = rowIndexByUuid.get(record.uuid);
+          if (existingIndex === undefined) {
+            rowIndexByUuid.set(record.uuid, rows.length);
+            rows.push(fragmentRow);
+          } else if (existingIndex >= 0) {
+            // Later fragment of an already-indexed uuid: merge navigation
+            // columns into the first fragment row, same as buildIndex. The
+            // fragment itself is still indexed (with empty nav columns) so
+            // segment reads can re-aggregate every occurrence of the uuid.
+            const target = rows[existingIndex];
+            const merged = {
+              ...chatRecord,
+              type: target.type,
+              subtype: target.subtype ?? undefined,
+            } as ChatRecord;
+            if (target.navKind === null) {
+              target.navKind = navigationKindForRecord(merged) ?? null;
+            }
+            if (!target.assistantPreview) {
+              target.assistantPreview = isAssistantPreviewCandidate(merged);
+            }
+            rows.push({
+              ...fragmentRow,
+              navKind: null,
+              assistantPreview: false,
+            });
+          } else {
+            // Fragment of a uuid indexed in an earlier scan window: merge
+            // into the stored row in place.
+            const priorSeq = -existingIndex - 1;
+            const stored = this.db
+              .prepare(
+                'SELECT type, subtype, navKind, assistantPreview FROM records WHERE sessionId = ? AND seq = ?',
+              )
+              .get(sessionId, priorSeq) as
+              | {
+                  type: string;
+                  subtype: string | null;
+                  navKind: string | null;
+                  assistantPreview: number;
+                }
+              | undefined;
+            if (stored) {
+              const merged = {
+                ...chatRecord,
+                type: stored.type,
+                subtype: stored.subtype ?? undefined,
+              } as ChatRecord;
+              const navKind =
+                stored.navKind ?? navigationKindForRecord(merged) ?? null;
+              const assistantPreview =
+                stored.assistantPreview === 1 ||
+                isAssistantPreviewCandidate(merged);
+              this.db
+                .prepare(
+                  'UPDATE records SET navKind = ?, assistantPreview = ? WHERE sessionId = ? AND seq = ?',
+                )
+                .run(navKind, assistantPreview ? 1 : 0, sessionId, priorSeq);
+            }
+            rows.push({
+              ...fragmentRow,
+              navKind: null,
+              assistantPreview: false,
+            });
+          }
+        }
+      },
+    );
+
+    // Listing-label fields: prompt from the head records, title from the
+    // shared tail-anchored helper, goal objective via the same resolution
+    // policy SessionService.resolveGoalObjective implements.
+    let resumedHeadRecords: ChatRecord[] | undefined;
+    const headRecordsForResume = async (): Promise<ChatRecord[]> => {
+      resumedHeadRecords ??= await readHeadChatRecords(filePath, sizeBytes);
+      return resumedHeadRecords;
+    };
+    if (!resumed) {
+      firstPrompt = extractFirstPromptFromRecords(headRecords);
+    } else {
+      const updatedHead = this.db
+        .prepare('SELECT firstPrompt FROM sessions WHERE sessionId = ?')
+        .get(sessionId) as { firstPrompt?: string } | undefined;
+      firstPrompt = updatedHead?.firstPrompt ?? '';
+      if (!firstPrompt) {
+        // The sync that stored the empty prompt ran before the first user
+        // prompt landed (a picker refresh racing session startup). Re-read
+        // the head once so the catalog label converges with the scan path.
+        firstPrompt = extractFirstPromptFromRecords(
+          await headRecordsForResume(),
+        );
+      }
+    }
+    if (resumed) {
+      // Creation metadata written AFTER the first sync (session startup
+      // raced a listing) must still land — re-check the head only when the
+      // stored row is missing it.
+      const priorMeta = this.db
+        .prepare(
+          'SELECT parentSessionId, sourceType, sourceId FROM sessions WHERE sessionId = ?',
+        )
+        .get(sessionId) as
+        | {
+            parentSessionId?: string | null;
+            sourceType?: string | null;
+            sourceId?: string | null;
+          }
+        | undefined;
+      if (!priorMeta?.parentSessionId || !priorMeta.sourceType) {
+        for (const record of await headRecordsForResume()) {
+          if (
+            record.type === 'system' &&
+            record.subtype === 'parent_session' &&
+            headParentSessionId === undefined
+          ) {
+            const payload = record.systemPayload as
+              | { parentSessionId?: unknown }
+              | undefined;
+            if (typeof payload?.parentSessionId === 'string') {
+              headParentSessionId = payload.parentSessionId;
+            }
+          }
+          if (
+            record.type === 'system' &&
+            record.subtype === 'session_source' &&
+            headSource.sourceType === undefined
+          ) {
+            const payload = record.systemPayload as
+              | { sourceType?: unknown; sourceId?: unknown }
+              | undefined;
+            if (typeof payload?.sourceType === 'string') {
+              headSource = {
+                sourceType: payload.sourceType,
+                ...(typeof payload.sourceId === 'string'
+                  ? { sourceId: payload.sourceId }
+                  : {}),
+              };
+            }
+          }
+        }
+      }
+    }
+    const titleInfo = readSessionTitleInfoFromFileSync(filePath);
+    let goalObjective: string | null = null;
+    if (!firstPrompt && !titleInfo.title) {
+      const totalRecords =
+        (resumed
+          ? ((
+              this.db
+                .prepare(
+                  'SELECT COUNT(*) AS c FROM records WHERE sessionId = ?',
+                )
+                .get(sessionId) as { c: number }
+            ).c ?? 0)
+          : 0) + rows.length;
+      if (!resumed && totalRecords < PROMPT_SCAN_HEAD_RECORDS) {
+        const recovery = recoverGoalFromRecords(headRecords);
+        const objective =
+          recovery.kind === 'v2'
+            ? recovery.payload.snapshot.goal?.objective
+            : recovery.kind === 'legacy'
+              ? recovery.objective
+              : undefined;
+        goalObjective = objective ? truncatePromptForDisplay(objective) : null;
+      } else if (
+        lastGoal.matched &&
+        lastGoal.offset >= sizeBytes - SOURCE_TAIL_WINDOW_BYTES
+      ) {
+        // Legacy probes only the last 64 KiB for the goal objective: a hit
+        // beyond the tail window may belong to a cleared goal and is left
+        // unlabelled there, so the sidecar must not label it either.
+        goalObjective = lastGoal.value
+          ? truncatePromptForDisplay(lastGoal.value)
+          : null;
+      } else if (resumed) {
+        const priorGoal = this.db
+          .prepare('SELECT goalObjective FROM sessions WHERE sessionId = ?')
+          .get(sessionId) as { goalObjective?: string | null } | undefined;
+        goalObjective = priorGoal?.goalObjective ?? null;
+      }
+    }
+
+    const insertRecord = this.db.prepare(
+      `INSERT INTO records(
+        sessionId, seq, uuid, parentUuid, type, subtype, timestamp,
+        offset, length, conversation, inherited, sideTaskSource,
+        navKind, assistantPreview, turnResultPromptId
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const row of rows) {
+      insertRecord.run(
+        sessionId,
+        row.seq,
+        row.uuid,
+        row.parentUuid,
+        row.type,
+        row.subtype,
+        row.timestamp,
+        row.offset,
+        row.length,
+        row.conversation ? 1 : 0,
+        row.inherited ? 1 : 0,
+        row.sideTaskSource ? 1 : 0,
+        row.navKind,
+        row.assistantPreview ? 1 : 0,
+        row.turnResultPromptId,
+      );
+    }
+
+    // Full-precision float mtime, same as the scan path: flooring would
+    // widen the equal-mtime class that the strict `<` cursor drops.
+    const mtimeMs = stats.mtimeMs;
+    const previous = this.db
+      .prepare(
+        'SELECT startTime, firstPrompt, cwd, gitBranch, firstRecordUuid, firstRecordTimestamp, firstRecordSessionId, parentSessionId, sourceType, sourceId, customTitle, titleSource, goalObjective FROM sessions WHERE sessionId = ?',
+      )
+      .get(sessionId) as
+      | (Partial<SessionIndexSessionRow> & {
+          firstPrompt?: string;
+          cwd?: string;
+          gitBranch?: string;
+          customTitle?: string;
+          titleSource?: string;
+          goalObjective?: string | null;
+          parentSessionId?: string;
+          sourceType?: string;
+          sourceId?: string;
+        })
+      | undefined;
+
+    // Source fallback mirrors SessionService.extractCreationMetadataFromFile:
+    // only consulted when the head records carried no sourceType, and only a
+    // session_source inside the last SOURCE_TAIL_WINDOW_BYTES qualifies.
+    const tailAccepted =
+      headSource.sourceType === undefined &&
+      tailSourceLast !== undefined &&
+      tailSourceLast.offset >= sizeBytes - SOURCE_TAIL_WINDOW_BYTES
+        ? tailSourceLast
+        : undefined;
+    let sourceType: string | null = null;
+    let sourceId: string | null = null;
+    if (headSource.sourceType !== undefined) {
+      sourceType = headSource.sourceType;
+      sourceId = headSource.sourceId ?? null;
+    } else if (tailAccepted !== undefined) {
+      sourceType = tailAccepted.sourceType;
+      sourceId = tailAccepted.sourceId ?? headSource.sourceId ?? null;
+    }
+    if (sourceType === null && resumed) {
+      sourceType = previous?.sourceType ?? null;
+      sourceId = previous?.sourceId ?? sourceId;
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO sessions(
+          sessionId, fileName, mtimeMs, sizeBytes, startTime,
+          firstRecordUuid, firstRecordTimestamp, firstRecordSessionId,
+          firstPrompt, cwd, gitBranch,
+          customTitle, titleSource, goalObjective, parentSessionId,
+          sourceType, sourceId, recordCount, indexedBytes, status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(sessionId) DO UPDATE SET
+          fileName = excluded.fileName,
+          mtimeMs = excluded.mtimeMs,
+          sizeBytes = excluded.sizeBytes,
+          startTime = COALESCE(sessions.startTime, excluded.startTime),
+          firstRecordUuid = COALESCE(sessions.firstRecordUuid, excluded.firstRecordUuid),
+          firstRecordTimestamp = COALESCE(sessions.firstRecordTimestamp, excluded.firstRecordTimestamp),
+          firstRecordSessionId = COALESCE(sessions.firstRecordSessionId, excluded.firstRecordSessionId),
+          firstPrompt = excluded.firstPrompt,
+          cwd = COALESCE(sessions.cwd, excluded.cwd),
+          gitBranch = COALESCE(sessions.gitBranch, excluded.gitBranch),
+          customTitle = excluded.customTitle,
+          titleSource = excluded.titleSource,
+          goalObjective = excluded.goalObjective,
+          parentSessionId = COALESCE(sessions.parentSessionId, excluded.parentSessionId),
+          sourceType = COALESCE(excluded.sourceType, sessions.sourceType),
+          sourceId = COALESCE(excluded.sourceId, sessions.sourceId),
+          recordCount = excluded.recordCount,
+          indexedBytes = excluded.indexedBytes,
+          status = excluded.status`,
+      )
+      .run(
+        sessionId,
+        fileName,
+        mtimeMs,
+        sizeBytes,
+        firstConversationStartTime,
+        firstRecordUuid,
+        firstRecordTimestamp,
+        firstRecordUuid !== null
+          ? firstRecordSessionId
+          : (previous?.firstRecordSessionId ?? null),
+        firstPrompt,
+        firstRecordUuid !== null ? cwd : (previous?.cwd ?? null),
+        firstRecordUuid !== null ? gitBranch : (previous?.gitBranch ?? null),
+        titleInfo.title ?? null,
+        titleInfo.source ?? null,
+        goalObjective,
+        headParentSessionId ?? null,
+        sourceType,
+        sourceId,
+        priorRecordCount + rows.length,
+        consumed,
+        priorMismatch || sessionMismatch ? 'mismatch' : 'ok',
+      );
+  }
+
+  catalogRows(): SessionIndexCatalogRow[] {
+    return this.db
+      .prepare(
+        `SELECT sessionId, fileName, mtimeMs, sizeBytes, startTime,
+                firstRecordUuid, firstRecordSessionId, firstPrompt,
+                cwd, gitBranch, customTitle, titleSource, goalObjective,
+                parentSessionId, sourceType, sourceId, recordCount,
+                indexedBytes, status
+         FROM sessions
+         ORDER BY mtimeMs DESC, sessionId`,
+      )
+      .all()
+      .map((row) => {
+        const r = row as Record<string, unknown>;
+        return {
+          sessionId: r['sessionId'] as string,
+          fileName: r['fileName'] as string,
+          mtimeMs: r['mtimeMs'] as number,
+          sizeBytes: r['sizeBytes'] as number,
+          startTime: (r['startTime'] as string | null) ?? null,
+          firstRecordUuid: (r['firstRecordUuid'] as string | null) ?? null,
+          firstRecordSessionId:
+            (r['firstRecordSessionId'] as string | null) ?? null,
+          firstPrompt: (r['firstPrompt'] as string | null) ?? null,
+          cwd: (r['cwd'] as string | null) ?? null,
+          gitBranch: (r['gitBranch'] as string | null) ?? null,
+          customTitle: (r['customTitle'] as string | null) ?? null,
+          titleSource: (r['titleSource'] as string | null) ?? null,
+          goalObjective: (r['goalObjective'] as string | null) ?? null,
+          parentSessionId: (r['parentSessionId'] as string | null) ?? null,
+          sourceType: (r['sourceType'] as string | null) ?? null,
+          sourceId: (r['sourceId'] as string | null) ?? null,
+          recordCount: r['recordCount'] as number,
+          indexedBytes: r['indexedBytes'] as number,
+          status: r['status'] === 'mismatch' ? 'mismatch' : 'ok',
+        };
+      }) as SessionIndexCatalogRow[];
+  }
+
+  catalogRowsAfterMtime(
+    beforeMtimeMs: number | null,
+    limit: number,
+  ): SessionIndexCatalogRow[] {
+    return this.db
+      .prepare(
+        `SELECT sessionId, fileName, mtimeMs, sizeBytes, startTime,
+                firstRecordUuid, firstRecordSessionId, firstPrompt,
+                cwd, gitBranch, customTitle, titleSource, goalObjective,
+                parentSessionId, sourceType, sourceId, recordCount,
+                indexedBytes, status
+         FROM sessions
+         WHERE (? IS NULL OR mtimeMs < ?)
+         ORDER BY mtimeMs DESC, sessionId
+         LIMIT ?`,
+      )
+      .all(beforeMtimeMs, beforeMtimeMs, limit)
+      .map((row) => {
+        const r = row as Record<string, unknown>;
+        return {
+          sessionId: r['sessionId'] as string,
+          fileName: r['fileName'] as string,
+          mtimeMs: r['mtimeMs'] as number,
+          sizeBytes: r['sizeBytes'] as number,
+          startTime: (r['startTime'] as string | null) ?? null,
+          firstRecordUuid: (r['firstRecordUuid'] as string | null) ?? null,
+          firstRecordSessionId:
+            (r['firstRecordSessionId'] as string | null) ?? null,
+          firstPrompt: (r['firstPrompt'] as string | null) ?? null,
+          cwd: (r['cwd'] as string | null) ?? null,
+          gitBranch: (r['gitBranch'] as string | null) ?? null,
+          customTitle: (r['customTitle'] as string | null) ?? null,
+          titleSource: (r['titleSource'] as string | null) ?? null,
+          goalObjective: (r['goalObjective'] as string | null) ?? null,
+          parentSessionId: (r['parentSessionId'] as string | null) ?? null,
+          sourceType: (r['sourceType'] as string | null) ?? null,
+          sourceId: (r['sourceId'] as string | null) ?? null,
+          recordCount: r['recordCount'] as number,
+          indexedBytes: r['indexedBytes'] as number,
+          status: r['status'] === 'mismatch' ? 'mismatch' : 'ok',
+        };
+      }) as SessionIndexCatalogRow[];
+  }
+
+  recordSegmentsForUuids(
+    sessionId: string,
+    uuids: ReadonlySet<string>,
+  ): Map<string, SessionIndexSegment[]> {
+    const out = new Map<string, SessionIndexSegment[]>();
+    if (uuids.size === 0) return out;
+    const placeholders = [...uuids].map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT uuid, offset, length FROM records
+         WHERE sessionId = ? AND uuid IN (${placeholders})
+         ORDER BY seq`,
+      )
+      .all(sessionId, ...uuids) as Array<Record<string, unknown>>;
+    for (const r of rows) {
+      const uuid = r['uuid'] as string;
+      const list = out.get(uuid) ?? [];
+      list.push({
+        offset: r['offset'] as number,
+        length: r['length'] as number,
+      });
+      out.set(uuid, list);
+    }
+    return out;
+  }
+
+  turnIndexCache(sessionId: string): SessionIndexTurnCache | null {
+    const r = this.db
+      .prepare(
+        `SELECT indexedBytes, leafUuid, startTime, totalTurns, turnsJson
+         FROM turns_cache WHERE sessionId = ?`,
+      )
+      .get(sessionId) as Record<string, unknown> | undefined;
+    if (!r) return null;
+    let turns: SessionIndexTurnHint[];
+    try {
+      turns = JSON.parse(r['turnsJson'] as string) as SessionIndexTurnHint[];
+    } catch {
+      return null;
+    }
+    return {
+      indexedBytes: r['indexedBytes'] as number,
+      leafUuid: r['leafUuid'] as string,
+      startTime: (r['startTime'] as string | null) ?? null,
+      totalTurns: r['totalTurns'] as number,
+      turns,
+    };
+  }
+
+  putTurnIndexCache(sessionId: string, cache: SessionIndexTurnCache): void {
+    this.db
+      .prepare(
+        `INSERT INTO turns_cache(sessionId, indexedBytes, leafUuid, startTime, totalTurns, turnsJson)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(sessionId) DO UPDATE SET
+           indexedBytes = excluded.indexedBytes,
+           leafUuid = excluded.leafUuid,
+           startTime = excluded.startTime,
+           totalTurns = excluded.totalTurns,
+           turnsJson = excluded.turnsJson`,
+      )
+      .run(
+        sessionId,
+        cache.indexedBytes,
+        cache.leafUuid,
+        cache.startTime,
+        cache.totalTurns,
+        JSON.stringify(cache.turns),
+      );
+  }
+
+  recordRows(sessionId: string): SessionIndexRecordRow[] | null {
+    const session = this.sessionRow(sessionId);
+    if (!session || session.status !== 'ok') return null;
+    return (
+      this.db
+        .prepare(
+          `SELECT seq, uuid, parentUuid, type, subtype, timestamp, offset, length,
+                  conversation, inherited, sideTaskSource, navKind,
+                  assistantPreview, turnResultPromptId
+           FROM records WHERE sessionId = ? ORDER BY seq`,
+        )
+        .all(sessionId) as Array<Record<string, unknown>>
+    ).map((r) => ({
+      seq: r['seq'] as number,
+      uuid: r['uuid'] as string,
+      parentUuid: (r['parentUuid'] as string | null) ?? null,
+      type: r['type'] as string,
+      subtype: (r['subtype'] as string | null) ?? null,
+      timestamp: (r['timestamp'] as string | null) ?? null,
+      offset: r['offset'] as number,
+      length: r['length'] as number,
+      conversation: r['conversation'] === 1,
+      inherited: r['inherited'] === 1,
+      sideTaskSource: r['sideTaskSource'] === 1,
+      navKind:
+        (r['navKind'] as SessionTranscriptNavigationTurnKind | null) ?? null,
+      assistantPreview: r['assistantPreview'] === 1,
+      turnResultPromptId: (r['turnResultPromptId'] as string | null) ?? null,
+    }));
+  }
+
+  sessionRow(sessionId: string): SessionIndexSessionRow | null {
+    const r = this.db
+      .prepare(
+        `SELECT sessionId, fileName, mtimeMs, sizeBytes, firstRecordUuid,
+                firstRecordTimestamp, firstRecordSessionId, startTime,
+                recordCount, indexedBytes, status
+         FROM sessions WHERE sessionId = ?`,
+      )
+      .get(sessionId) as Record<string, unknown> | undefined;
+    if (!r) return null;
+    return {
+      sessionId: r['sessionId'] as string,
+      fileName: r['fileName'] as string,
+      mtimeMs: r['mtimeMs'] as number,
+      sizeBytes: r['sizeBytes'] as number,
+      firstRecordUuid: (r['firstRecordUuid'] as string | null) ?? null,
+      firstRecordSessionId:
+        (r['firstRecordSessionId'] as string | null) ?? null,
+      firstRecordTimestamp:
+        (r['firstRecordTimestamp'] as string | null) ?? null,
+      startTime: (r['startTime'] as string | null) ?? null,
+      recordCount: r['recordCount'] as number,
+      indexedBytes: r['indexedBytes'] as number,
+      status: r['status'] === 'mismatch' ? 'mismatch' : 'ok',
+    };
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // closing after a failed open is best-effort
+    }
+  }
+}
+
+export function openSessionIndexStore(
+  driver: SqliteDriver,
+  projectDir: string,
+): SessionIndexStore {
+  return new SqliteSessionIndexStore(driver, projectDir);
+}

--- a/packages/core/src/services/session-index/types.ts
+++ b/packages/core/src/services/session-index/types.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Contract for the session-index sidecar: a durable, rebuildable index over
+// the append-only JSONL transcripts. The JSONL files remain the sole
+// authoritative store; any provider returned here may be deleted, corrupted,
+// or disabled at any time and callers must still work (they fall back to
+// file scanning). See docs/design/session-sqlite-sidecar.md.
+
+import type { SessionTranscriptNavigationTurnKind } from './nav-hints.js';
+
+export type SessionIndexMode = 'file' | 'sqlite';
+
+export interface SessionIndexCatalogRow {
+  sessionId: string;
+  fileName: string;
+  mtimeMs: number;
+  sizeBytes: number;
+  startTime: string | null;
+  firstRecordUuid: string | null;
+  /** The session id carried by the first record (differs for mismatched files). */
+  firstRecordSessionId: string | null;
+  firstPrompt: string | null;
+  cwd: string | null;
+  gitBranch: string | null;
+  customTitle: string | null;
+  titleSource: string | null;
+  goalObjective: string | null;
+  parentSessionId: string | null;
+  sourceType: string | null;
+  sourceId: string | null;
+  recordCount: number;
+  /** Byte checkpoint: the records index covers [0, indexedBytes) of the file. */
+  indexedBytes: number;
+  /** 'mismatch' when a record carries a foreign sessionId (legacy parity). */
+  status: 'ok' | 'mismatch';
+}
+
+export interface SessionIndexRecordRow {
+  seq: number;
+  uuid: string;
+  parentUuid: string | null;
+  type: string;
+  subtype: string | null;
+  timestamp: string | null;
+  offset: number;
+  length: number;
+  conversation: boolean;
+  inherited: boolean;
+  sideTaskSource: boolean;
+  navKind: SessionTranscriptNavigationTurnKind | null;
+  assistantPreview: boolean;
+  turnResultPromptId: string | null;
+}
+
+export interface SessionIndexSessionRow {
+  sessionId: string;
+  fileName: string;
+  mtimeMs: number;
+  sizeBytes: number;
+  firstRecordUuid: string | null;
+  firstRecordSessionId: string | null;
+  firstRecordTimestamp: string | null;
+  /** First conversation record's timestamp, mirroring buildIndex's startTime. */
+  startTime: string | null;
+  recordCount: number;
+  indexedBytes: number;
+  status: 'ok' | 'mismatch';
+}
+
+export interface SessionIndexSegment {
+  offset: number;
+  length: number;
+}
+
+/** One derived navigation turn, exactly as the transcript index computes it. */
+export interface SessionIndexTurnHint {
+  turnId: string;
+  replayPosition: number;
+  kind: 'prompt' | 'realtime' | 'scheduled';
+  promptId?: string;
+  finalAssistantRecordId?: string;
+}
+
+/**
+ * Durable cache of one session's derived navigation turns, valid only for
+ * the exact indexedBytes checkpoint it was computed from. Rebuilt whenever
+ * the file moves past that checkpoint — never repaired, never merged.
+ */
+export interface SessionIndexTurnCache {
+  indexedBytes: number;
+  leafUuid: string;
+  startTime: string | null;
+  totalTurns: number;
+  turns: SessionIndexTurnHint[];
+}
+
+/**
+ * One sidecar per project directory. All query methods are synchronous
+ * (node:sqlite is a synchronous API); sync methods are async because they
+ * read JSONL files with cooperative I/O.
+ */
+export interface SessionIndexStore {
+  /**
+   * Reconcile the catalog with a chats directory: index new/changed files
+   * (incremental from byte checkpoints), drop removed ones. No-op when the
+   * previous sweep finished less than `minIntervalMs` ago. Returns the
+   * number of files examined during the sweep, or -1 when skipped as fresh.
+   */
+  syncDirectory(chatsDir: string, minIntervalMs?: number): Promise<number>;
+  /**
+   * Reconcile one transcript file with the index (stat + incremental tail
+   * scan; rewind-rebuild when the file shrank).
+   */
+  syncFile(filePath: string): Promise<void>;
+  catalogRows(): SessionIndexCatalogRow[];
+  /**
+   * Catalog rows whose mtimeMs is strictly below `beforeMtimeMs` (or from the
+   * newest when null), newest-first, at most `limit` rows.
+   */
+  catalogRowsAfterMtime(
+    beforeMtimeMs: number | null,
+    limit: number,
+  ): SessionIndexCatalogRow[];
+  /**
+   * Full record metadata for one session in file order, or null when the
+   * session is unknown or flagged 'mismatch'.
+   */
+  recordRows(sessionId: string): SessionIndexRecordRow[] | null;
+  /** Byte segments of every line carrying one of `uuids`, grouped by uuid. */
+  recordSegmentsForUuids(
+    sessionId: string,
+    uuids: ReadonlySet<string>,
+  ): Map<string, SessionIndexSegment[]>;
+  turnIndexCache(sessionId: string): SessionIndexTurnCache | null;
+  putTurnIndexCache(sessionId: string, cache: SessionIndexTurnCache): void;
+  sessionRow(sessionId: string): SessionIndexSessionRow | null;
+  close(): void;
+}

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -86,6 +86,20 @@ import {
   resolveBranchPoints,
   type BranchPointRecord,
 } from './branch-points.js';
+import {
+  isAssistantPreviewCandidate,
+  navigationDisplayText,
+  navigationKindForRecord,
+  type SessionTranscriptNavigationTurnKind,
+} from './session-index/nav-hints.js';
+import { getSessionIndexStore } from './session-index/config.js';
+import type {
+  SessionIndexRecordRow,
+  SessionIndexSegment,
+  SessionIndexSessionRow,
+  SessionIndexStore,
+  SessionIndexTurnHint,
+} from './session-index/types.js';
 
 export const SESSION_TRANSCRIPT_DEFAULT_LIMIT = 100;
 export const SESSION_TRANSCRIPT_MAX_LIMIT = 500;
@@ -178,10 +192,7 @@ export interface SessionTranscriptSnapshotState {
   lastUpdated: string;
 }
 
-export type SessionTranscriptNavigationTurnKind =
-  | 'prompt'
-  | 'realtime'
-  | 'scheduled';
+export type { SessionTranscriptNavigationTurnKind };
 
 export interface SessionTranscriptNavigationTurn {
   ordinal: number;
@@ -1013,87 +1024,6 @@ function normalizeMaxBytes(maxBytes: number | undefined): number | undefined {
     );
   }
   return maxBytes;
-}
-
-function navigationDisplayText(text: string, systemPayload: unknown): string {
-  const stripped = stripGeneratedAttachmentTokens(text, systemPayload);
-  return isUserPromptSubmitContextPartText(stripped) ? '' : stripped;
-}
-
-function navigationKindForRecord(
-  record: ChatRecord,
-): SessionTranscriptNavigationTurnKind | undefined {
-  if (record.type !== 'user') return undefined;
-  if (
-    record.subtype === 'goal_runtime' ||
-    record.subtype === 'notification' ||
-    record.subtype === 'mid_turn_user_message'
-  ) {
-    return undefined;
-  }
-  if (record.subtype === 'cron') {
-    const payload = isObjectRecord(record.systemPayload)
-      ? record.systemPayload
-      : undefined;
-    const displayText =
-      typeof payload?.['displayText'] === 'string'
-        ? navigationDisplayText(payload['displayText'], record.systemPayload)
-        : '';
-    return displayText.trim().length > 0 ? 'scheduled' : undefined;
-  }
-
-  const projection = projectUserTranscriptForDisplay(record);
-  const displayText =
-    projection.displayText === undefined
-      ? undefined
-      : navigationDisplayText(projection.displayText, record.systemPayload);
-  const hasVisibleText =
-    displayText !== undefined
-      ? displayText.trim().length > 0
-      : projection.parts.some(
-          (part) =>
-            isObjectRecord(part) &&
-            typeof part['text'] === 'string' &&
-            part['text'].trim().length > 0 &&
-            !isUserPromptSubmitContextPartText(part['text']),
-        );
-  const hasVisibleAttachment =
-    projection.parts.some((part) => {
-      if (!isObjectRecord(part) || !isObjectRecord(part['inlineData'])) {
-        return false;
-      }
-      const inlineData = part['inlineData'];
-      return (
-        typeof inlineData['data'] === 'string' &&
-        typeof inlineData['mimeType'] === 'string' &&
-        inlineData['mimeType'].startsWith('image/')
-      );
-    }) ||
-    (isObjectRecord(record.systemPayload) &&
-      Array.isArray(record.systemPayload['attachmentReferences']) &&
-      record.systemPayload['attachmentReferences'].some(
-        (reference) =>
-          isObjectRecord(reference) &&
-          (reference['type'] === 'image' || reference['type'] === 'resource') &&
-          typeof reference['attachmentId'] === 'string' &&
-          typeof reference['mimeType'] === 'string' &&
-          typeof reference['size'] === 'number',
-      ));
-  if (!hasVisibleText && !hasVisibleAttachment) return undefined;
-  return record.subtype === 'realtime_message' ? 'realtime' : 'prompt';
-}
-
-function isAssistantPreviewCandidate(record: ChatRecord): boolean {
-  return (
-    record.type === 'assistant' &&
-    (record.message?.parts ?? []).some(
-      (part) =>
-        isObjectRecord(part) &&
-        part['thought'] !== true &&
-        typeof part['text'] === 'string' &&
-        part['text'].trim().length > 0,
-    )
-  );
 }
 
 function compactPreviewText(text: string, maxCodePoints: number): string {
@@ -2513,6 +2443,320 @@ export class SessionTranscriptReader {
     );
   }
 
+  /**
+   * Serves {@link readTurnIndexPage} from the session-index sidecar.
+   * Turn derivation mirrors buildIndex exactly (same leaf-chunk walk, replay
+   * slicing, kind/assistant/promptId rules) over the durable record metadata;
+   * labels/details are projected through the same helpers from the original
+   * JSONL bytes fetched via stored offsets. Returns undefined when the
+   * sidecar cannot serve, leaving the caller's legacy path untouched.
+   */
+  private async readTurnIndexPageFromIndexStore(params: {
+    sessionId: string;
+    filePath: string;
+    snapshot: SessionTranscriptSnapshotState | undefined;
+    options: SessionTranscriptReadTurnIndexOptions;
+    limit: number;
+    fileIdentity: SessionTranscriptFileIdentity;
+    snapshotSize: number;
+    lastUpdated: string;
+  }): Promise<SessionTranscriptTurnIndexPage | undefined> {
+    const {
+      sessionId,
+      filePath,
+      snapshot,
+      options,
+      limit,
+      fileIdentity,
+      snapshotSize,
+      lastUpdated,
+    } = params;
+
+    // The fast path enforces the same snapshot-size ceiling buildIndex does,
+    // so oversized sessions get the identical typed error in both modes.
+    if (snapshotSize > SESSION_TRANSCRIPT_MAX_INDEX_BYTES) {
+      throw new SessionTranscriptTooLargeError(
+        sessionId,
+        snapshotSize,
+        SESSION_TRANSCRIPT_MAX_INDEX_BYTES,
+      );
+    }
+
+    let store: SessionIndexStore | null;
+    let srow: SessionIndexSessionRow | null;
+    try {
+      store = await getSessionIndexStore(this.storage.getProjectDir());
+      if (!store) return undefined;
+      await store.syncFile(filePath);
+      srow = store.sessionRow(sessionId);
+    } catch (error) {
+      debugLogger.debug(
+        `session index turn page unavailable, falling back: ${String(error)}`,
+      );
+      return undefined;
+    }
+    // Unservable sessions fall back: 'mismatch' reproduces the legacy throw
+    // via buildIndex; an empty index reproduces the EmptySessionTranscript
+    // handling of the legacy catch path.
+    if (!srow || srow.status !== 'ok' || !srow.firstRecordUuid) {
+      return undefined;
+    }
+
+    let navigationTurns: SessionIndexTurnHint[] | undefined;
+    let leafUuid: string;
+    let sessionStartTime: string | null;
+    let rows: SessionIndexRecordRow[] | null = null;
+
+    // The durable turn cache is keyed by the byte checkpoint it was derived
+    // from; appends past that checkpoint invalidate it wholesale.
+    const cached = store.turnIndexCache(sessionId);
+    if (cached && cached.indexedBytes === srow.indexedBytes) {
+      navigationTurns = cached.turns;
+      leafUuid = cached.leafUuid;
+      sessionStartTime = cached.startTime;
+    } else {
+      rows = store.recordRows(sessionId);
+      if (!rows || rows.length === 0) return undefined;
+      leafUuid = '';
+      for (let i = rows.length - 1; i >= 0; i--) {
+        if (rows[i].conversation) {
+          leafUuid = rows[i].uuid;
+          break;
+        }
+      }
+      if (!leafUuid) return undefined;
+      sessionStartTime = srow.startTime;
+    }
+
+    if (snapshot && snapshot.leafUuid !== leafUuid) {
+      throw new SessionTranscriptSnapshotUnavailableError(sessionId);
+    }
+    const startTime = sessionStartTime ?? snapshot?.startTime ?? lastUpdated;
+
+    try {
+      if (navigationTurns === undefined && rows !== null) {
+        const byUuidMeta = new Map<string, SessionIndexRecordRow>();
+        for (const row of rows) {
+          if (!byUuidMeta.has(row.uuid)) byUuidMeta.set(row.uuid, row);
+        }
+        const chain = walkTranscriptUuidChain(leafUuid, (uuid) => {
+          const row = byUuidMeta.get(uuid);
+          return row && row.conversation
+            ? {
+                uuid: row.uuid,
+                parentUuid: row.parentUuid,
+                sessionId,
+                timestamp: startTime,
+                type: 'system',
+              }
+            : undefined;
+        });
+        const runtimeUuids = [...chain.uuids];
+        const sourceBoundary = runtimeUuids.findIndex(
+          (uuid) => byUuidMeta.get(uuid)?.sideTaskSource === true,
+        );
+        const replayUuids =
+          sourceBoundary >= 0
+            ? runtimeUuids
+                .slice(sourceBoundary)
+                .filter((uuid) => byUuidMeta.get(uuid)?.inherited !== true)
+            : [...runtimeUuids];
+
+        const derivedTurns: SessionIndexTurnHint[] = [];
+        let currentPromptTurn: SessionIndexTurnHint | undefined;
+        let currentRealtimeTurn: SessionIndexTurnHint | undefined;
+        for (let position = 0; position < replayUuids.length; position++) {
+          const uuid = replayUuids[position]!;
+          const entry = byUuidMeta.get(uuid);
+          const navigationKind = entry?.navKind ?? undefined;
+          if (navigationKind) {
+            const turn = {
+              turnId: uuid,
+              replayPosition: position,
+              kind: navigationKind,
+            } satisfies SessionIndexTurnHint;
+            derivedTurns.push(turn);
+            if (navigationKind === 'realtime') {
+              currentRealtimeTurn = turn;
+            } else {
+              currentPromptTurn = turn;
+              currentRealtimeTurn = undefined;
+            }
+            continue;
+          }
+          if (entry?.assistantPreview) {
+            const targetTurn =
+              entry.subtype === 'realtime_message'
+                ? currentRealtimeTurn
+                : currentPromptTurn;
+            if (targetTurn) targetTurn.finalAssistantRecordId = uuid;
+          }
+          if (entry?.turnResultPromptId && currentPromptTurn) {
+            currentPromptTurn.promptId = entry.turnResultPromptId;
+            currentPromptTurn = undefined;
+          }
+        }
+        navigationTurns = derivedTurns;
+        try {
+          store.putTurnIndexCache(sessionId, {
+            indexedBytes: srow.indexedBytes,
+            leafUuid,
+            startTime: sessionStartTime,
+            totalTurns: derivedTurns.length,
+            turns: derivedTurns,
+          });
+        } catch {
+          // Cache persistence is an optimization; a failed write only costs
+          // re-derivation on the next read.
+        }
+      }
+      if (!navigationTurns) return undefined;
+
+      const totalTurns = navigationTurns.length;
+      const start =
+        options.start ?? Math.max(0, totalTurns - Math.min(limit, totalTurns));
+      if (start > totalTurns) {
+        throw new InvalidSessionTranscriptCursorError();
+      }
+      const selectedTurns = navigationTurns.slice(start, start + limit);
+      const selectedUuids = selectedTurns.flatMap((turn) => [
+        turn.turnId,
+        ...(turn.finalAssistantRecordId ? [turn.finalAssistantRecordId] : []),
+      ]);
+      const selectedKinds = new Map(
+        selectedTurns.map((turn) => [turn.turnId, turn.kind]),
+      );
+      const selectedAssistantUuids = new Set(
+        selectedTurns.flatMap((turn) =>
+          turn.finalAssistantRecordId ? [turn.finalAssistantRecordId] : [],
+        ),
+      );
+
+      const labels = new Map<string, { label: string; timestamp?: string }>();
+      const details = new Map<string, string>();
+      for (const record of await this.readAggregatedIndexRecords(
+        filePath,
+        sessionId,
+        store.recordSegmentsForUuids(sessionId, new Set(selectedUuids)),
+      )) {
+        const kind = selectedKinds.get(record.uuid);
+        if (kind) {
+          labels.set(record.uuid, {
+            label: projectNavigationLabel(record, kind),
+            ...(record.timestamp ? { timestamp: record.timestamp } : {}),
+          });
+        }
+        if (selectedAssistantUuids.has(record.uuid)) {
+          const detail = projectNavigationDetail(record);
+          if (detail) details.set(record.uuid, detail);
+        }
+      }
+
+      const turns = selectedTurns.map((turn, offset) => {
+        const preview = labels.get(turn.turnId);
+        const detail = turn.finalAssistantRecordId
+          ? details.get(turn.finalAssistantRecordId)
+          : undefined;
+        return {
+          ordinal: start + offset,
+          turnId: turn.turnId,
+          kind: turn.kind,
+          ...(turn.promptId ? { promptId: turn.promptId } : {}),
+          ...(preview?.timestamp ? { timestamp: preview.timestamp } : {}),
+          label: preview
+            ? preview.label
+            : turn.kind === 'scheduled'
+              ? 'Scheduled prompt'
+              : turn.kind === 'realtime'
+                ? 'Realtime message'
+                : 'Prompt',
+          ...(detail ? { detail } : {}),
+        } satisfies SessionTranscriptNavigationTurn;
+      });
+
+      const snapshotState: SessionTranscriptSnapshotState = {
+        v: SESSION_TRANSCRIPT_TURN_INDEX_VERSION,
+        kind: 'turn_index',
+        sessionId,
+        fileIdentity,
+        snapshotSize,
+        leafUuid,
+        startTime,
+        lastUpdated,
+      };
+      return {
+        v: SESSION_TRANSCRIPT_TURN_INDEX_VERSION,
+        sessionId,
+        snapshot: this.encodeSnapshot(snapshotState),
+        totalTurns,
+        start,
+        turns,
+        startTime,
+        lastUpdated,
+      };
+    } catch (error) {
+      // Deliberate cursor errors propagate for parity; everything else about
+      // the sidecar is invisible by design.
+      if (
+        error instanceof InvalidSessionTranscriptCursorError ||
+        error instanceof SessionTranscriptSnapshotUnavailableError
+      ) {
+        throw error;
+      }
+      debugLogger.debug(
+        `session index turn page failed, falling back: ${String(error)}`,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Re-materializes the aggregated records behind one page of turn starts
+   * and final assistant previews by reading the stored JSONL segments. Only
+   * the page's own uuids are touched — never the rest of the file.
+   */
+  private async readAggregatedIndexRecords(
+    filePath: string,
+    sessionId: string,
+    segmentsByUuid: Map<string, SessionIndexSegment[]>,
+  ): Promise<ChatRecord[]> {
+    const fh = await fsp.open(filePath, 'r');
+    try {
+      const records: ChatRecord[] = [];
+      for (const [uuid, segments] of segmentsByUuid) {
+        // Mirror readSegmentRecords' integrity contract: only fragments
+        // carrying this entry's uuid may be aggregated; bytes that point at
+        // a different record invalidate the snapshot instead of projecting
+        // wrong labels/details.
+        const fragments: TranscriptRecordInput[] = [];
+        let foreignSessionId = false;
+        for (const segment of segments) {
+          const buffer = Buffer.alloc(segment.length);
+          await fh.read(buffer, 0, segment.length, segment.offset);
+          const text = buffer.toString('utf8').trim();
+          if (text.length === 0) continue;
+          for (const value of jsonl.parseLineTolerant<unknown>(
+            text,
+            filePath,
+          )) {
+            const fragment = validateTranscriptRecord(value).record;
+            if (!fragment) continue;
+            if (fragment.sessionId !== sessionId) foreignSessionId = true;
+            if (fragment.uuid === uuid) fragments.push(fragment);
+          }
+        }
+        if (fragments.length === 0 || foreignSessionId) {
+          throw new SessionTranscriptSnapshotUnavailableError(sessionId);
+        }
+        const aggregated = aggregateTranscriptRecordFragments(fragments);
+        if (aggregated) records.push(aggregated as unknown as ChatRecord);
+      }
+      return records;
+    } finally {
+      await fh.close();
+    }
+  }
+
   async readTurnIndexPage(
     sessionId: string,
     options: SessionTranscriptReadTurnIndexOptions = {},
@@ -2548,6 +2792,23 @@ export class SessionTranscriptReader {
     }
     const lastUpdated =
       snapshot?.lastUpdated ?? new Date(stats.mtimeMs).toISOString();
+
+    // Fast path: the session-index sidecar serves the same page from its
+    // durable record offsets instead of a full-file scan. Deliberate
+    // continuity failures (snapshot cursor mismatch) propagate so callers
+    // see identical errors; any other provider problem falls back to the
+    // index build below.
+    const indexPage = await this.readTurnIndexPageFromIndexStore({
+      sessionId,
+      filePath,
+      snapshot,
+      options,
+      limit,
+      fileIdentity,
+      snapshotSize,
+      lastUpdated,
+    });
+    if (indexPage !== undefined) return indexPage;
 
     let index: TranscriptIndex | undefined;
     try {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -81,6 +81,8 @@ import {
 } from './branch-points.js';
 import { recoverGoalFromRecords } from '../goals/goal-persistence.js';
 import { parseGoalStateRecordPayloadV2 } from '../goals/goal-reducer.js';
+import { getSessionIndexStore } from './session-index/config.js';
+import type { SessionIndexStore } from './session-index/types.js';
 export {
   buildApiHistoryFromConversation,
   type BuildApiHistoryOptions,
@@ -2511,13 +2513,113 @@ export class SessionService {
   }
 
   /**
+   * Serves {@link listSessions} from the session-index sidecar catalog.
+   * Mirrors the scan path's semantics: mtime-desc order, mtime-keyed cursor,
+   * project-membership filtering, and label fields resolved from the same
+   * record/tail extractions (computed at index-sync time).
+   */
+  private async listSessionsWithIndex(
+    indexStore: SessionIndexStore,
+    chatsDir: string,
+    options: {
+      cursor?: string | number;
+      size: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<ListSessionsResult> {
+    const { cursor, size, signal } = options;
+    const parsedCursor = cursor !== undefined ? Number(cursor) : undefined;
+    if (parsedCursor !== undefined && !Number.isFinite(parsedCursor)) {
+      // Scan parity: an unparseable cursor compares false against every
+      // file, so the page is empty rather than restarted from the newest.
+      return { items: [], hasMore: false };
+    }
+    await indexStore.syncDirectory(chatsDir);
+
+    const items: SessionListItem[] = [];
+    let lastProcessedMtime: number | undefined;
+    let hasMoreFiles = false;
+    // Windowed keyset paging: never materialize the whole catalog, even for
+    // very large session populations. 200 rows amortize one SQL round-trip
+    // per page; membership skips simply consume the window.
+    const WINDOW_SIZE = 200;
+    let windowStart: number | null = parsedCursor ?? null;
+
+    outer: for (let guard = 0; ; guard++) {
+      if (guard > 100000) throw new Error('session index pagination runaway');
+      const rows = indexStore.catalogRowsAfterMtime(windowStart, WINDOW_SIZE);
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        if (items.length >= size) {
+          hasMoreFiles = true;
+          break outer;
+        }
+        signal?.throwIfAborted();
+        lastProcessedMtime = row.mtimeMs;
+
+        // Scan parity: files without a readable first record never produce an
+        // item (but still advance the pagination key).
+        if (!row.firstRecordUuid) continue;
+        if (!SESSION_FILE_PATTERN.test(row.fileName)) continue;
+
+        // Mismatched-session parity: the item id and the membership probe use
+        // the id carried by the first record, not the file name.
+        const recordSessionId = row.firstRecordSessionId ?? row.sessionId;
+        if (
+          !(await this.sessionBelongsToCurrentProject(
+            recordSessionId,
+            row.cwd ?? '',
+            signal,
+          ))
+        ) {
+          continue;
+        }
+
+        items.push({
+          sessionId: recordSessionId,
+          cwd: row.cwd ?? '',
+          startTime: row.startTime ?? '',
+          mtime: row.mtimeMs,
+          prompt: row.firstPrompt ?? '',
+          gitBranch: row.gitBranch ?? undefined,
+          filePath: path.join(chatsDir, row.fileName),
+          customTitle: row.customTitle ?? undefined,
+          goalObjective: row.goalObjective ?? undefined,
+          titleSource: (row.titleSource as TitleSource | null) ?? undefined,
+          ...(row.parentSessionId
+            ? { parentSessionId: row.parentSessionId }
+            : {}),
+          ...(row.sourceType ? { sourceType: row.sourceType } : {}),
+          ...(row.sourceId !== null ? { sourceId: row.sourceId } : {}),
+          isArchived: false,
+        });
+      }
+      if (rows.length < WINDOW_SIZE) break;
+      windowStart = rows[rows.length - 1].mtimeMs;
+    }
+    signal?.throwIfAborted();
+
+    const nextCursor =
+      hasMoreFiles && lastProcessedMtime !== undefined
+        ? lastProcessedMtime
+        : undefined;
+
+    return {
+      items,
+      nextCursor,
+      hasMore: hasMoreFiles,
+    };
+  }
+
+  /**
    * Lists sessions for the current project with pagination.
    *
    * Sessions are ordered by file modification time (most recent first).
    * Uses cursor-based pagination with mtime as the cursor.
    *
-   * Only reads the first line of each JSONL file for efficiency.
-   * Files are filtered by UUID pattern first, then by project hash.
+   * Only reads the first line of each JSONL file for efficiency (or, when
+   * the session-index sidecar is enabled, serves the same rows from its
+   * catalog). Files are filtered by UUID pattern first, then by project hash.
    *
    * @param options Pagination options
    * @returns Paginated list of sessions
@@ -2529,6 +2631,31 @@ export class SessionService {
     const chatsDir = this.getChatsDirForState(archiveState);
     const isArchived = archiveState === 'archived';
     signal?.throwIfAborted();
+
+    // Fast path: serve the listing from the session-index sidecar when one
+    // is enabled and healthy. Any provider-side failure falls back to the
+    // scan below; archived listings (rare, small) always scan.
+    if (!isArchived) {
+      const indexStore = await getSessionIndexStore(
+        this.storage.getProjectDir(),
+      );
+      if (indexStore) {
+        try {
+          return await this.listSessionsWithIndex(indexStore, chatsDir, {
+            cursor,
+            size,
+            signal,
+          });
+        } catch (error) {
+          // Abort is caller cancellation, not an index malfunction: never
+          // route it into the scan fallback.
+          if (signal?.aborted) throw error;
+          debugLogger.warn(
+            `session index listing failed, falling back to scan: ${String(error)}`,
+          );
+        }
+      }
+    }
 
     // Get all valid session files (matching UUID pattern) with their stats
     let files: Array<{ name: string; mtime: number }> = [];

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -3713,6 +3713,14 @@
           "description": "Generate a short LLM-based label after each tool batch completes. For a completed tool group the label replaces the generic `Tool × N` header; when the group is force-expanded it appears as a dim `● <label>` line below the tool group. Requires a fast model to be configured; runs in parallel with the next API call so latency is hidden. Currently affects interactive CLI rendering only — SDK / non-interactive emission of the `tool_use_summary` message is not yet wired (the message factory is exported for a follow-up PR). Can be overridden with QWEN_CODE_EMIT_TOOL_USE_SUMMARIES=0 or =1.",
           "type": "boolean",
           "default": true
+        },
+        "sessionIndex": {
+          "description": "Index backend for session listing and transcript navigation: 'file' (default; derive indexes by scanning session JSONL on demand) or 'sqlite' (experimental; maintain a rebuildable node:sqlite sidecar per project with byte-offset checkpoints and serve reads from it). Session JSONL files remain the sole authoritative store either way; when the sidecar or the node:sqlite driver is unavailable, reads automatically fall back to file scanning. Options: file, sqlite",
+          "enum": [
+            "file",
+            "sqlite"
+          ],
+          "default": "file"
         }
       }
     },


### PR DESCRIPTION
## What this PR does

Adds an opt-in, rebuildable SQLite sidecar index for session storage, enabled via `experimental.sessionIndex: "sqlite"` (default `file`, which keeps today's behavior exactly). JSONL transcripts remain the sole authoritative store; the sidecar is a per-project node:sqlite database that mirrors a session catalog and per-record byte offsets, maintained incrementally with byte checkpoints — append catch-up, rewind-rebuild on shrink or replacement, TTL-bounded directory reconciliation with an always-on names pass, and a durable derived-turn cache invalidated by byte position. The session listing and transcript turn-navigation read paths serve from it when enabled, and every failure mode — mode off, driver missing, database corrupted, store busy, mismatched or oversized input — either falls back to today's file-scanning behavior or reproduces today's typed errors identically (#11433 alternative 2, as scoped in that discussion).

## Why it's needed

The current read paths re-derive index data on every process start: listings scan the chats directory (stat + sort, plus first-line reads per page), and transcript paging scans an entire session file on an in-memory index miss. Benchmarks run for the #11433 evaluation (methodology posted there) measured, on realistic synthetic corpora: 8.3 s to page through 10,000 sessions, 365 ms cold per 200 MB transcript, and — once the working set's combined index estimate exceeds the 64 MiB in-memory budget (#11493) — a full rescan on every single history navigation, forever. With this PR enabled, 10k-session pagination is ~100x faster, multi-session navigation regains a stable sub-10 ms path immune to the admission cliff, daemon restarts stop re-scanning sessions for listing and turn navigation, and the memory cost of hot indexes moves from the JS heap to disk — which is the trade small 2–4 vCPU daemon hosts want. Turning the flag off reverts everything with zero migration, because nothing in the write path changed.

## Reviewer Test Plan

### How to verify

The load-bearing guarantee is output parity against file-scan mode: `cd packages/core && npx vitest run src/services/session-index/` — 33 tests: the sqlite store (incremental sync, partial trailing lines, rewind, mismatch, schema rebuild, GC), process wiring (driver probe, in-flight open dedup, corruption recovery), and a parity suite that runs the same adversarial corpus (branches, realtime, cron/scheduled, forks, glued-line fragments, malformed lines, non-UUID files, empty files, goal-only sessions, parent/source/title metadata, appends after caching, unparseable cursors, sweep-window session creation) through both modes and asserts byte-identical `listSessions` pages (items + `hasMore`/`nextCursor`) and `readTurnIndexPage` results including snapshot continuation in both directions. Also relevant: `npx vitest run src/services/sessionService.test.ts src/services/session-transcript-reader.test.ts` (existing suites, unchanged expectations) and `packages/cli/src/config/config.test.ts` (settings wiring). For a hands-on check: `npm run dev -- serve --port 4179 --workspace <tmp-ws> --safe-mode` with `HOME` pointed at an isolated dir, seed a few sessions under a custom `QWEN_RUNTIME_DIR`, and compare `GET /workspace/<urlenc-cwd>/sessions` and `GET /session/:id/turn-index` response bodies with `experimental.sessionIndex` absent vs `"sqlite"` — they must be identical, and a `sessions.index.sqlite` file then appears next to `chats/`.

### Evidence (Before & After)

N/A (not user-visible without the flag; behavior with the flag on is asserted byte-identical to off).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Node v22.23.2 (`node:sqlite` unflagged, `ExperimentalWarning` only); daemon route parity validated via dev `serve` with isolated `HOME`/`QWEN_RUNTIME_DIR`; performance numbers from the #11433 evaluation harness rerun against this implementation (10k-session full pagination 8,304 ms → 79 ms; 40-session churn median 14.9 ms → 1.5 ms; 200 MB turn page warm 1.4 ms).

## Risk & Scope

- Main risk or tradeoff: SQLite sync work is synchronous — incremental sync is chunked and queued on a single shared connection, but a first-ever full build of a very large archive is a deliberate one-time cost (measured 3.9 s for 10k sessions, bounded and off the hot path).
- Not validated / out of scope: `readPage` / full in-memory transcript index from SQL, full-text search, the write-path inline sync hook (deferred — read-path stat validation bounds staleness correctly), Node 24 stability status of `node:sqlite` before any default flip, and a Bun CI lane for the standalone OpenTUI flavor.
- Breaking changes / migration notes: none — flag default off; file scan untouched; sidecar deletable at any time with automatic rebuild.

Design doc: [session-sqlite-sidecar.md](docs/design/session-sqlite-sidecar.md) · [中文版](docs/design/session-sqlite-sidecar.zh-CN.md) — both updated to the final implementation (settings key, daemon wiring, derived-turn cache, reconciliation policy).

## Linked Issues

Ref #11433 · Related: #11493

<details>
<summary>中文说明</summary>

本 PR 增加一个可选开启、可重建的 SQLite sidecar 会话索引，经 `experimental.sessionIndex: "sqlite"` 启用(默认 `file`,完全保持现状)。JSONL transcript 保持唯一权威存储;sidecar 是每个项目一个的 node:sqlite 数据库,镜像会话目录与记录字节偏移,用字节检查点增量维护——追加追平、收缩或替换时回卷重建、TTL 限速的目录对账(名称对账永不缺席),以及按字节位置失效的持久派生 turn 缓存。开启后,会话列表与 transcript turn 导航读路径改由它服务;所有失败模式——未开启、驱动缺失、数据库损坏、store 繁忙、mis-matched 或超大输入——要么回退到今天的文件扫描行为,要么产生与今天完全一致的类型化错误(#11433 的方案二,按该讨论的收敛范围)。

动机:当前读路径在每次进程启动时都要重新推导索引——列表要扫目录(stat+排序,逐页读首行),transcript 分页在内存索引未命中时要扫完整个会话文件。#11433 评估基准(方法已发到 issue)实测:翻完 1 万个会话 8.3 秒,200MB transcript 冷读 365ms,工作集索引合计超过 64MiB 内存预算后(#11493)每次翻历史都是全量重扫、永不收敛。开启本 PR 后:一万会话翻页约 100 倍加速,多会话导航稳定到 10ms 内且免疫准入悬崖,daemon 重启不再重扫一切,热索引的内存占用从 JS 堆移到磁盘——这正是 2–4 vCPU 小规格 daemon 主机需要的交换。关闭开关即零迁移回退,因为写路径没有任何变化。

验证:核心保证是与文件扫描模式的输出一致性——`cd packages/core && npx vitest run src/services/session-index/`(33 个测试:sqlite store 增量同步/半行/回卷/mismatch/schema 重建/GC;进程级驱动探测/并发去重/损坏恢复;以及覆盖分支/realtime/cron/fork/glued-line/坏行/非 UUID 文件/空文件/goal-only/元数据/追加后缓存/异常游标/新建会话可见性的双向逐字节 parity 套件)。另有既有 sessionService/reader 套件与 CLI settings 接线测试。手工抽查:`serve` 起本地守护,对比开关两侧 `sessions` 与 `turn-index` 路由响应体必须一致,随后项目目录出现 `sessions.index.sqlite`。

测试环境:macOS + Node v22.23.2 已测;Windows/Linux 未测(⚠️)。

风险:同步 SQLite 调用为阻塞式——增量同步已分片并在单共享连接上排队,但超大会话档案的首次全量构建是有意的一次性成本(实测一万会话 3.9 秒,有界且不在热路径)。范围外:readPage、全文检索、写路径内联同步(读路径 stat 校验足以界定陈旧)、默认翻转前 node:sqlite 在 Node 24 线的状态、Bun CI 冒烟。无破坏性变更:开关默认关,文件扫描不受影响,sidecar 随时可删自动重建。

设计文档见上方链接(中英文已同步到最终实现)。关联 #11433、#11493。

</details>

