### PR TITLE
fix(vscode): preserve active file exclusion

### DIFF
--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
@@ -352,7 +352,7 @@ describe('EmbeddedApp host wiring', () => {
     expect(container.textContent).toContain('Get Started');
   });
 
-  it('keeps an explicit active-file exclusion across same-file editor changes', async () => {
+  it('keeps an explicit active-file exclusion across editor changes', async () => {
     await renderApp();
 
     const dispatchEditorChanged = (fileName: string, filePath: string) =>
@@ -410,7 +410,7 @@ describe('EmbeddedApp host wiring', () => {
         prepareSubmitAfterSameFile({ prompt: 'hi', inputAnnotations: [] }),
       ).resolves.toBeUndefined();
 
-      // Switching to a different file re-arms inclusion.
+      // Switching to a different file must preserve the explicit exclusion.
       await dispatchEditorChanged('other.ts', '/workspace/other.ts');
       const prepareSubmitAfterSwitch = callback<
         (submission: {
@@ -422,7 +422,7 @@ describe('EmbeddedApp host wiring', () => {
       >(mocks.embeddedProps.current as CapturedProps, 'prepareSubmit');
       await expect(
         prepareSubmitAfterSwitch({ prompt: 'hi', inputAnnotations: [] }),
-      ).resolves.toMatchObject({ prompt: '@other.ts hi' });
+      ).resolves.toBeUndefined();
     } finally {
       act(() => toolbarRoot.unmount());
       toolbarContainer.remove();

--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
@@ -419,7 +419,6 @@ export function EmbeddedApp() {
   const webShellPermissionRequestIdRef = useRef<string | undefined>(undefined);
   const focusedPermissionRequestIdRef = useRef<string | undefined>(undefined);
   const contextMenuRowKeyRef = useRef<string | null>(null);
-  const previousActiveFilePathRef = useRef<string | undefined>(undefined);
   const daemonBaseUrl = runtime?.baseUrl;
   const daemonToken = runtime?.token;
   const daemonClient = useMemo(
@@ -954,16 +953,8 @@ export function EmbeddedApp() {
             filePath: data.filePath,
             selection: data.selection,
           });
-          // The host fires this on every selection change, including plain
-          // cursor moves; only an actual file change may re-arm inclusion,
-          // or a click silently undoes the user's explicit exclusion.
-          if (previousActiveFilePathRef.current !== data.filePath) {
-            setIncludeActiveFile(true);
-          }
-          previousActiveFilePathRef.current = data.filePath;
         } else {
           setActiveFile(undefined);
-          previousActiveFilePathRef.current = undefined;
         }
       } else if (
         message.type === 'modeChanged' ||


### PR DESCRIPTION
## What this PR does

Restores the session-lifetime opt-out for automatic active-editor context in the VS Code companion. After a user excludes the active file, switching editors updates which file is displayed but no longer silently turns automatic inclusion back on. The user can still click the active-file control to re-enable inclusion, and the regression coverage now includes switching to a different file.

## Why it's needed

The v0.23 WebShell migration changed the previous interaction: an explicit exclusion was reset whenever the active file changed. That could add file context the user had deliberately excluded and made the control feel temporary rather than user-owned. This restores the pre-migration behavior reported in #11558.

## Reviewer Test Plan

### How to verify

1. Open the VS Code companion with file A active and confirm active-file context is included by default.
2. Click the active-file control to exclude file A.
3. Switch to file B and confirm the control still reports the active file as excluded and the next submission does not automatically include file B.
4. Click the control again and confirm active-file context is included for file B.

### Evidence (Before & After)

Before: after excluding file A, switching to file B changed the control back to included and the next submission received file B as automatic context.

After: in a real VS Code Extension Development Host on macOS, excluding `alpha.ts` and switching to `beta.ts` kept the control in the excluded state for `beta.ts`; clicking it again changed the state to included. The focused component regression suite also passes. This is a state-management fix with no visual layout change.

### Tested on

| OS | Status |
| --- | --- |
| macOS | ✅ Tested in VS Code Extension Development Host |
| Windows | ⚠️ Not manually tested |
| Linux | ⚠️ Not manually tested |

### Environment (optional)

VS Code Extension Development Host on macOS using a local development build.

## Risk & Scope

- Main risk or tradeoff: the exclusion now remains sticky for the current webview session until the user explicitly re-enables it, matching the behavior before the v0.23 migration.
- Not validated / out of scope: manual verification on Windows and Linux; persistence across a webview reload is intentionally unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11558

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复 VS Code companion 中自动附带当前编辑器文件的会话级关闭行为。用户主动排除当前文件后，切换编辑器仍会更新界面显示的文件，但不会再悄悄重新开启自动附带。用户仍可点击当前文件控件重新开启；回归测试也覆盖了切换到另一个文件的场景。

## 为什么需要

v0.23 WebShell 迁移改变了原有交互：每次切换当前文件都会重置用户主动做出的排除选择。这可能把用户明确不希望附带的文件上下文重新加入请求，也让这个开关表现得更像一次性操作。本 PR 恢复 #11558 所反馈的迁移前行为。

## Reviewer 测试计划

### 如何验证

1. 在文件 A 处于活动状态时打开 VS Code companion，确认默认会附带当前文件上下文。
2. 点击当前文件控件，排除文件 A。
3. 切换到文件 B，确认控件仍显示当前文件已排除，并且下一次提交不会自动附带文件 B。
4. 再次点击该控件，确认文件 B 的当前文件上下文重新被附带。

### 前后对比证据

修复前：排除文件 A 后切换到文件 B，控件会重新变成已包含，下一次提交也会自动收到文件 B 的上下文。

修复后：在 macOS 的真实 VS Code Extension Development Host 中，排除 `alpha.ts` 后切换到 `beta.ts`，控件对 `beta.ts` 仍保持已排除状态；再次点击后才变为已包含。聚焦的组件回归测试也已通过。本次仅修复状态管理，没有视觉布局变化。

### 测试平台

| 操作系统 | 状态 |
| --- | --- |
| macOS | ✅ 已在 VS Code Extension Development Host 中验证 |
| Windows | ⚠️ 未手动验证 |
| Linux | ⚠️ 未手动验证 |

### 环境（可选）

macOS 上的 VS Code Extension Development Host，本地开发构建。

## 风险与范围

- 主要风险或取舍：排除选择现在会在当前 webview 会话内保持，直到用户主动重新开启；这与 v0.23 迁移前的行为一致。
- 未验证 / 不在范围内：Windows 和 Linux 手动验证；webview 重新加载后的持久化行为有意保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #11558

</details>
