### PR TITLE
fix(cli): make an open context menu own the keyboard at the dispatch layer

### DIFF
--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -10,6 +10,7 @@ import { Box, Text } from 'ink';
 import { waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../test-utils/render.js';
+import { useKeypress } from '../hooks/useKeypress.js';
 import { ContextMenuOverlay } from './ContextMenuOverlay.js';
 import {
   ContextMenuProvider,
@@ -42,6 +43,22 @@ function MenuOpener({
   useEffect(() => {
     openMenu(items, position);
   }, [openMenu, items, position]);
+  return null;
+}
+
+/**
+ * Stands in for the surfaces the issue measured: a key consumer that has no
+ * idea the context menu exists (composer, tool-approval dialog, tab bar).
+ * Records every key it receives so tests can assert what leaked under the
+ * open menu.
+ */
+function InnocentBystander({ onKey }: { onKey: (key: string) => void }) {
+  useKeypress(
+    (key) => {
+      onKey(key.sequence ?? key.name);
+    },
+    { isActive: true },
+  );
   return null;
 }
 
@@ -138,6 +155,102 @@ describe('ContextMenuOverlay', () => {
     stdin.write('\r'); // Enter
     await waitFor(() => expect(handlers.copy).toHaveBeenCalledTimes(1));
     expect(handlers.open).not.toHaveBeenCalled();
+  });
+
+  // #11228: while the menu is open its overlay owns the keyboard. The
+  // composer, approval dialog, and tab bar must not act on the same key.
+  describe('key exclusivity', () => {
+    function ExclusiveScene({
+      items,
+      onKey,
+    }: {
+      items: ContextMenuItem[];
+      onKey: (key: string) => void;
+    }) {
+      return (
+        <Scene>
+          <ContextMenuProvider>
+            <InnocentBystander onKey={onKey} />
+            <MenuOpener items={items} />
+            <ContextMenuOverlay />
+          </ContextMenuProvider>
+        </Scene>
+      );
+    }
+
+    it('an ordinary handler does not receive Enter aimed at the open menu', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      stdin.write('\r'); // Enter — executes the menu item
+      await waitFor(() => expect(handlers.open).toHaveBeenCalledTimes(1));
+
+      expect(bystanderKeys).toEqual([]);
+    });
+
+    it('an ordinary handler does not receive Escape aimed at the open menu', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      stdin.write('\u001b'); // Escape — dismisses the menu
+      await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
+
+      expect(bystanderKeys).toEqual([]);
+    });
+
+    it('a dismissing key falls through to ordinary handlers in the same keystroke', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      // A printable key the menu does not handle: dismisses the menu AND
+      // still reaches the ordinary handler (typing "x" dismisses and types
+      // "x"). Swallowing it would drop the keystroke entirely.
+      stdin.write('x');
+      await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
+
+      expect(bystanderKeys).toContain('x');
+    });
+
+    it('ordinary handlers receive keys again after the menu closes', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      stdin.write('\u001b'); // Escape — close the menu
+      await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
+      expect(bystanderKeys).toEqual([]);
+
+      // The next keystroke must reach ordinary handlers again.
+      stdin.write('y');
+      await waitFor(() => expect(bystanderKeys).toContain('y'));
+    });
   });
 
   it('renders the box at the stored position, not in-flow', async () => {

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -83,6 +83,29 @@ function Scene({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * The exclusivity fixture: an ordinary key consumer listening while the menu
+ * is open. Single definition for every test that asserts what leaked (or was
+ * consumed) under the open menu.
+ */
+function ExclusiveScene({
+  items,
+  onKey,
+}: {
+  items: ContextMenuItem[];
+  onKey: (key: string) => void;
+}) {
+  return (
+    <Scene>
+      <ContextMenuProvider>
+        <InnocentBystander onKey={onKey} />
+        <MenuOpener items={items} />
+        <ContextMenuOverlay />
+      </ContextMenuProvider>
+    </Scene>
+  );
+}
+
 describe('ContextMenuOverlay', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -150,13 +173,10 @@ describe('ContextMenuOverlay', () => {
     const handlers = { open: vi.fn(), copy: vi.fn() };
     const bystanderKeys: string[] = [];
     const { lastFrame, stdin } = renderWithProviders(
-      <Scene>
-        <ContextMenuProvider>
-          <InnocentBystander onKey={(k) => bystanderKeys.push(k)} />
-          <MenuOpener items={makeItems(handlers)} />
-          <ContextMenuOverlay />
-        </ContextMenuProvider>
-      </Scene>,
+      <ExclusiveScene
+        items={makeItems(handlers)}
+        onKey={(k) => bystanderKeys.push(k)}
+      />,
     );
     await waitFor(() => expect(lastFrame()).toContain('Open Link'));
     stdin.write('\u001b[B'); // ArrowDown
@@ -174,24 +194,6 @@ describe('ContextMenuOverlay', () => {
   // #11228: while the menu is open its overlay owns the keyboard. The
   // composer, approval dialog, and tab bar must not act on the same key.
   describe('key exclusivity', () => {
-    function ExclusiveScene({
-      items,
-      onKey,
-    }: {
-      items: ContextMenuItem[];
-      onKey: (key: string) => void;
-    }) {
-      return (
-        <Scene>
-          <ContextMenuProvider>
-            <InnocentBystander onKey={onKey} />
-            <MenuOpener items={items} />
-            <ContextMenuOverlay />
-          </ContextMenuProvider>
-        </Scene>
-      );
-    }
-
     it('an ordinary handler does not receive Enter aimed at the open menu', async () => {
       const handlers = { open: vi.fn(), copy: vi.fn() };
       const bystanderKeys: string[] = [];
@@ -205,6 +207,26 @@ describe('ContextMenuOverlay', () => {
 
       stdin.write('\r'); // Enter — executes the menu item
       await waitFor(() => expect(handlers.open).toHaveBeenCalledTimes(1));
+
+      expect(bystanderKeys).toEqual([]);
+    });
+
+    it('an unmodified ArrowUp is consumed by the open menu', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      // Legacy unparameterized form — the only Up that decodes as a bare
+      // 'up' under the kitty protocol (KeypressContext matches \u001b[A but
+      // not \u001b[1A), so this reaches the unmodified up claim branch.
+      stdin.write('\u001b[A');
+      await wait();
 
       expect(bystanderKeys).toEqual([]);
     });

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -84,9 +84,12 @@ function Scene({ children }: { children: ReactNode }) {
 }
 
 /**
- * The exclusivity fixture: an ordinary key consumer listening while the menu
- * is open. Single definition for every test that asserts what leaked (or was
- * consumed) under the open menu.
+ * The exclusivity fixture: ordinary key consumers listening while the menu
+ * is open. Two bystanders, both ordinary subscribers — production always
+ * has several live at once (global handler, composer input, focus hooks),
+ * so a declined key must fan out to EVERY ordinary handler, not just the
+ * first: the doubled exact-array assertions below pin that the declined
+ * path delivers to all subscribers and a first-only truncation reddens.
  */
 function ExclusiveScene({
   items,
@@ -98,6 +101,7 @@ function ExclusiveScene({
   return (
     <Scene>
       <ContextMenuProvider>
+        <InnocentBystander onKey={onKey} />
         <InnocentBystander onKey={onKey} />
         <MenuOpener items={items} />
         <ContextMenuOverlay />
@@ -231,6 +235,40 @@ describe('ContextMenuOverlay', () => {
       expect(bystanderKeys).toEqual([]);
     });
 
+    it('an unmodified ArrowUp at the top row clamps and keeps the menu usable', async () => {
+      // Effect witness for the up branch: from index 0, `Math.max(0, -1)`
+      // is the only thing keeping selectedIndex at a real row. A no-op, an
+      // unclamped decrement, or a closeMenu-instead-of-move would each
+      // leave the plain consumption test above green. The leading Up from
+      // the clamped floor is the ONLY press that exposes a lost clamp —
+      // Down-first ordering yields 0 with or without Math.max. Separate
+      // chunks with a wait between: one stdin chunk dispatches in a single
+      // tick and both arrows would compute from the same stale closure
+      // index (the open R3-1 follow-up), proving nothing about navigation.
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      stdin.write('\u001b[A'); // Up from index 0 — clamps to 0
+      await wait();
+      stdin.write('\u001b[B'); // Down -> item 2
+      await wait();
+      stdin.write('\u001b[A'); // Up -> back to item 1, menu stays open
+      await wait();
+      expect(lastFrame()).toContain('Open Link');
+
+      stdin.write('\r');
+      await waitFor(() => expect(handlers.open).toHaveBeenCalledTimes(1));
+      expect(handlers.copy).not.toHaveBeenCalled();
+      expect(bystanderKeys).toEqual([]);
+    });
+
     it('an ordinary handler does not receive Escape aimed at the open menu', async () => {
       const handlers = { open: vi.fn(), copy: vi.fn() };
       const bystanderKeys: string[] = [];
@@ -260,12 +298,13 @@ describe('ContextMenuOverlay', () => {
       await waitFor(() => expect(lastFrame()).toContain('Open Link'));
 
       // A printable key the menu does not handle: dismisses the menu AND
-      // still reaches the ordinary handler (typing "x" dismisses and types
-      // "x"). Swallowing it would drop the keystroke entirely.
+      // still reaches every ordinary handler (typing "x" dismisses and
+      // types "x"). Swallowing it would drop the keystroke entirely;
+      // first-only fan-out would deliver it to just one subscriber.
       stdin.write('x');
       await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
 
-      expect(bystanderKeys).toContain('x');
+      expect(bystanderKeys).toEqual(['x', 'x']);
     });
 
     it('Shift+Enter dismisses the menu and falls through without firing the item', async () => {
@@ -288,10 +327,12 @@ describe('ContextMenuOverlay', () => {
 
       expect(handlers.open).not.toHaveBeenCalled();
       expect(handlers.copy).not.toHaveBeenCalled();
-      // The exact key must reach the bystander: if kitty decoding
-      // regressed, the sequence would shred into an escape plus
-      // printables instead of one decoded 'return+shift'.
-      expect(bystanderKeys).toEqual(['return+shift']);
+      // The exact key must reach BOTH bystanders: fan-out on the declined
+      // path is all-subscribers, and a first-only truncation would leave
+      // the second recorder empty. If kitty decoding regressed, the
+      // sequence would shred into an escape plus printables instead of
+      // one decoded 'return+shift' per subscriber.
+      expect(bystanderKeys).toEqual(['return+shift', 'return+shift']);
     });
 
     // R2-4: the claim predicate has three modifier axes; pin every cell
@@ -320,7 +361,9 @@ describe('ContextMenuOverlay', () => {
 
         expect(handlers.open).not.toHaveBeenCalled();
         expect(handlers.copy).not.toHaveBeenCalled();
-        expect(bystanderKeys).toEqual([expectedBystander]);
+        // Delivered to BOTH ordinary bystanders — first-only fan-out on
+        // the declined path would leave the array at length 1.
+        expect(bystanderKeys).toEqual([expectedBystander, expectedBystander]);
       },
     );
 

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -55,7 +55,14 @@ function MenuOpener({
 function InnocentBystander({ onKey }: { onKey: (key: string) => void }) {
   useKeypress(
     (key) => {
-      onKey(key.sequence ?? key.name);
+      // Record the decoded identity, not the raw bytes: the kitty
+      // provider decodes `\u001b[13;2u` into name='return' + shift=true,
+      // and the assertions care about WHICH key leaked, not its bytes.
+      const parts = [key.name];
+      if (key.ctrl) parts.push('ctrl');
+      if (key.meta) parts.push('meta');
+      if (key.shift) parts.push('shift');
+      onKey(parts.join('+'));
     },
     { isActive: true },
   );
@@ -141,9 +148,11 @@ describe('ContextMenuOverlay', () => {
 
   it('ArrowDown + Enter executes the second item', async () => {
     const handlers = { open: vi.fn(), copy: vi.fn() };
+    const bystanderKeys: string[] = [];
     const { lastFrame, stdin } = renderWithProviders(
       <Scene>
         <ContextMenuProvider>
+          <InnocentBystander onKey={(k) => bystanderKeys.push(k)} />
           <MenuOpener items={makeItems(handlers)} />
           <ContextMenuOverlay />
         </ContextMenuProvider>
@@ -155,6 +164,11 @@ describe('ContextMenuOverlay', () => {
     stdin.write('\r'); // Enter
     await waitFor(() => expect(handlers.copy).toHaveBeenCalledTimes(1));
     expect(handlers.open).not.toHaveBeenCalled();
+    // R1-5: the arrows and the executing Return are CONSUMED by the open
+    // menu — flipping any claim branch's `return true` to `false` leaks
+    // the key to ordinary subscribers (the exact collision #11228
+    // describes) and turns this red.
+    expect(bystanderKeys).toEqual([]);
   });
 
   // #11228: while the menu is open its overlay owns the keyboard. The
@@ -252,8 +266,41 @@ describe('ContextMenuOverlay', () => {
 
       expect(handlers.open).not.toHaveBeenCalled();
       expect(handlers.copy).not.toHaveBeenCalled();
-      expect(bystanderKeys.length).toBeGreaterThan(0);
+      // The exact key must reach the bystander: if kitty decoding
+      // regressed, the sequence would shred into an escape plus
+      // printables instead of one decoded 'return+shift'.
+      expect(bystanderKeys).toEqual(['return+shift']);
     });
+
+    // R2-4: the claim predicate has three modifier axes; pin every cell
+    // of the matrix that must fall through (modified keys reach ordinary
+    // handlers instead of being consumed by the menu).
+    it.each([
+      ['Shift+Up', '\u001b[1;2A', 'up+shift'],
+      ['Shift+Down', '\u001b[1;2B', 'down+shift'],
+      ['Ctrl+Enter', '\u001b[13;5u', 'return+ctrl'],
+      ['Alt+Enter', '\u001b[13;3u', 'return+meta'],
+    ] as const)(
+      '%s dismisses the menu and falls through without moving or firing',
+      async (_label, sequence, expectedBystander) => {
+        const handlers = { open: vi.fn(), copy: vi.fn() };
+        const bystanderKeys: string[] = [];
+        const { lastFrame, stdin } = renderWithProviders(
+          <ExclusiveScene
+            items={makeItems(handlers)}
+            onKey={(k) => bystanderKeys.push(k)}
+          />,
+        );
+        await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+        stdin.write(sequence);
+        await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
+
+        expect(handlers.open).not.toHaveBeenCalled();
+        expect(handlers.copy).not.toHaveBeenCalled();
+        expect(bystanderKeys).toEqual([expectedBystander]);
+      },
+    );
 
     it('ordinary handlers receive keys again after the menu closes', async () => {
       const handlers = { open: vi.fn(), copy: vi.fn() };

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -232,6 +232,29 @@ describe('ContextMenuOverlay', () => {
       expect(bystanderKeys).toContain('x');
     });
 
+    it('Shift+Enter dismisses the menu and falls through without firing the item', async () => {
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      // Shift+Enter is Command.NEWLINE in the composer, not menu-execute.
+      // Kitty CSI-u form (the provider enables the protocol): modifiers 2.
+      // It must dismiss the menu, reach ordinary handlers, and never run
+      // the highlighted item's onSelect.
+      stdin.write('\u001b[13;2u');
+      await waitFor(() => expect(lastFrame()).not.toContain('Open Link'));
+
+      expect(handlers.open).not.toHaveBeenCalled();
+      expect(handlers.copy).not.toHaveBeenCalled();
+      expect(bystanderKeys.length).toBeGreaterThan(0);
+    });
+
     it('ordinary handlers receive keys again after the menu closes', async () => {
       const handlers = { open: vi.fn(), copy: vi.fn() };
       const bystanderKeys: string[] = [];

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.test.tsx
@@ -269,6 +269,40 @@ describe('ContextMenuOverlay', () => {
       expect(bystanderKeys).toEqual([]);
     });
 
+    it('an unmodified ArrowDown at the last row clamps and keeps the menu usable', async () => {
+      // Mirror of the up-clamp witness for the down branch's Math.min:
+      // from the last row, the clamp is the only thing keeping
+      // selectedIndex on a real row. Without it a second Down lands past
+      // the end, Enter bounds-checks to a no-op inside executeIndex while
+      // the menu still closes — the chosen action silently drops and all
+      // 17 committed tests stay green. The second Down (from the last row)
+      // is the only press that discriminates the clamp: one chunk holding
+      // both Downs would compute both from the same stale closure index
+      // (the open R3-1 follow-up) and copy would fire either way. The
+      // fixture has exactly 2 rows, so the boundary is one Down past
+      // index 1.
+      const handlers = { open: vi.fn(), copy: vi.fn() };
+      const bystanderKeys: string[] = [];
+      const { lastFrame, stdin } = renderWithProviders(
+        <ExclusiveScene
+          items={makeItems(handlers)}
+          onKey={(k) => bystanderKeys.push(k)}
+        />,
+      );
+      await waitFor(() => expect(lastFrame()).toContain('Open Link'));
+
+      stdin.write('\u001b[B'); // Down -> item 2 (the last row)
+      await wait();
+      stdin.write('\u001b[B'); // Down from the last row — clamps to 1
+      await wait();
+      expect(lastFrame()).toContain('Open Link');
+
+      stdin.write('\r');
+      await waitFor(() => expect(handlers.copy).toHaveBeenCalledTimes(1));
+      expect(handlers.open).not.toHaveBeenCalled();
+      expect(bystanderKeys).toEqual([]);
+    });
+
     it('an ordinary handler does not receive Escape aimed at the open menu', async () => {
       const handlers = { open: vi.fn(), copy: vi.fn() };
       const bystanderKeys: string[] = [];

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.tsx
@@ -53,15 +53,20 @@ const ActiveContextMenu: React.FC = () => {
         closeMenu();
         return true;
       }
-      if (key.name === 'up') {
+      // Claim the menu's keys only without modifiers: a modified Return or
+      // arrow belongs to a composer binding (Shift+Enter / Ctrl+Enter are
+      // Command.NEWLINE in keyBindings.ts), and consuming it here would
+      // drop the newline while still firing the highlighted item.
+      const unmodified = !key.ctrl && !key.shift && !key.meta;
+      if (key.name === 'up' && unmodified) {
         setSelectedIndex(Math.max(0, selectedIndex - 1));
         return true;
       }
-      if (key.name === 'down') {
+      if (key.name === 'down' && unmodified) {
         setSelectedIndex(Math.min(menu.items.length - 1, selectedIndex + 1));
         return true;
       }
-      if (key.name === 'return') {
+      if (key.name === 'return' && unmodified) {
         executeIndex(selectedIndex);
         return true;
       }

--- a/packages/cli/src/ui/context-menu/ContextMenuOverlay.tsx
+++ b/packages/cli/src/ui/context-menu/ContextMenuOverlay.tsx
@@ -22,10 +22,17 @@ import { useContextMenu } from './ContextMenuContext.js';
  * menu has no provider requirements at all — the inner component (and its
  * `useKeypress`, which needs KeypressProvider) mounts only while open.
  *
- * Keyboard: ↑/↓ move the highlight, Enter executes, Esc closes. Mouse
- * hover / click are handled by {@link ContentMouseController}, which
- * hit-tests with `contextMenuSize` — the border/padding encoded below must
- * stay in sync with that helper.
+ * Keyboard: ↑/↓ move the highlight, Enter executes, Esc closes. Any other key
+ * also dismisses the menu (click-away parity), but that key is the user's, not
+ * the menu's — it must keep flowing through the normal pipeline (typing "x"
+ * dismisses and types "x"; returning early would drop it into the bare
+ * readline layer). Dismissal is therefore reported back to KeypressContext so
+ * the same dispatch falls through to the ordinary handlers the moment the menu
+ * is gone. While the menu is open the subscription is exclusive: keys are
+ * routed here only, so the composer, approval dialogs, and tab bars cannot act
+ * on the same keystroke. Mouse hover / click are handled by
+ * {@link ContentMouseController}, which hit-tests with `contextMenuSize` —
+ * the border/padding encoded below must stay in sync with that helper.
  */
 export const ContextMenuOverlay: React.FC = () => {
   const { menu } = useContextMenu();
@@ -40,29 +47,34 @@ const ActiveContextMenu: React.FC = () => {
     useContextMenu();
 
   const handleKeypress = useCallback(
-    (key: Key) => {
-      if (!menu) return;
+    (key: Key): boolean => {
+      if (!menu) return true;
       if (key.name === 'escape') {
         closeMenu();
-        return;
+        return true;
       }
       if (key.name === 'up') {
         setSelectedIndex(Math.max(0, selectedIndex - 1));
-        return;
+        return true;
       }
       if (key.name === 'down') {
         setSelectedIndex(Math.min(menu.items.length - 1, selectedIndex + 1));
-        return;
+        return true;
       }
       if (key.name === 'return') {
         executeIndex(selectedIndex);
-        return;
+        return true;
       }
+      // Any other key dismisses the menu. Return false so this same
+      // keystroke falls through to ordinary handlers — the key was aimed at
+      // the app, not the menu, and swallowing it here would lose it.
+      closeMenu();
+      return false;
     },
     [menu, selectedIndex, closeMenu, setSelectedIndex, executeIndex],
   );
 
-  useKeypress(handleKeypress, { isActive: menu !== null });
+  useKeypress(handleKeypress, { isActive: menu !== null, exclusive: true });
 
   if (!menu) {
     return null;

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -879,6 +879,133 @@ describe('KeypressContext - Kitty Protocol', () => {
     });
   });
 
+  describe('Exclusive subscriptions', () => {
+    it('routes keys to the exclusive handler only while it is subscribed', () => {
+      const ordinary = vi.fn();
+      const exclusive = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: false }),
+      });
+
+      act(() => {
+        result.current.subscribe(ordinary);
+      });
+
+      // Before any exclusive subscription, ordinary handlers receive keys.
+      act(() => {
+        stdin.pressKey({
+          name: 'return',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: '\r',
+        });
+      });
+      expect(ordinary).toHaveBeenCalledTimes(1);
+
+      // While an exclusive handler is subscribed, ordinary handlers see
+      // nothing — this is the open right-click menu owning the keyboard.
+      act(() => {
+        result.current.subscribe(exclusive, { exclusive: true });
+      });
+      act(() => {
+        stdin.pressKey({
+          name: 'down',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: '\x1b[B',
+        });
+      });
+      expect(exclusive).toHaveBeenCalledTimes(1);
+      expect(ordinary).toHaveBeenCalledTimes(1);
+
+      // After unsubscribe, ordinary handlers receive keys again.
+      act(() => {
+        result.current.unsubscribe(exclusive);
+      });
+      act(() => {
+        stdin.pressKey({
+          name: 'down',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: '\x1b[B',
+        });
+      });
+      expect(ordinary).toHaveBeenCalledTimes(2);
+    });
+
+    it('lets a declining exclusive handler pass the key to ordinary handlers', () => {
+      const ordinary = vi.fn();
+      // Returns false: the menu dismissed itself on this key and the key
+      // must keep flowing (e.g. a printable character that should be typed).
+      const exclusive = vi.fn().mockReturnValue(false);
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: false }),
+      });
+
+      act(() => {
+        result.current.subscribe(ordinary);
+        result.current.subscribe(exclusive, { exclusive: true });
+      });
+
+      act(() => {
+        stdin.pressKey({
+          name: 'x',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: 'x',
+        });
+      });
+
+      expect(exclusive).toHaveBeenCalledTimes(1);
+      expect(ordinary).toHaveBeenCalledTimes(1);
+      expect(ordinary).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'x' }),
+      );
+    });
+
+    it('swallows the key for ordinary handlers when the exclusive handler consumes it', () => {
+      const ordinary = vi.fn();
+      // Returns true (handled): up/down/return/escape on the open menu.
+      const exclusive = vi.fn().mockReturnValue(true);
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: false }),
+      });
+
+      act(() => {
+        result.current.subscribe(ordinary);
+        result.current.subscribe(exclusive, { exclusive: true });
+      });
+
+      act(() => {
+        stdin.pressKey({
+          name: 'escape',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: false,
+          sequence: '\x1b',
+        });
+      });
+
+      expect(exclusive).toHaveBeenCalledTimes(1);
+      expect(ordinary).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Escape key handling', () => {
     it('should recognize escape key (keycode 27) in kitty protocol', async () => {
       const keyHandler = vi.fn();

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -130,7 +130,14 @@ export interface Key {
   clipboardImageUnavailable?: boolean;
 }
 
-export type KeypressHandler = (key: Key) => void;
+/**
+ * Return-value contract: only a literal `false` means anything — an
+ * exclusive handler declining a key so the dispatch continues into ordinary
+ * handlers (see {@link ExclusiveKeypressOptions}). Every other return value
+ * is ignored, and `unknown` keeps both sync and async handlers assignable
+ * (matching the old void-return assignability).
+ */
+export type KeypressHandler = (key: Key) => unknown;
 export type MouseHandler = (event: SgrMouseEvent) => void;
 
 export interface PasteProgress {
@@ -138,8 +145,27 @@ export interface PasteProgress {
   receivedBytes: number;
 }
 
+export interface ExclusiveKeypressOptions {
+  /**
+   * While any exclusive handler is subscribed, ordinary (non-exclusive)
+   * handlers do not receive keys. Reserved for modal surfaces that own the
+   * keyboard while mounted (the right-click context menu overlay), so the
+   * composer, dialogs, and tab bars cannot act on the same keystroke.
+   *
+   * An exclusive handler may return `false` to decline the key it was just
+   * handed: the dispatch then continues into the ordinary handlers for that
+   * same keystroke. This is the dismissal contract — the modal releases the
+   * keyboard and the dismissing key keeps flowing, instead of being dropped
+   * into the bare readline layer.
+   */
+  exclusive?: boolean;
+}
+
 interface KeypressContextValue {
-  subscribe: (handler: KeypressHandler) => void;
+  subscribe: (
+    handler: KeypressHandler,
+    options?: ExclusiveKeypressOptions,
+  ) => void;
   unsubscribe: (handler: KeypressHandler) => void;
   subscribeMouse: (handler: MouseHandler) => void;
   unsubscribeMouse: (handler: MouseHandler) => void;
@@ -179,6 +205,11 @@ export function KeypressProvider({
 }) {
   const { stdin, setRawMode } = useStdin();
   const subscribers = useRef<Set<KeypressHandler>>(new Set()).current;
+  // Exclusive handlers are tracked separately so broadcast() can gate the
+  // ordinary set with a cheap `size > 0` check instead of tagging every
+  // entry. A Set keyed by the same handler function keeps subscribe /
+  // unsubscribe symmetric.
+  const exclusiveSubscribers = useRef<Set<KeypressHandler>>(new Set()).current;
   const mouseSubscribers = useRef<Set<MouseHandler>>(new Set()).current;
   const [pasteProgress, setPasteProgress] = useState<PasteProgress>({
     active: false,
@@ -186,17 +217,22 @@ export function KeypressProvider({
   });
 
   const subscribe = useCallback(
-    (handler: KeypressHandler) => {
+    (handler: KeypressHandler, options?: ExclusiveKeypressOptions) => {
+      if (options?.exclusive) {
+        exclusiveSubscribers.add(handler);
+        return;
+      }
       subscribers.add(handler);
     },
-    [subscribers],
+    [subscribers, exclusiveSubscribers],
   );
 
   const unsubscribe = useCallback(
     (handler: KeypressHandler) => {
       subscribers.delete(handler);
+      exclusiveSubscribers.delete(handler);
     },
-    [subscribers],
+    [subscribers, exclusiveSubscribers],
   );
 
   const subscribeMouse = useCallback(
@@ -771,6 +807,22 @@ export function KeypressProvider({
       // FOCUS_IN/OUT) early-return before reaching broadcast, so terminal
       // protocol noise does not count as user activity.
       noteInteraction();
+      // While an exclusive handler is subscribed (an open context menu's
+      // overlay), it owns the keyboard: ordinary handlers are skipped for
+      // this key. The overlay returns false for a key it does not handle —
+      // the dismissal case — and the same key then flows to ordinary
+      // handlers below, so a dismissing keystroke is never lost.
+      if (exclusiveSubscribers.size > 0) {
+        let declined = false;
+        for (const handler of exclusiveSubscribers) {
+          if (handler(key) === false) {
+            declined = true;
+          }
+        }
+        if (!declined) {
+          return;
+        }
+      }
       for (const handler of subscribers) {
         handler(key);
       }
@@ -1641,6 +1693,7 @@ export function KeypressProvider({
     pasteWorkaround,
     config,
     subscribers,
+    exclusiveSubscribers,
     mouseSubscribers,
     initialCapturedInput,
   ]);

--- a/packages/cli/src/ui/hooks/useKeypress.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.ts
@@ -16,28 +16,35 @@ export type { Key };
  * @param onKeypress - The callback function to execute on each keypress.
  * @param options - Options to control the hook's behavior.
  * @param options.isActive - Whether the hook should be actively listening for input.
+ * @param options.exclusive - While subscribed, ordinary (non-exclusive)
+ *   handlers do not receive keys; returning `false` from the handler releases
+ *   a declined key back to them. Reserved for modal surfaces that own the
+ *   keyboard while mounted (the right-click context menu overlay).
  */
 export function useKeypress(
   onKeypress: KeypressHandler,
-  { isActive }: { isActive: boolean },
+  { isActive, exclusive = false }: { isActive: boolean; exclusive?: boolean },
 ) {
   const { subscribe, unsubscribe } = useKeypressContext();
   const onKeypressRef = useRef(onKeypress);
 
   onKeypressRef.current = onKeypress;
 
-  const handleKeypress = useCallback<KeypressHandler>((key) => {
-    onKeypressRef.current(key);
-  }, []);
+  // Forward the inner return value: an exclusive handler's `false` (key
+  // declined) must reach KeypressContext's broadcast, not die here.
+  const handleKeypress = useCallback<KeypressHandler>(
+    (key) => onKeypressRef.current(key),
+    [],
+  );
 
   useEffect(() => {
     if (!isActive) {
       return;
     }
 
-    subscribe(handleKeypress);
+    subscribe(handleKeypress, { exclusive });
     return () => {
       unsubscribe(handleKeypress);
     };
-  }, [isActive, handleKeypress, subscribe, unsubscribe]);
+  }, [isActive, exclusive, handleKeypress, subscribe, unsubscribe]);
 }


### PR DESCRIPTION
## What this PR does

Makes the right-click context menu own the keyboard while it is open, enforced at the keypress dispatch layer rather than by teaching every key consumer about the menu. The keypress context now has an exclusive subscription tier: while an exclusive handler is subscribed, ordinary handlers do not receive keys at all. The menu overlay subscribes exclusively for exactly as long as it is open — it consumes up/down/return/escape, and on any other key it dismisses itself and declines the key, so that same keystroke falls through to the ordinary pipeline (typing "x" with the menu open dismisses the menu and types "x"). Before this change the dispatch was a pure broadcast, so with a menu open: Enter executed the menu item and also submitted the composer's half-typed draft or confirmed the tool-approval dialog (down+enter could land on "Always allow in this project" — a persistent project-wide permission grant written by a keystroke aimed at the menu); Escape dismissed the menu and also cancelled the running stream or wiped the composer draft; Down moved the menu highlight and also switched agent tabs.

## Why it's needed

Entrance-by-entrance gating had not converged: on the teammate-tab PR three consecutive review rounds each closed one entrance of this family and left the next open. The durable fix the issue asks for is exclusivity at the dispatch layer, with two constraints this PR respects: the dismissing key must still fall through after the menu closes (returning early would drop it into the bare readline layer), and the mouse controller's own activation must not be gated (its menu-open branch is the only hover/click/dismiss path for the open menu). The existing per-consumer gating in the main input prompt and the app container is untouched — it stays correct and now redundant-safe.

## Reviewer Test Plan

### How to verify

Build and open the interactive CLI in a terminal with mouse support, trigger a tool confirmation, right-click the transcript to open the context menu, then press Enter / Escape / Down: each key must act on the menu only — the approval dialog must not confirm or cancel, the composer must not submit or clear, tabs must not switch. Then press a printable key: the menu must dismiss and the character must appear in the composer in the same keystroke. Close the menu and confirm keys reach the app normally again. Unit tests cover all four behaviors at the dispatch layer and at the overlay level with a bystandar handler.

### Evidence (Before & After)

Non-trivial UI behavior; before/after TUI recording pending — unit tests included (3 dispatch-layer tests, 4 overlay exclusivity tests, all green along with the existing 167 keypress/context-menu tests and 452 consumer-surface tests: InputPrompt, AppContainer, AgentComposer, ToolConfirmationMessage).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |        |
| 🪟 Windows |   ✅    |
|  🐧 Linux  |        |

### Environment (optional)

npm run dev + vitest unit tests, Windows sandbox none.

## Risk & Scope

- Main risk or tradeoff: the exclusive tier is a new dispatch semantic; only the context menu overlay uses it today. An exclusive handler that fails to unsubscribe (crash inside the handler without React unmounting) would starve ordinary handlers, but the overlay's subscription is bound to its mount state, so unmount always releases it.
- Not validated / out of scope: full E2E/tmux recording; the legacy per-consumer gating in InputPrompt/AppContainer was intentionally left in place (still correct; removing it is follow-up cleanup if maintainers prefer).
- Breaking changes / migration notes: none — `subscribe(handler)` without options behaves exactly as before; `KeypressHandler`'s return type widened from `void` to `unknown` (source-compatible).

## Linked Issues

Fixes #11228