### PR TITLE
fix(ci): widen the replayed supersede-cede timeline margin to deflake Scripts

### DIFF
--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -6234,8 +6234,11 @@ describe('review supersede salvage (#10110)', () => {
       // run start is the triggering push's shape, and no watcher poll
       // could have recorded the kill that early) — so the event postdates
       // START_TS + SALVAGE_POLL_SECONDS with margin for the harness setup
-      // between now and the loop start.
-      const now = new Date(Date.now() + 75000).toISOString();
+      // between now and the loop start. The margin is deliberately
+      // generous: the branch has no upper bound on the timestamp, and a
+      // loaded self-hosted runner once ate a 15s margin and turned this
+      // genuine cede red.
+      const now = new Date(Date.now() + 300000).toISOString();
       const r = runScenario('cede_revert_ff_kill', {
         armWatcher: true,
         extraEnv: {
@@ -6364,7 +6367,7 @@ describe('review supersede salvage (#10110)', () => {
         armWatcher: true,
         extraEnv: {
           ...base,
-          STUB_TIMELINE: `head-x head-a ${new Date(Date.now() + 75000).toISOString()}`,
+          STUB_TIMELINE: `head-x head-a ${new Date(Date.now() + 300000).toISOString()}`,
           STUB_TIMELINE_ACTOR: 'qwen-ci-bot',
         },
       });


### PR DESCRIPTION
## What this PR does

Deflakes the replayed-loop test "cedes a killed attempt whose superseding departure was a normal push" by widening the fabricated timeline-event offset from 75 seconds to 300 seconds, and adjusts the one sibling arm that deliberately mirrors that timestamp to the same value. Only test inputs change; no workflow or product code is touched.

## Why it's needed

The test flaked on main in Release run 34485181843 ("Quality Checks (Scripts)", `AssertionError: expected 1 to be +0`). The workflow's kill-record salvage branch accepts a lone back-push timeline event only when its timestamp is at least one poll interval (60s) past the run's start, which distinguishes a genuine watcher-witnessed supersede from the run's own triggering push. The test generated the event 75s ahead of its own clock, leaving only a 15s margin for the harness setup that runs before the replayed loop captures its start time. On a loaded self-hosted runner that setup exceeded 15s, the genuine cede was refused and the replayed loop exited red. The salvage branch places no upper bound on the event timestamp and the harness stubs the watcher's poll sleep, so a much larger offset removes the race without changing what the test verifies.

## Reviewer Test Plan

### How to verify

Confirm the diff only changes two millisecond offsets (75_000-style to 300_000-style) plus a comment in the one test file, then run the scripts suite: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js`. Expected: all tests pass, including the previously failing cede test and the mirrored bot-actor refusal arm. I ran the full file three times locally after the change — 259 passed | 1 skipped, exit 0 each time — plus targeted runs of both affected tests.

### Evidence (Before & After)

N/A (CI test-only change). Before: Release run 34485181843, Scripts job red with `expected 1 to be +0` at the cede assertion. After: repeated full-file runs green; the previous Release run on main (34405573082) also passed this test, confirming the failure was a margin flake rather than a regression.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx vitest run --config ./scripts/tests/vitest.config.ts` (Node 22, macOS arm64). Linux is covered by CI's "Quality Checks (Scripts)" job.

## Risk & Scope

- Main risk or tradeoff: none beyond the two test-input values; assertions and verified behavior are unchanged.
- Not validated / out of scope: the sibling "inside the first poll interval" arm keeps its +30s offset on purpose — its expected refusal outcome is insensitive to harness setup latency, so it cannot flake the same way.
- Breaking changes / migration notes: none.

## Linked Issues

None — fixes the CI flake observed in Release run 34485181843.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将回放 loop 测试 "cedes a killed attempt whose superseding departure was a normal push" 中伪造的时间线事件偏移从 75 秒放宽到 300 秒，以消除 flake;并把刻意镜像该时间戳的一个同类 arm 调整到相同数值。仅修改测试输入,不涉及任何 workflow 或产品代码。

## 为什么需要

该测试在 main 的 Release run 34485181843("Quality Checks (Scripts)" job)中 flake 失败(`AssertionError: expected 1 to be +0`)。workflow 的 kill-record salvage 分支只接受时间戳不早于 run 开始后一个轮询间隔(60 秒)的孤立 back-push 时间线事件,以此区分"watcher 真实目击的 supersede"与"触发本次 run 自己的 push"。测试生成的事件只比测试自身时钟提前 75 秒,留给回放 loop 捕获开始时间之前的 harness 搭建工作的余量仅 15 秒。在高负载的 self-hosted runner 上搭建超过 15 秒,真实的 cede 被拒绝,回放 loop 红着退出。salvage 分支对事件时间戳没有上界校验,且 harness 中 watcher 的轮询 sleep 是 stub 的,因此更大的偏移可以在不改变被验证行为的前提下消除竞争。

## Reviewer 测试计划

### 如何验证

确认 diff 只改动了一个测试文件中的两处毫秒偏移(75 秒级改为 300 秒级)及一处注释,然后运行脚本套件:`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js`。预期:全部测试通过,包括此前失败的 cede 用例和镜像它的 bot-actor 拒绝 arm。改动后我在本地完整运行该文件三次——每次均为 259 通过 | 1 跳过,退出码 0——并对两个受影响用例做了定点运行。

### 证据(前后对比)

N/A(仅 CI 测试改动)。改动前:Release run 34485181843 的 Scripts job 在 cede 断言处红,报 `expected 1 to be +0`。改动后:整文件重复运行全绿;main 上前一次 Release run(34405573082)也曾通过该测试,证实失败是余量 flake 而非回归。

### 测试平台

macOS 已验证 ✅;Windows、Linux 未本地验证 ⚠️(Linux 由 CI 的 "Quality Checks (Scripts)" job 覆盖)。

### 环境(可选)

`npx vitest run --config ./scripts/tests/vitest.config.ts`(Node 22,macOS arm64)。

## 风险与范围

- 主要风险或取舍:仅两个测试输入值,断言与被验证行为均未改变,无其他风险。
- 未验证 / 超出范围:同文件中"落在第一个轮询间隔内"的 arm 刻意保留 +30 秒偏移——其预期结果是拒绝,对 harness 搭建耗时不敏感,不会以同样方式 flake。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

无——修复的是 Release run 34485181843 中观测到的 CI flake。

</details>
