### PR TITLE
ci(desktop): promote a built desktop release without rebuilding it

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -23,6 +23,7 @@
 1482 codeql.yml
 9389 comment-attachment-guard.yml
 1634 desktop-packaging-check.yml
+7559 desktop-promote.yml
 31677 desktop-release.yml
 2038 docs-page-action.yml
 10005 dsw-swe-verified-release.yml

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -1,0 +1,179 @@
+name: 'Desktop Promote'
+
+run-name: 'Promote Qwen Code Desktop ${{ inputs.version }}'
+
+# Publishes an already-built desktop release and advances the updater feed,
+# without building anything.
+#
+# The version string is compiled into every artifact — the app bundle's
+# Info.plist, the NSIS VIProductVersion, the deb control file, the binary
+# itself — so a build made as `0.3.0-preview.0` can never become `0.3.0` by
+# renaming files. The installed app would keep reporting the prerelease
+# version, the feed would keep offering it the stable one, and it would
+# update in a loop. Promotion therefore only works on a release built under
+# the version it will ship as, held back as a draft:
+#
+#   Desktop Release   version=0.3.1  dry_run=false  draft=true  prerelease=false
+#     signed, notarized, complete — and invisible: the publish job leaves the
+#     feed alone for a draft, and the OSS mirror does not run
+#   verify that draft's assets on a real machine
+#   Desktop Promote   version=0.3.1
+#     publishes the release, advances the feed, mirrors to OSS
+#
+# What this replaces is building the same commit twice and notarizing it
+# twice — once as a preview, once as the release — for a change of version
+# string alone.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable desktop version to promote, for example 0.3.1. Its release must already exist.'
+        required: true
+        type: 'string'
+
+permissions:
+  contents: 'read'
+
+# Shares the release workflow's publishing group: a promote and a publishing
+# release run both move the feed, and must not interleave.
+concurrency:
+  group: 'desktop-release-publish'
+  cancel-in-progress: false
+
+env:
+  DESKTOP_FEED_TAG: 'desktop-latest'
+
+jobs:
+  promote:
+    name: 'Promote release'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 20
+    permissions:
+      contents: 'write'
+    outputs:
+      version: '${{ steps.resolve.outputs.version }}'
+      url: '${{ steps.publish.outputs.url }}'
+    steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Resolve release'
+        id: 'resolve'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          INPUT_VERSION: '${{ inputs.version }}'
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF_NAME" != 'main' ]; then
+            echo '::error::Desktop promotions must run from main.'
+            exit 1
+          fi
+          version="${INPUT_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Promotion needs a stable X.Y.Z version, got '$INPUT_VERSION'. A prerelease build cannot be promoted: its version is compiled into the artifacts, so it must be rebuilt under the stable version instead."
+            exit 1
+          fi
+          tag="desktop-v$version"
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            echo "::error::Release $tag does not exist. Build it first with Desktop Release (dry_run=false, draft=true)."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: 'Verify the release ships this version'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          RELEASE_TAG: '${{ steps.resolve.outputs.tag }}'
+          RELEASE_VERSION: '${{ steps.resolve.outputs.version }}'
+        run: |
+          set -euo pipefail
+          mkdir -p promote-assets
+          gh release download "$RELEASE_TAG" --dir promote-assets --pattern 'desktop-latest.json'
+          # The manifest is generated from the artifacts themselves, so a
+          # mismatch here means the release was built under a different
+          # version and renaming it would start the update loop above.
+          manifest_version="$(jq -r '.version' promote-assets/desktop-latest.json)"
+          if [ "$manifest_version" != "$RELEASE_VERSION" ]; then
+            echo "::error::$RELEASE_TAG carries an updater manifest for $manifest_version, not $RELEASE_VERSION."
+            exit 1
+          fi
+          for platform in darwin-aarch64 darwin-x86_64 windows-x86_64 linux-x86_64; do
+            if ! jq -e --arg platform "$platform" '.platforms[$platform].url' promote-assets/desktop-latest.json >/dev/null; then
+              echo "::error::The updater manifest in $RELEASE_TAG has no entry for $platform."
+              exit 1
+            fi
+          done
+
+      - name: 'Publish the release'
+        id: 'publish'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          RELEASE_TAG: '${{ steps.resolve.outputs.tag }}'
+        run: |
+          set -euo pipefail
+          # Before the feed: the manifest points at this release's download
+          # URLs, which only resolve once it is no longer a draft.
+          gh release edit "$RELEASE_TAG" --draft=false --prerelease=false
+          echo "url=$(gh release view "$RELEASE_TAG" --json url --jq '.url')" >> "$GITHUB_OUTPUT"
+
+      - name: 'Update stable updater feed'
+        shell: 'bash'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          FEED_TAG: '${{ env.DESKTOP_FEED_TAG }}'
+          RELEASE_VERSION: '${{ steps.resolve.outputs.version }}'
+        run: |
+          set -euo pipefail
+          if gh release view "$FEED_TAG" >/dev/null 2>&1; then
+            directory="$(mktemp -d)"
+            trap 'rm -rf "$directory"' EXIT
+            gh release download "$FEED_TAG" --dir "$directory" --pattern 'desktop-latest.json'
+            current="$(jq -r '.version' "$directory/desktop-latest.json")"
+            if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Current Desktop stable feed has an invalid version: $current"
+              exit 1
+            fi
+            newest="$(printf '%s\n%s\n' "$RELEASE_VERSION" "$current" | sort -V | tail -n 1)"
+            if [ "$current" != "$RELEASE_VERSION" ] && [ "$newest" = "$current" ]; then
+              echo "::notice::Desktop $RELEASE_VERSION will not replace newer stable feed $current."
+              exit 0
+            fi
+            gh release upload "$FEED_TAG" promote-assets/desktop-latest.json --clobber
+          else
+            gh release create "$FEED_TAG" promote-assets/desktop-latest.json --title 'Qwen Code Desktop latest' --notes 'Stable desktop updater feed.' --latest=false
+          fi
+
+      - name: 'Promotion summary'
+        shell: 'bash'
+        env:
+          RELEASE_TAG: '${{ steps.resolve.outputs.tag }}'
+          RELEASE_URL: '${{ steps.publish.outputs.url }}'
+          RELEASE_VERSION: '${{ steps.resolve.outputs.version }}'
+        run: |
+          {
+            echo '## Desktop promotion'
+            echo
+            echo "Version: $RELEASE_VERSION"
+            echo "Tag: $RELEASE_TAG"
+            echo "Release: $RELEASE_URL"
+            echo
+            echo 'Nothing was rebuilt: the published assets are the ones this release was already carrying.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  sync-oss:
+    name: 'Mirror stable Desktop release to Aliyun OSS'
+    needs: 'promote'
+    permissions:
+      actions: 'read'
+      contents: 'read'
+    uses: './.github/workflows/sync-desktop-to-oss.yml'
+    with:
+      version: '${{ needs.promote.outputs.version }}'
+      source: 'release'
+    secrets:
+      ALIYUN_OSS_ACCESS_KEY_ID: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}'
+      ALIYUN_OSS_ACCESS_KEY_SECRET: '${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}'


### PR DESCRIPTION
## What this PR does

Adds a workflow that publishes an already-built desktop release and advances the updater feed, without building anything.

The flow it enables is: build the release under the version it will ship as but hold it back as a draft, verify that draft on real machines, then promote it. The release workflow already leaves the updater feed alone for a draft and skips the OSS mirror, so such a build is complete, signed, notarized — and invisible. Promotion publishes it, moves the feed, and mirrors to OSS.

## Why it's needed

Shipping 0.3.0 built the same commit twice and notarized it twice: once as `0.3.0-preview.0` so it could be verified, once as `0.3.0` so it could be released. The second build differed from the first by a version string. That is roughly fifty minutes of runner time, two trips through Apple's notary service, and a second chance for something unrelated to break between them.

Reusing the first build's artifacts by renaming them is not an option, and that deserves saying plainly because it looks like one. The version is compiled into the app bundle's Info.plist, the Windows installer's product version, the deb control file, and the binary itself. A renamed preview would install and then report itself as `0.3.0-preview.0`, while the feed offered it `0.3.0` — and since a stable version sorts above its own prerelease, it would update again on every check, forever. The artifacts have to be built under the version they ship as; what does not have to happen twice is the build.

The guards exist for the same reason. The workflow refuses a version carrying a prerelease suffix, and refuses a release whose updater manifest names a different version or is missing a platform — each is the renamed-artifacts mistake arriving by a different route.

## Reviewer Test Plan

### How to verify

The next release is the test. Build it with the stable version and `draft=true`, and confirm what the draft state is supposed to give you: a release with a full set of signed assets, an updater feed still on the previous version, and no OSS mirror run. Verify the assets, then promote and confirm the release goes public, both feeds advance to the new version, and no build job ran.

The guards are worth exercising directly, since they are what stands between a mistake and an update loop on every installation. Promoting a version with a prerelease suffix should be refused at the first step. Promoting a version whose release carries a manifest for a different version should be refused before anything is published — the existing `desktop-v0.3.0-preview.0` release is a ready-made case: asking to promote `0.3.0` while that manifest says `0.3.0-preview.0`.

Also confirm the feed guard still holds: promoting an older version while the feed is on a newer one should decline rather than roll the feed backwards, the same behavior the release workflow has.

### Evidence (Before & After)

Before: promoting meant a second full build — for 0.3.0, run [34451486651](https://github.com/QwenLM/qwen-code/actions/runs/34451486651) rebuilt and re-notarized what run [34441331711](https://github.com/QwenLM/qwen-code/actions/runs/34441331711) had already produced. After: a job that downloads one JSON file and edits two releases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ not tested  |

Every shell block was syntax-checked and the file parses as valid workflow YAML, but a workflow can only really be tested by dispatching it, which needs it on the default branch first.

## Risk & Scope

- Main risk or tradeoff: this workflow moves the updater feed, so a mistake here reaches every installation. That is why it validates before it publishes and publishes before it moves the feed — the manifest inside a release points at that release's download URLs, which do not resolve while it is a draft. It shares the release workflow's publishing concurrency group so the two cannot interleave.
- Not validated / out of scope: the draft-based release flow itself is unchanged and already supported; this only adds the second half. The Electron bridge assets are deliberately not handled — that was a one-time migration tied to a specific build, not something a promotion should carry.
- Breaking changes / migration notes: none. Releasing the way 0.3.0 was released still works exactly as before.

## Linked Issues

Related to #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个 workflow，用于发布一个已经构建好的桌面版本并推进更新源，全程不构建任何东西。

它启用的流程是：以最终版本号构建、但先压成 draft 不公开，在真机上验收该 draft，然后再转正。发布 workflow 对 draft 本来就不会动更新源、也不会跑 OSS 镜像，因此这样构建出来的版本是完整的、已签名、已公证的——同时又是不可见的。转正这一步负责把它公开、推进更新源、并同步到 OSS。

## 为什么需要

发布 0.3.0 时，同一个 commit 被构建了两次、公证了两次：一次叫 `0.3.0-preview.0` 用来验收，一次叫 `0.3.0` 用来发布。第二次构建与第一次的差别只是一个版本字符串。这大约是五十分钟的机器时间、两趟苹果公证服务，以及多出来的一次"中间出别的岔子"的机会。

把第一次的产物改名复用是行不通的，而这一点值得明说，因为它看起来行得通。版本号被编译进了 app bundle 的 Info.plist、Windows 安装包的产品版本、deb 的 control 文件，以及二进制本身。改过名的 preview 装上之后仍会自报 `0.3.0-preview.0`，而更新源提供的是 `0.3.0`——由于正式版在 semver 中大于它自己的预发布版，它会在每次检查时再次更新，永无止境。产物必须以它将要发布的版本号构建；不必发生两次的是构建本身。

那些校验也源于同一个原因。该 workflow 拒绝带预发布后缀的版本，也拒绝更新清单版本不符或缺少平台的 release——它们都是"改名复用"这个错误换了条路径抵达。

## 评审验证计划

### 如何验证

下一次发布就是验证。以正式版本号加 `draft=true` 构建，确认 draft 状态应当给出的东西：一个带完整签名产物的 release、仍停留在旧版本的更新源、以及没有跑过的 OSS 镜像。验收产物之后再执行转正，确认 release 变为公开、两个更新源都推进到新版本，且没有任何构建 job 运行过。

那几道校验值得单独试，因为它们正是"一个失误"和"所有安装陷入更新循环"之间的唯一屏障。转正一个带预发布后缀的版本，应当在第一步就被拒绝。转正一个更新清单版本不符的 release，应当在任何东西被发布之前就被拒绝——现有的 `desktop-v0.3.0-preview.0` 正好是现成的用例：在其清单写着 `0.3.0-preview.0` 的情况下请求转正 `0.3.0`。

同时确认更新源的防退化仍然成立：在更新源已是较新版本时转正一个较旧版本，应当放弃而不是把更新源回退——与发布 workflow 的行为一致。

### 证据（Before & After）

之前：转正意味着第二次完整构建——0.3.0 的运行 [34451486651](https://github.com/QwenLM/qwen-code/actions/runs/34451486651) 重新构建并重新公证了运行 [34441331711](https://github.com/QwenLM/qwen-code/actions/runs/34441331711) 已经产出过的东西。之后：一个下载一份 JSON、编辑两个 release 的 job。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ⚠️ 未测试  |

所有 shell 块都做了语法检查，文件也能作为合法的 workflow YAML 解析；但 workflow 只能通过实际触发来真正验证，而那需要它先进入默认分支。

## 风险与范围

- 主要风险/取舍：该 workflow 会移动更新源，因此这里的失误会波及所有安装。正因如此，它先校验再发布、先发布再移动更新源——release 内的清单指向的是该 release 的下载地址，而这些地址在它还是 draft 时无法解析。它与发布 workflow 共用同一个发布并发组，两者不会交错运行。
- 未验证 / 不在范围内：基于 draft 的发布流程本身没有改动，且本来就受支持；本 PR 只补上后半段。Electron 桥接产物有意不处理——那是绑定于某次特定构建的一次性迁移，不该由转正流程携带。
- 破坏性变更 / 迁移说明：无。按 0.3.0 的方式发布仍然完全照旧可用。

## 关联 Issue

关联 #8092。

</details>
