### PR TITLE
fix(core): free an exited web terminal's PTY resources at exit time

### DIFF
--- a/packages/core/src/services/web-terminal-registry.test.ts
+++ b/packages/core/src/services/web-terminal-registry.test.ts
@@ -406,6 +406,83 @@ describe('WebTerminalRegistry', () => {
     expect(kill).not.toHaveBeenCalled();
   });
 
+  it('frees an exited session at exit time, not at the idle reclaim', async () => {
+    osPlatform.mockReturnValue('win32');
+    const registry = new WebTerminalRegistry();
+    await registry.create({
+      terminalId: 'terminal:exit-time-release',
+      workspaceCwd: '/workspace',
+    });
+
+    onExit({ exitCode: 0 });
+    // One turn of the event loop, on real timers: the 15-minute idle reclaim
+    // cannot have run, and nothing below calls release(). A live exit closes
+    // the route's socket with 4000, which the client treats as non-retryable,
+    // so no tab close follows either — that window is what #11353 is about.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // node-pty strands its conout worker on a natural exit, so that worker is
+    // the resource an exited web terminal held for up to IDLE_RECLAIM_MS — and
+    // exited sessions do not count against the admission cap, so accumulation
+    // inside the window was unbounded. See #11303 / #11353.
+    expect(conoutDispose).toHaveBeenCalledOnce();
+    expect(disposeData).toHaveBeenCalledOnce();
+    expect(disposeExit).toHaveBeenCalledOnce();
+    // Nothing may signal an exited shell's possibly-recycled pid.
+    expect(kill).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
+    // The session itself survives the release, for scrollback replay.
+    expect(registry.readSnapshot('terminal:exit-time-release')).toBeDefined();
+  });
+
+  it('still replays buffered scrollback after the exit-time release', async () => {
+    osPlatform.mockReturnValue('win32');
+    const registry = new WebTerminalRegistry();
+    await registry.create({
+      terminalId: 'terminal:replay-after-exit-release',
+      workspaceCwd: '/workspace',
+    });
+
+    onData('boot\r\n');
+    onExit({ exitCode: 3 });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The exit-time release frees PTY handles only. The session and its buffer
+    // stay in the map, so a second tab attaching to this terminal id still gets
+    // the scrollback plus the exit state — which is what terminal.ts's
+    // releaseAfterReplay path depends on.
+    expect(conoutDispose).toHaveBeenCalledOnce();
+    expect(registry.readSnapshot('terminal:replay-after-exit-release')).toEqual(
+      {
+        output: 'boot\r\n',
+        exited: true,
+        exitCode: 3,
+        workspaceCwd: '/workspace',
+      },
+    );
+  });
+
+  it('does not free an exited session twice when release follows', async () => {
+    osPlatform.mockReturnValue('win32');
+    const registry = new WebTerminalRegistry();
+    await registry.create({
+      terminalId: 'terminal:exit-release-once',
+      workspaceCwd: '/workspace',
+    });
+
+    onExit({ exitCode: 0 });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    // The tab close, a workspace drain, dispose() or the reclaim all still run
+    // release() on a session whose PTY was already freed at exit time.
+    expect(registry.release('terminal:exit-release-once')).toBe(true);
+
+    expect(conoutDispose).toHaveBeenCalledOnce();
+    expect(disposeData).toHaveBeenCalledOnce();
+    expect(disposeExit).toHaveBeenCalledOnce();
+    expect(kill).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
   it('forwards live output and bounds unacknowledged PTY input', async () => {
     const registry = new WebTerminalRegistry();
     await registry.create({

--- a/packages/core/src/services/web-terminal-registry.ts
+++ b/packages/core/src/services/web-terminal-registry.ts
@@ -72,6 +72,13 @@ interface PtySession {
   reclaimTimer?: ReturnType<typeof setTimeout>;
   dataDisposable?: { dispose(): void };
   exitDisposable?: { dispose(): void };
+  /**
+   * Set once the PTY-side resources above have been freed. The exit-time
+   * release frees them while the session stays in the map for scrollback
+   * replay, so a later `release()` — tab close, workspace drain, `dispose()`,
+   * idle reclaim — must not free them a second time. See #11353.
+   */
+  ptyResourcesReleased: boolean;
 }
 
 interface SpawnedWebTerminalPty extends WebTerminalPty {
@@ -270,6 +277,23 @@ export class WebTerminalRegistry {
       session.exited = true;
       session.exitCode = e.exitCode;
       for (const listener of [...session.exitListeners]) listener(e);
+      // Nothing needs the PTY once the shell is gone: write() and resize()
+      // already short-circuit on `exited`, and readSnapshot() replays the
+      // JS-side `buffer`, not the console. Waiting for release() instead left
+      // every exited web terminal holding node-pty's conout worker — and,
+      // upstream, its conhost.exe — for up to IDLE_RECLAIM_MS, because the
+      // route keeps the session alive for scrollback and the client treats the
+      // 4000 close as non-retryable, so only a tab close releases it. Exited
+      // sessions also do not count against the admission cap, so accumulation
+      // inside that window was unbounded. See #11303 / #11353.
+      //
+      // Deferred one turn rather than run inline: onExit can arrive slightly
+      // before late PTY data is processed, the same race shellExecutionService
+      // drains before finalizing. setImmediate runs after the poll-phase
+      // callbacks already queued this tick, so trailing output still reaches
+      // `buffer` before the data listener is detached. handleData is fully
+      // synchronous, so one turn is enough — there is no chain to flush.
+      setImmediate(() => this.releasePtyResources(session));
     };
     let dataDisposable: { dispose(): void } | undefined;
     let exitDisposable: { dispose(): void } | undefined;
@@ -347,6 +371,7 @@ export class WebTerminalRegistry {
       exitListeners: new Set(),
       dataDisposable,
       exitDisposable,
+      ptyResourcesReleased: false,
     };
     sessionRef.current = session;
     this.sessions.set(terminalId, session);
@@ -458,29 +483,20 @@ export class WebTerminalRegistry {
         listener({ exitCode: 143, signal: 15 });
       }
     }
-    session.dataDisposable?.dispose();
-    session.exitDisposable?.dispose();
     session.outputListeners.clear();
     session.exitListeners.clear();
     if (!session.exited) {
+      // killPtyTree has to run before releasePtyResources: its pty.kill()
+      // defers the whole teardown while `_isReady` is false, so a terminal
+      // released before its shell's first output byte (tab closed during slow
+      // pwsh startup, or a workspace drain) still has a kill() queued in
+      // node-pty's `_deferreds`. The wrapper's kill() notes the close only when
+      // it really ran; releaseHost then disposes the worker a deferred kill
+      // would strand, and skips the native close so the queued kill() stays the
+      // single closer — never a second close.
       killPtyTree(session.pty);
-      // killPtyTree's pty.kill() defers its whole teardown while `_isReady` is
-      // false, so a terminal released before its shell's first output byte (tab
-      // closed during slow pwsh startup, or a workspace drain) still has a
-      // kill() queued in node-pty's `_deferreds`. The wrapper's kill() notes
-      // the close only when it really ran; releaseHost then disposes the worker
-      // a deferred kill would strand, and skips the native close so the queued
-      // kill() stays the single closer — never a second close.
-      session.pty.releaseHost?.();
-    } else {
-      // The shell already exited, so nothing may signal its (possibly recycled)
-      // pid — but node-pty does not release its conout worker thread on a
-      // natural exit, so without this every terminal the user exits leaks one
-      // for the life of the CLI. Same defect as the shell-tool path in
-      // shellExecutionService. The conhost.exe half is not freed here (the
-      // native baton is already gone); see releaseConPtyHost. See #11303.
-      session.pty.releaseHost?.();
     }
+    this.releasePtyResources(session);
     return true;
   }
 
@@ -500,6 +516,33 @@ export class WebTerminalRegistry {
   private finishCreating(terminalId: string): void {
     this.creating.delete(terminalId);
     this.cancelledCreations.delete(terminalId);
+  }
+
+  /**
+   * Free a session's PTY-side resources exactly once: detach the data/exit
+   * listeners, then release the ConPTY host / conout worker that node-pty
+   * strands on a natural exit. Without the second half every terminal the user
+   * exits leaks a worker for the life of the CLI — the same defect the
+   * shell-tool path has. The conhost.exe half is not freed on that path (the
+   * native baton is already gone); see releaseConPtyHost. See #11303.
+   *
+   * Deliberately leaves the session's map entry and its `buffer` alone, and
+   * never signals the pid: on the exited path the shell is gone and its pid may
+   * be recycled, which is why #11313 added `releaseHost` instead of reusing
+   * `kill()`. Keeping the entry is what lets `readSnapshot()` still replay the
+   * scrollback after an exit-time release.
+   *
+   * Called from `handleExit` (deferred one turn, so an exited web terminal
+   * stops holding the worker for the whole idle-reclaim window — #11353) and
+   * from `release()` on both of its arms, where the flag keeps a release that
+   * follows an exit-time release from disposing anything twice.
+   */
+  private releasePtyResources(session: PtySession): void {
+    if (session.ptyResourcesReleased) return;
+    session.ptyResourcesReleased = true;
+    session.dataDisposable?.dispose();
+    session.exitDisposable?.dispose();
+    session.pty.releaseHost?.();
   }
 
   private clearReclaim(session: PtySession): void {


### PR DESCRIPTION
## What this PR does

Frees an exited web terminal's PTY resources at exit time instead of waiting for `release()`. `WebTerminalRegistry.handleExit` now releases the PTY through a new private `releasePtyResources()` helper, deferred one `setImmediate`. The session object and its scrollback `buffer` stay in the map, so replay is untouched. `release()` routes both of its arms through the same helper, guarded by a per-session `ptyResourcesReleased` flag so nothing is disposed twice when a tab close, a workspace drain, `dispose()` or the idle reclaim runs later on an already-freed session.

## Why it's needed

`releaseHost` existed in exactly two places, `web-terminal-registry.ts:474` and `:482`, both inside `release()`. `handleExit` (`:264-273` on the base SHA) only set `exited`/`exitCode` and notified the exit listeners. Nothing else released the PTY on a natural exit: the browser route keeps an exited session alive for scrollback replay (`finishExited` leaves `releaseAfterReplay` at its `false` default), and the client will not trigger an earlier release either, because a live exit closes the socket with `4000` and `4000` is in `NON_RETRYABLE_CLOSE_CODES`. So an exited web terminal held node-pty's conout worker — and, once microsoft/node-pty#965 is fixed upstream, its `conhost.exe` — for up to `IDLE_RECLAIM_MS`, 15 minutes. Exited sessions are also excluded from the admission cap on purpose (`filter((session) => !session.exited)`), so a user opening and exiting terminals faster than they are reclaimed accumulates without bound inside that window. This is one feeder into the wider leak in #11303 (347 `conhost.exe` / ~2.8 GB after 12h).

Nothing needs the PTY once the shell is gone: `write()` and `resize()` already short-circuit on `session.exited`, and `readSnapshot()` replays the JS-side `session.buffer`, not the console.

## Reviewer Test Plan

### How to verify

This was previously written off as not reproducible off Windows. #11313 changed that: the `web-terminal-registry.test.ts` scaffolding it added exposes `_agent._conoutSocketWorker.dispose` plus the `onData`/`onExit` disposables through a fake PTY, which makes "was the PTY freed at exit?" directly assertable without a Windows machine. That is the reason this PR exists now rather than being parked, not a lowering of the bar — the release *timing* is observable on Linux even though the actual Windows resource reclamation is not.

Red on the base SHA (`ac1edef97`), with the three new tests added and no source change:

```
 FAIL  src/services/web-terminal-registry.test.ts > WebTerminalRegistry > frees an exited session at exit time, not at the idle reclaim
AssertionError: expected "spy" to be called once, but got 0 times
 ❯ src/services/web-terminal-registry.test.ts:428:27
    428|     expect(conoutDispose).toHaveBeenCalledOnce();

 FAIL  src/services/web-terminal-registry.test.ts > WebTerminalRegistry > still replays buffered scrollback after the exit-time release
AssertionError: expected "spy" to be called once, but got 0 times
 ❯ src/services/web-terminal-registry.test.ts:454:27

 Test Files  1 failed (1)
      Tests  2 failed | 30 passed (32)
```

Nothing in that test calls `release()` and no clock is advanced — real timers, a single `setImmediate` tick — so the 15-minute reclaim provably cannot have fired.

Green with the fix: `Test Files 1 passed (1) / Tests 32 passed (32)`. The 29 pre-existing tests are unchanged and still pass; the test-file diff is purely additive (`+77 / -0`), and no existing assertion was relaxed. In particular `expect(nativeKill/conoutDispose/disposeData/disposeExit).toHaveBeenCalledOnce()` after `onExit` → `release` and the deferred-arm counts still hold as written, which is what the `ptyResourcesReleased` flag is for.

The flag was mutation-checked rather than assumed: commenting out the `if (session.ptyResourcesReleased) return;` guard turns `does not free an exited session twice when release follows` red with `expected "spy" to be called once, but got 2 times` (`1 failed | 31 passed`), so that test has teeth. Worth noting the two pre-existing `toHaveBeenCalledOnce()` tests do *not* catch the double release — they assert synchronously after `release()`, before the deferred turn runs — which is exactly why the new test flushes the immediate first.

Commands:

```
cd packages/core
npx vitest run src/services/web-terminal-registry.test.ts   # 32 passed
npm run typecheck                                           # tsc --noEmit, 0 errors
npx prettier --check src/services/web-terminal-registry{,.test}.ts
npx eslint src/services/web-terminal-registry{,.test}.ts
```

No change to the live-release path's observable behaviour, and this is provable rather than merely asserted: `release()` now detaches the data/exit listeners after `killPtyTree` instead of before, but everything in between is synchronous (`spawnSync`, `process.kill`, `pty.kill()`), so no `onData` callback can interleave. `killPtyTree` still runs before `releaseHost` on the live arm, which the pre-existing `does not double-close a live session whose kill already closed it` test pins through its call counts.

### Evidence (Before & After)

No user-visible surface changed — this is resource-release timing inside `packages/core`, with no pixel-level or TUI delta, so there are no screenshots. The evidence is the red/green test output above: before, `conoutDispose` is called 0 times after an exit; after, exactly once, with the session and its buffer still replayable. The third new test asserts scrollback replay still returns `output: 'boot\r\n'` plus `exited: true, exitCode: 3` after the exit-time release, which is what keeps the route's `releaseAfterReplay` reconnect path working.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested — no Windows machine available; see Risk & Scope |
|  🐧 Linux  | ✅ tested (mechanism level: unit tests with `os.platform()` mocked to `win32`) |

### Environment (optional)

Unit tests only, on a headless Linux host, node_modules reused via hardlink from an existing checkout. `packages/core` was built once to satisfy the vitest global-setup prerequisite guard.

## Risk & Scope

- Main risk or tradeoff: an exited session's PTY is now freed one event-loop turn after the exit event instead of up to 15 minutes later. The turn is deferred deliberately — `onExit` can arrive slightly before late PTY data is processed, the same race `shellExecutionService` drains before finalizing ("Give any last onData callbacks a chance to run before finalizing"), and disposing the data listener inline inside `handleExit` could truncate the tail of the very scrollback `readSnapshot()` replays. `setImmediate` runs after the poll-phase callbacks already queued this tick, and `handleData` is fully synchronous, so one turn is enough — there is no processing chain to flush the way `shellExecutionService` has.
- Not validated / out of scope: **the trailing-output drain is reasoned from the shell-tool precedent, not measured, and cannot be verified on Linux.** `conpty-host.ts` returns early when `os.platform() !== 'win32'`, so what this PR proves is the release timing and its exactly-once property; actual conout-worker and `conhost.exe` reclamation on a real Windows ConPTY is unverified and needs a Windows run. There is deliberately **no** test asserting that trailing output survives the release: the existing fake's `dispose` is a bare `vi.fn()` that does not detach the listener, so `handleData` still appends to the buffer after "dispose" and such an assertion would pass with or without the fix. Making it real would mean reworking the fake #11313 just landed, which is not this PR's business. Windows CI is skipped on PRs, so this also will not be covered by the pipeline here.
- Out of scope, unchanged on purpose: `packages/cli/src/serve/routes/terminal.ts` needs no edit — `finishExited` only calls `registry.release()` when `releaseAfterReplay` is true (the reconnect-to-an-exited-session arm), and that arm reads the snapshot before releasing, which still works because the session and buffer survive. No `killPtyTree` on the exited path: the shell is gone and its pid may be recycled, which is why #11313 added `releaseHost` rather than reusing `kill()`. The admission cap's `!session.exited` filter is intentional and untouched. #11352's upstream ConPTY close defect is not addressed here, and #11303's wider leak surface is not — this only closes one feeder.
- Breaking changes / migration notes: none. `releasePtyResources` is private; no public signature changed. Relationship to the related work: #11313 (merged as `d8baa873`) made the release *effective*, this makes it *timely*; #11352 is the upstream close defect; #11303 is the aggregate leak. All three are complementary and none is duplicated here.

## Linked Issues

Fixes #11353

Related, non-closing: #11313 (merged — introduced `releaseHost` and the test scaffolding this builds on), #11352 (upstream microsoft/node-pty#965, `status/blocked`), #11303 (aggregate Windows PTY leak).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 shell 退出时就释放已退出 web terminal 的 PTY 资源，而不是等到 `release()`。`WebTerminalRegistry.handleExit` 现在通过新的私有辅助函数 `releasePtyResources()` 释放 PTY，并延后一个 `setImmediate`。session 对象及其 scrollback `buffer` 保留在 map 中，因此回放不受影响。`release()` 的两个分支都改为走同一个辅助函数，并用每会话的 `ptyResourcesReleased` 标志保护，使得之后的关闭标签页、workspace 排空、`dispose()` 或空闲回收在已释放的会话上不会二次 dispose。

## 为什么需要

`releaseHost` 此前只出现在两个地方，`web-terminal-registry.ts:474` 与 `:482`，都在 `release()` 内部。`handleExit`（基线 SHA 上为 `:264-273`）只设置 `exited`/`exitCode` 并通知退出监听器。自然退出时没有其它任何路径会释放 PTY：浏览器路由为了 scrollback 回放刻意保留已退出的会话（`finishExited` 让 `releaseAfterReplay` 保持默认的 `false`），客户端也不会更早触发释放，因为实时退出会以 `4000` 关闭连接，而 `4000` 在 `NON_RETRYABLE_CLOSE_CODES` 里。于是已退出的 web terminal 会持有 node-pty 的 conout worker 最长 `IDLE_RECLAIM_MS`，即 15 分钟；在上游 microsoft/node-pty#965 修好之后，还会持有它的 `conhost.exe`。已退出会话又被有意排除在准入上限之外（`filter((session) => !session.exited)`），所以用户在这个窗口内开得比回收得快时，累积没有上限。这是 #11303（12 小时后 347 个 `conhost.exe` / 约 2.8 GB）那个更大泄漏的一个来源。

shell 退出后没有任何东西还需要 PTY：`write()` 与 `resize()` 已经对 `session.exited` 短路，而 `readSnapshot()` 回放的是 JS 侧的 `session.buffer`，不是 console。

## 评审测试计划

### 如何验证

这一件此前被判定为"非 Windows 不可复现"。#11313 改变了这一点：它新增的 `web-terminal-registry.test.ts` 脚手架通过 fake PTY 暴露了 `_agent._conoutSocketWorker.dispose` 以及 `onData`/`onExit` 的 disposable，这让"退出时 PTY 是否被释放"在没有 Windows 机器的情况下也能直接断言。这才是本 PR 现在能提出来的原因，而不是放低了门槛——释放**时机**在 Linux 上可观测，尽管 Windows 上真实的资源回收并不可观测。

在基线 SHA（`ac1edef97`）上的红态：新增三个测试、不改任何源码时，

```
 FAIL  src/services/web-terminal-registry.test.ts > WebTerminalRegistry > frees an exited session at exit time, not at the idle reclaim
AssertionError: expected "spy" to be called once, but got 0 times
 ❯ src/services/web-terminal-registry.test.ts:428:27
    428|     expect(conoutDispose).toHaveBeenCalledOnce();

 FAIL  src/services/web-terminal-registry.test.ts > WebTerminalRegistry > still replays buffered scrollback after the exit-time release
AssertionError: expected "spy" to be called once, but got 0 times
 ❯ src/services/web-terminal-registry.test.ts:454:27

 Test Files  1 failed (1)
      Tests  2 failed | 30 passed (32)
```

该测试没有任何一处调用 `release()`，也没有推进任何时钟——使用真实定时器、只等一个 `setImmediate`——所以 15 分钟的空闲回收可证明不可能已经触发。

带上修复后的绿态：`Test Files 1 passed (1) / Tests 32 passed (32)`。29 个既有测试未作修改且仍然通过；测试文件的 diff 是纯新增（`+77 / -0`），没有放宽任何既有断言。特别是 `onExit` → `release` 之后的 `expect(nativeKill/conoutDispose/disposeData/disposeExit).toHaveBeenCalledOnce()`，以及 deferred 分支的调用计数，都按原样成立——这正是 `ptyResourcesReleased` 标志的作用。

该标志做了变异验证而非想当然：把 `if (session.ptyResourcesReleased) return;` 这行守卫注释掉后，`does not free an exited session twice when release follows` 会以 `expected "spy" to be called once, but got 2 times` 变红（`1 failed | 31 passed`），说明这个测试是有牙齿的。值得一提的是，两个既有的 `toHaveBeenCalledOnce()` 测试并**不能**抓到这次重复释放——它们在 `release()` 之后同步断言，那时延后的那一轮还没跑——这恰恰是新测试要先 flush immediate 的原因。

命令：

```
cd packages/core
npx vitest run src/services/web-terminal-registry.test.ts   # 32 passed
npm run typecheck                                           # tsc --noEmit, 0 errors
npx prettier --check src/services/web-terminal-registry{,.test}.ts
npx eslint src/services/web-terminal-registry{,.test}.ts
```

实时释放路径的可观测行为没有变化，而且这一点是可证明的、不只是口头断言：`release()` 现在在 `killPtyTree` 之后才摘除 data/exit 监听器，而不是之前，但两者之间的所有操作都是同步的（`spawnSync`、`process.kill`、`pty.kill()`），因此没有 `onData` 回调能插入其间。实时分支上 `killPtyTree` 仍然先于 `releaseHost`，既有的 `does not double-close a live session whose kill already closed it` 测试通过调用计数钉住了这一点。

### 证据（Before & After）

没有用户可见的界面变化——这是 `packages/core` 内部的资源释放时机，没有像素级或 TUI 差异，因此没有截图。证据是上面的红/绿测试输出：修复前，退出之后 `conoutDispose` 被调用 0 次；修复后恰好 1 次，且会话与其 buffer 仍可回放。第三个新测试断言退出时释放之后，scrollback 回放仍返回 `output: 'boot\r\n'` 以及 `exited: true, exitCode: 3`，这正是保证路由 `releaseAfterReplay` 重连路径可用的部分。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 —— 没有可用的 Windows 机器，见「风险与范围」 |
|  🐧 Linux  | ✅ 已测试（机制级：单元测试中将 `os.platform()` mock 成 `win32`） |

### 环境（可选）

仅单元测试，在一台 headless Linux 主机上，node_modules 通过硬链接复用已有 checkout。`packages/core` 构建过一次，用于满足 vitest global-setup 的前置检查。

## 风险与范围

- 主要风险或取舍：已退出会话的 PTY 现在在退出事件之后一个事件循环轮次就被释放，而不是最长 15 分钟之后。这一轮的延后是刻意的——`onExit` 可能略早于最后的 PTY 数据被处理，这与 `shellExecutionService` 在 finalize 前 drain 的是同一个竞态（"Give any last onData callbacks a chance to run before finalizing"），而在 `handleExit` 内同步 dispose data 监听器可能截断 `readSnapshot()` 本该回放的那段尾部输出。`setImmediate` 会在本轮已经排队的 poll 阶段回调之后运行，而 `handleData` 是完全同步的，所以一个轮次就够——不像 `shellExecutionService` 那样还有一条处理链需要 flush。
- 未验证 / 范围之外：**尾部输出 drain 是依据 shell 工具路径的先例推理出来的，不是实测的，并且在 Linux 上无法验证。** `conpty-host.ts` 在 `os.platform() !== 'win32'` 时直接提前返回，所以本 PR 证明的是释放时机及其"恰好一次"的性质；真实 Windows ConPTY 上 conout worker 与 `conhost.exe` 的实际回收未经验证，需要在 Windows 上跑一次。这里刻意**没有**添加"尾部输出在释放后仍存在"的断言：既有 fake 的 `dispose` 只是一个裸 `vi.fn()`，并不会真正摘除监听器，所以"dispose"之后 `handleData` 仍会往 buffer 里追加，这样的断言在修与不修的情况下都会通过。要让它变成真断言就得改造 #11313 刚落地的那套 fake，那不属于本 PR 的职责。此外 PR 上的 Windows CI 是被跳过的，所以流水线也不会覆盖到这一点。
- 有意保持不变的范围之外内容：`packages/cli/src/serve/routes/terminal.ts` 无需修改——`finishExited` 只在 `releaseAfterReplay` 为 true 时（即重连到已退出会话的那一分支）才调用 `registry.release()`，而该分支在释放之前先读 snapshot，这在会话与 buffer 存活的前提下依然可用。已退出路径上不加 `killPtyTree`：shell 已经没了、pid 可能被复用，这正是 #11313 新增 `releaseHost` 而不复用 `kill()` 的原因。准入上限的 `!session.exited` 过滤是有意设计，未作改动。#11352 的上游 ConPTY 关闭缺陷不在本 PR 处理，#11303 的更大泄漏面也不在——这里只关掉其中一个来源。
- 破坏性变更 / 迁移说明：无。`releasePtyResources` 是私有的，没有公开签名变化。与相关工作的关系：#11313（已合并为 `d8baa873`）让释放**有效**，本 PR 让释放**及时**；#11352 是上游关闭缺陷；#11303 是整体泄漏。三者互补，本 PR 不重复其中任何一个。

## 关联 Issue

Fixes #11353

相关但不关闭：#11313（已合并——引入了本 PR 依赖的 `releaseHost` 与测试脚手架）、#11352（上游 microsoft/node-pty#965，`status/blocked`）、#11303（Windows PTY 整体泄漏）。

</details>
