### PR TITLE
fix(ci): grant the packaging check the permissions its callee declares

### DIFF
--- a/.github/workflows/desktop-packaging-check.yml
+++ b/.github/workflows/desktop-packaging-check.yml
@@ -23,8 +23,14 @@ on:
         default: 'main'
         type: 'string'
 
+# A caller must grant every permission the called workflow's jobs declare, or
+# the run fails to start — the check happens when the file is loaded, before
+# any `if` is evaluated, so the publish job being unreachable in a dry run
+# does not exempt its `contents: write`. Nothing here writes: `dry_run` is
+# hardcoded true below, which skips both the publish and the mirror job.
 permissions:
-  contents: 'read'
+  actions: 'read'
+  contents: 'write'
 
 concurrency:
   group: 'desktop-packaging-check'


### PR DESCRIPTION
## What this PR does

Grants the scheduled desktop packaging check the two permissions the release workflow's own jobs declare, so it can start.

## Why it's needed

The first dispatch of the check died in two seconds with no job, no step and no annotation — the shape of a startup failure. A workflow that calls another must grant every permission the called workflow's jobs declare, and the release workflow's publish job declares write access to contents while the OSS mirror job asks to read actions. The check granted read access to contents and nothing else.

The trap is that this validation happens when the file is loaded, before any condition is evaluated. Both of those jobs are unreachable from this check — it hardcodes a dry run, and each of them is additionally gated on a real publish — but being unreachable does not exempt their declared permissions from the comparison. So a check that can never write still has to say it may.

Nothing here writes. The dry run leaves the publish and mirror jobs skipped on their own conditions, exactly as it did in the release runs this reuses.

## Reviewer Test Plan

### How to verify

Dispatch the check against `main` and confirm it now starts and fans out into the release workflow's four build jobs, and that the publish and mirror jobs report skipped rather than running. Before this change the same dispatch produced a run with zero jobs.

### Evidence (Before & After)

Before: run [34444598159](https://github.com/QwenLM/qwen-code/actions/runs/34444598159), `startup_failure`, 2 seconds, no jobs. After: a run that reaches the build matrix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ not tested  |

Workflow permission resolution only happens on GitHub's side, so this can only be confirmed by dispatching after merge.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: a scheduled workflow now declares write access to contents that it never exercises. The narrower alternative would be relaxing the permissions the release workflow's publish job declares, which trades a real safeguard for a cosmetic one on the caller.
- Not validated / out of scope: whether the check passes once it starts. Its first real run is still ahead of it.
- Breaking changes / migration notes: none.

## Linked Issues

Follows #11519.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为定时的桌面打包检查授予被调用 workflow 各 job 所声明的两项权限，使其能够正常启动。

## 为什么需要

该检查的第一次触发在两秒内结束，没有 job、没有 step、也没有任何注解——这是启动失败的典型形态。调用方 workflow 必须授予被调用 workflow 中各 job 所声明的全部权限，而发布 workflow 的 publish job 声明了对 contents 的写权限，OSS 镜像 job 则请求读取 actions。该检查只授予了 contents 的读权限。

陷阱在于：这项校验发生在文件被加载时，早于任何条件求值。这两个 job 从本检查出发都是不可达的——它把 dry run 写死为 true，而两者各自还有以真实发布为前提的门槛——但"不可达"并不能让它们声明的权限免于比对。因此一个永远不会写入的检查，仍然必须声明它可能写入。

这里不会有任何写入。dry run 会让 publish 与镜像 job 按各自条件保持 skipped，与它所复用的那些发布运行中的表现完全一致。

## 评审验证计划

### 如何验证

针对 `main` 触发该检查，确认它现在能够启动并展开为发布 workflow 的四个构建 job，且 publish 与镜像 job 报告 skipped 而非实际运行。在此改动之前，同样的触发产生的是一个零 job 的运行。

### 证据（Before & After）

之前：运行 [34444598159](https://github.com/QwenLM/qwen-code/actions/runs/34444598159)，`startup_failure`，2 秒，无任何 job。之后：能够走到构建矩阵的运行。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ 未测试  |

workflow 的权限解析只发生在 GitHub 侧，因此只能在合并后通过触发来确认。

### 环境（可选）

N/A

## 风险与范围

- 主要风险/取舍：一个定时 workflow 现在声明了它从不使用的 contents 写权限。更收敛的替代方案是放宽发布 workflow 中 publish job 所声明的权限，但那是用一项真实的防护换取调用方形式上的收敛。
- 未验证 / 不在范围内：该检查启动之后能否通过。它的第一次真实运行仍在前方。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

承接 #11519。

</details>
