### PR TITLE
test(web-shell): fix brand test breakage from the compact-footer interaction

### DIFF
--- a/packages/web-shell/client/components/WorkspaceSessionProvider.loading.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.loading.test.tsx
@@ -196,7 +196,13 @@ it.each(
         );
         root.render(strictMode ? <StrictMode>{tree}</StrictMode> : tree);
       });
-      expect(calls).toEqual(['GET /capabilities']);
+      // The brand fetch rides beside capabilities on its own deferred
+      // channel (#11244), so whether it lands before this assertion is
+      // scheduling-dependent; what this test pins is that the load itself
+      // fetched capabilities exactly once.
+      expect(calls.filter((call) => call !== 'GET /brand')).toEqual([
+        'GET /capabilities',
+      ]);
       expect(observeLiveStateSupport).not.toHaveBeenCalled();
       await act(async () => {
         releaseCapabilities();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.brand.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.brand.test.tsx
@@ -195,7 +195,10 @@ describe('sidebar brand', () => {
   it('treats an empty name as unset rather than blanking the brand row', () => {
     // `""` means "use the built-in name" on the settings surface, so a host
     // that builds its prop the same way must not get an empty sidebar row and
-    // a version tooltip reading " v1.2.3".
+    // a version tooltip reading " v1.2.3". The tooltip lives on the footer
+    // version label, which compact mode intentionally hides below its
+    // breakpoint (#11470) — render wider than that so it exists at all.
+    window.localStorage.setItem('qwen-code-web-shell-sidebar-width', '400');
     renderSidebar({ name: '' });
 
     expect(container.textContent).toContain('Qwen Code');
@@ -205,6 +208,9 @@ describe('sidebar brand', () => {
   });
 
   it('names the version tooltip after the brand', () => {
+    // Same compact-mode breakpoint: the tooltip is on the footer version
+    // label, so the sidebar must render above it.
+    window.localStorage.setItem('qwen-code-web-shell-sidebar-width', '400');
     renderSidebar({ name: 'QiuQiu Code' });
 
     expect(


### PR DESCRIPTION
## What this PR does

Fixes two web-shell test breakages on main: the brand sidebar tests now render at a sidebar width above the compact-foot breakpoint when they assert the version tooltip, and the workspace-session loading test no longer assumes the brand fetch's timing relative to its load assertion.

## Why it's needed

Main's `Test` job fails on every PR right now. Two recent merges interact: the branding feature (#11244) added brand sidebar tests that assert the `[title="<name> v<version>"]` tooltip, but the compact-footer change (#11470) intentionally removes the version label below its 344px breakpoint and the default test width is 260px, so the tooltip is never rendered in those tests. The same branding change also made the workspace provider fetch `GET /brand` beside `GET /capabilities` on a deferred channel; the loading test's exact fetch-list assertion races with it — consistently red under CI's scheduling, consistently green on a fast local machine.

Verified broken on `origin/main` locally before this change, and verified green after: full web-shell suite 300 files / 7113 tests pass.

## Reviewer Test Plan

### How to verify

On current main, run the two files: `cd packages/web-shell && npx vitest run client/components/sidebar/WebShellSidebar.brand.test.tsx` fails 2 brand tests deterministically; `npx vitest run` (full suite, which adds scheduling pressure) fails the 6 workspace-loading variants. With this PR both are green.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: none — test-only changes; no production behavior changes. The compact-mode hiding of the version label (the #11470 behavior) is preserved and not re-tested here.
- Not validated / out of scope: whether the version tooltip should also exist in compact mode is a product question for #11470's owner, deliberately left alone.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #11244, #11470.

<details>
<summary>中文说明</summary>

修复 main 上当前两个 web-shell 测试破坏:品牌 sidebar 测试在断言版本 tooltip 时改在 compact footer 断点以上的宽度渲染;workspace 加载测试不再假定品牌拉取与其加载断言的相对时序。

背景:#11244(品牌可配置)新增的品牌测试断言 `[title="<名称> v<版本>"]` tooltip,但 #11470(compact footer)在 344px 断点以下有意移除版本标签,而测试默认宽度 260px,所以 tooltip 根本不会渲染。同一品牌变更还让 workspace provider 在 `GET /capabilities` 旁异步拉取 `GET /brand`,与加载测试的精确请求列表断言产生时序竞争 —— CI 调度下必红,本地快机上必绿。

本地已在 `origin/main` 上复现失败,修复后 web-shell 全套件 300 文件 / 7113 测试全绿。

</details>