### PR TITLE
fix(cli): drain notification queue when a turn errors out

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -1676,6 +1676,54 @@ describe('Session', () => {
       session.dispose();
     });
 
+    it('drains a shell notification stranded when the owning prompt errors out', async () => {
+      let rejectPrompt!: (reason: Error) => void;
+      mockChat.sendMessageStream = vi.fn().mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectPrompt = reject;
+        }),
+      );
+      createReportingSession();
+      const notify =
+        mockBackgroundShellRegistry.setNotificationCallback.mock.calls.at(
+          -1,
+        )?.[0] as (
+          displayText: string,
+          modelText: string,
+          meta: { shellId: string; status: string },
+        ) => void;
+
+      // Start a prompt and let it reach the model send before the shell
+      // completes, so the completion notification queues while the prompt is
+      // still pending.
+      const promptPromise = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hello' }],
+      });
+      await vi.waitFor(() =>
+        expect(mockChat.sendMessageStream).toHaveBeenCalledOnce(),
+      );
+
+      notify('Shell completed.', '<task-notification />', {
+        shellId: 'shell-stranded',
+        status: 'completed',
+      });
+      await vi.waitFor(() =>
+        expect(holdIds('shell')).toEqual(['background-shells']),
+      );
+
+      // The prompt then fails with a plain provider error (not loop detection
+      // or a stop guard), which previously stranded the queued notification.
+      rejectPrompt(new Error('provider failed'));
+      await expect(promptPromise).rejects.toThrow('provider failed');
+
+      await vi.waitFor(() =>
+        expect(session.collectActiveWorkHolds()).toEqual([]),
+      );
+      expect(session.isIdle()).toBe(true);
+      session.dispose();
+    });
+
     it('releases the shell hold after a cancelled continuation exits', async () => {
       let releaseNotification!: () => void;
       const notificationGate = new Promise<void>((resolve) => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -39173,7 +39173,7 @@ describe('Session', () => {
       expect(guardAttempts).toEqual([1, 2, 2]);
     });
 
-    it('does not change error-time queue draining before the Guard is armed', async () => {
+    it('drains a mid-turn background completion when an unarmed turn errors out', async () => {
       rebuildSessionWithGuard();
       const callback =
         mockBackgroundTaskRegistry.setNotificationCallback.mock.calls.at(
@@ -39189,19 +39189,24 @@ describe('Session', () => {
           status: 'completed',
         });
       });
-      mockChat.sendMessageStream = vi.fn().mockResolvedValue(failedStream);
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValueOnce(failedStream)
+        .mockResolvedValue(createEmptyStream());
 
       await expect(runGuardPrompt()).rejects.toThrow('unarmed stream failed');
 
-      const internals = session as unknown as {
-        notificationProcessing: boolean;
-        notificationQueue: Array<{ taskId: string }>;
-      };
-      expect(internals.notificationProcessing).toBe(false);
-      expect(internals.notificationQueue).toEqual([
-        expect.objectContaining({ taskId: 'unrelated-after-unarmed-error' }),
-      ]);
-      expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(1);
+      // A background completion queued mid-turn must not be stranded when the
+      // owning turn errors out: the error path drains it so the session can
+      // return to idle instead of holding activeWorkState forever.
+      await vi.waitFor(() => {
+        expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(2);
+      });
+      const automaticCall = vi.mocked(mockChat.sendMessageStream).mock
+        .calls[1]?.[1] as { message: Part[] };
+      expect(textParts(automaticCall.message).join('\n')).toContain(
+        '<unrelated-after-unarmed-error />',
+      );
     });
 
     it('clears a failed guard chain when a new ordinary prompt starts', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -5000,7 +5000,10 @@ export class Session implements SessionContext {
       if (stillOwnsPendingPrompt) {
         this.todoStopGuardDrainAutomaticQueuesWhenIdle = false;
       }
-      if (shouldDrainAutomaticQueues) {
+      // The success path drains after releasePendingSend; mirror that on the
+      // error path so a background-shell completion that queued mid-turn is
+      // not stranded when the turn ends with a provider error.
+      if (shouldDrainAutomaticQueues || stillOwnsPendingPrompt) {
         void this.#drainCronQueue();
         void this.#drainNotificationQueue();
       }


### PR DESCRIPTION
## What this PR does

Fixes a stuck session in the daemon-hosted Web Shell where the sidebar spinner never clears. When a background shell finishes mid-turn and that turn then ends with a provider streaming error, the shell's completion notification is left stranded in the automatic notification queue because the error path never drains it. The change makes the turn's error path drain the automatic queues exactly as the success path already does, so the queued completion is delivered and the session's active-work state clears.

## Why it's needed

The sidebar spinner is driven by the daemon's active-work state. A background-shell completion is represented as a "shell" hold that only clears once its terminal notification is drained and turned into a follow-up continuation. The success path drains the queue after the turn releases its pending-prompt lock, but the error path only drained under a narrower set of conditions (loop detection and a few stop-guard cases). A plain provider error skipped the drain, so the shell hold never cleared, the daemon kept reporting the session as active, and the spinner spun forever even though the turn had already failed and the shell had already completed.

## Reviewer Test Plan

### How to verify

Run the targeted regression test in the ACP session suite, filtering for "drains a shell notification stranded when the owning prompt errors out". Without the fix the test fails asserting a leftover shell hold after the prompt rejects; with the fix the hold clears and the session reports idle.

### Evidence (Before & After)

Before: the assertion that the session has no active work holds receives `[{ category: 'shell', id: 'background-shells' }]` — the stranded shell hold.
After: the assertion passes, the shell hold clears, and the session is idle.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Unit test only, run from the CLI package directory.

## Risk & Scope

- Behavior change: the error path now drains the automatic queues whenever the failing turn still owns its pending prompt, mirroring the success path. A background completion — shell, agent, or workflow — that queued mid-turn now starts its follow-up continuation after a plain provider error, instead of sitting in the queue and pinning the session's active-work state. This is the intended behavior: an undrained completion keeps the daemon reporting an active session and the sidebar spinner spinning forever, which is exactly the symptom being fixed.
- The drain remains guarded: it no-ops while another turn owns the prompt or the session is busy, and it still refuses work the todo-stop-guard has deferred. The extra attempt is therefore safe and idempotent.
- Out of scope: a notification queued while a goal or cron turn is active still does not arm a settle-retry, because those turn paths settle outside the ordinary prompt flow. Tracked as a follow-up.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #11547

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复了守护进程托管的 Web Shell 中会话卡住、侧边栏加载指示器永不消失的问题。当后台 shell 在某一轮会话进行中完成、而这一轮随后又以提供方流式错误结束时，shell 的完成通知会被滞留在自动通知队列里，因为错误路径不会清理该队列。此改动让这一轮的错误路径像成功路径一样清理自动队列，从而把排队的完成通知派发出去，并清空会话的活动工作状态。

## 为什么需要

侧边栏加载指示器由守护进程的活动工作状态驱动。后台 shell 的完成以"shell"占用（hold）表示，只有在其终止通知被清理并转化为后续续跑之后，该占用才会解除。成功路径会在这一轮释放待处理提示锁之后清理队列，但错误路径只在更窄的一组条件（循环检测以及若干停止守卫场景）下才会清理。普通的提供方错误跳过了清理，于是 shell 占用永远无法解除，守护进程一直把会话报告为活动状态，加载指示器无限旋转——即使这一轮早已失败、shell 也早已完成。

## 审阅者测试计划

### 如何验证

在 ACP 会话测试套件中运行针对性回归测试，过滤关键词 "drains a shell notification stranded when the owning prompt errors out"。没有修复时，测试会因断言在提示被拒绝后仍残留 shell 占用而失败；有了修复，占用解除、会话报告为空闲。

### 证据（修复前与修复后）

修复前：断言"会话无活动工作占用"收到 `[{ category: 'shell', id: 'background-shells' }]`——即被滞留的 shell 占用。
修复后：断言通过，shell 占用解除，会话处于空闲状态。

### 测试环境

|     操作系统      | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 运行环境（可选）

仅单元测试，从 CLI 包目录运行。

## 风险与范围

- 行为变更：错误路径现在会在失败轮仍持有其待处理提示时清理自动队列，与成功路径一致。在轮中途排队的后台完成（shell、agent 或 workflow）现在会在普通提供方错误之后启动其后续续跑，而不是滞留队列并把会话的活动工作状态卡住。这正是预期行为——未清理的完成会让守护进程持续报告活动会话、侧边栏加载指示器无限旋转，也就是本次要修复的症状。
- 清理仍受守卫：当另一轮持有提示或会话忙碌时会直接跳过，并且仍会拒绝 todo-stop-guard 已延迟的工作。因此额外的一次尝试是安全且幂等的。
- 超出范围：在 goal 或 cron 轮活跃期间排队的通知仍未武装 settle-retry，因为这些轮路径在普通提示流程之外结算。已记录为后续跟进。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Resolves #11547

</details>
