### PR TITLE
fix(ci): pin the fleet install to the /usr/local prefix

### DIFF
--- a/.github/scripts/update-ecs-runner-qwen-workflow.test.mjs
+++ b/.github/scripts/update-ecs-runner-qwen-workflow.test.mjs
@@ -124,6 +124,18 @@ describe('ECS runner qwen update workflow', () => {
     );
   });
 
+  it('pins the install to the /usr/local prefix', () => {
+    // Clearing NPM_CONFIG_PREFIX only drops the environment variable; npm's
+    // own computed default survives it, and on hk-4 and hk-5 that default is a
+    // bundled Node directory rather than /usr/local. The install then succeeds
+    // into a tree the runner's PATH never reads, while the verify step keeps
+    // checking /usr/local/bin/qwen — which is how those pools served four
+    // releases on a stale binary. This flag is the only thing making the
+    // target explicit, and it was dropped once before without anything
+    // objecting.
+    assert.ok(workflow.includes('npm install -g --prefix /usr/local'));
+  });
+
   it('pins the 90-minute resolve budget', () => {
     const resolveJob = workflow.slice(
       workflow.indexOf('  resolve:'),

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -105,7 +105,9 @@ jobs:
             PKG_DIR='/usr/local/lib/node_modules/@qwen-code'
             for attempt in 1 2 3; do
               sudo rm -rf "${PKG_DIR}"/.qwen-code-* 2>/dev/null || true
-              if sudo env -u NPM_CONFIG_PREFIX npm install -g --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"; then
+              # --prefix pins the install to /usr/local: on the hk-4/hk-5
+              # machines root's npm global prefix is a custom Node directory
+              if sudo env -u NPM_CONFIG_PREFIX npm install -g --prefix /usr/local --registry=https://registry.npmjs.org "@qwen-code/qwen-code@${VERSION}"; then
                 exit 0
               fi
               if [[ "${attempt}" -lt 3 ]]; then


### PR DESCRIPTION
## What this PR does

Pins the fleet updater's install to the `/usr/local` prefix, so the version it installs is the one the runners actually execute.

## Why it's needed

The updater installs with `sudo env -u NPM_CONFIG_PREFIX npm install -g`. Clearing the environment variable does not change npm's own computed default prefix, and on hk-4 and hk-5 that default is a custom Node directory rather than `/usr/local`. The new version therefore lands in a bin directory nothing on the runner's PATH reads, while `/usr/local/bin/qwen` goes on pointing at the previous install.

What makes this expensive is how quiet it is. npm reports `changed 16 packages` exactly as it does on the hosts where the two prefixes happen to agree — the install genuinely succeeded, just somewhere else — so the only step that notices is the verify at the end, by which point the log says nothing about where the package went. hk-4 and hk-5 stayed on `0.23.0` through `0.23.1`, `0.23.2` and `0.23.3`, five consecutive runs, each green through the install. A pool that misses an update is indistinguishable from a healthy one while it serves PR reviews on the old CLI.

`--prefix` is a command-line option, so it outranks the computed default, root's npmrc and `/etc/npmrc` alike, and it makes the install target explicit rather than dependent on each host's Node layout. The two hosts where this has always worked are not running a different workflow — their npm simply happens to agree with `/usr/local/bin/qwen`.

This restores c64936d6, which carried the same one-line change and was dropped from #10921 to keep that PR's scope on the npm publish timeout.

## Reviewer Test Plan

### How to verify

Already verified on the affected host: running the same install with the prefix pinned moved hk-4 from `0.23.0` to `0.23.3` immediately. hk-5 has deliberately been left untouched, so the first run of this workflow after merge is a live test — it should bring hk-5 up to the current version, and its verify step should pass rather than reporting the old one.

The hosts that were already working are the other half of the check: hk-1 and hk-3 should keep passing, since pinning a prefix they already resolve to changes nothing for them.

### Evidence (Before & After)

Before, on hk-4 and hk-5: `changed 16 packages in 3s`, then `qwen version: 0.23.0` against an expected `0.23.3`. After, on hk-4: the same command with `--prefix /usr/local` installs to the path the runner resolves, and the version reads `0.23.3`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ✅ verified by hand on hk-4  |

### Environment (optional)

The ECS runner fleet — five Hong Kong pools of 32 logical runners each, one runner per pool carrying the `ecs-update-hk-N` label that routes this workflow to that machine.

## Risk & Scope

- Main risk or tradeoff: the install target is now fixed at `/usr/local` rather than following each host's npm configuration. That is the intent — the verify step has always assumed `/usr/local/bin/qwen` — but a host deliberately configured to keep its global packages elsewhere would now be written to anyway.
- Not validated / out of scope: nothing here makes a mislanded install easier to diagnose. If a future divergence sends the package somewhere unexpected again, the log will still say only that the version is wrong, not where the files went. Printing npm's resolved prefix and the real path behind `/usr/local/bin/qwen` when the verify fails would fix that, and belongs in its own change rather than widening this one — which is how the fix ended up dropped the first time.
- Breaking changes / migration notes: none.

## Linked Issues

None — restores c64936d6, which was dropped from #10921. Closes #11403, the stale-fleet alert this condition raised.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 fleet 更新流程的安装目标固定到 `/usr/local` 前缀，使它装上的版本就是 runner 实际执行的那一个。

## 为什么需要

更新使用 `sudo env -u NPM_CONFIG_PREFIX npm install -g` 执行。清除该环境变量并不会改变 npm 自身计算出的默认前缀，而在 hk-4 和 hk-5 上，这个默认值是一个自定义的 Node 目录，而非 `/usr/local`。于是新版本被装进了一个 runner PATH 根本不会读取的 bin 目录，而 `/usr/local/bin/qwen` 仍然指向上一次的安装。

代价高的地方在于它有多安静。npm 会输出 `changed 16 packages`，与那些两个前缀恰好一致的主机上完全相同——安装确实成功了，只是装到了别处——因此唯一会察觉的只有最后的校验步骤，而到那时日志已经无法说明包去了哪里。hk-4 与 hk-5 就这样在 `0.23.1`、`0.23.2`、`0.23.3` 三个版本期间一直停留在 `0.23.0`，连续五次运行，每次都在安装步骤上是绿的。一个漏掉更新的池，在它用旧版 CLI 处理 PR 审查时，与健康的池毫无区别。

`--prefix` 是命令行选项，因此其优先级高于计算出的默认值、root 的 npmrc 以及 `/etc/npmrc`，并且让安装目标变成显式声明，而不再依赖每台主机的 Node 布局。那两台一直正常的主机并非跑着不同的 workflow——只是它们的 npm 恰好与 `/usr/local/bin/qwen` 对齐。

本 PR 恢复了 c64936d6，该提交包含同样的一行改动，此前为使 #10921 的范围聚焦于 npm 发布等待时间而被移出。

## 评审验证计划

### 如何验证

已在受影响主机上验证：以固定前缀执行同样的安装，hk-4 立即从 `0.23.0` 更新到 `0.23.3`。hk-5 有意未做手工修改，因此合并后本 workflow 的第一次运行就是一次实机验证——它应当把 hk-5 更新到当前版本，其校验步骤应当通过，而不再报出旧版本。

一直正常的那些主机是检查的另一半：hk-1 与 hk-3 应当继续通过，因为把前缀固定到它们本就解析到的位置，对它们没有任何改变。

### 证据（Before & After）

改动前，在 hk-4 与 hk-5 上：`changed 16 packages in 3s`，随后 `qwen version: 0.23.0`，而期望值是 `0.23.3`。改动后，在 hk-4 上：同样的命令加上 `--prefix /usr/local`，安装到 runner 实际解析的路径，版本读数为 `0.23.3`。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  ✅ 已在 hk-4 上手工验证  |

### 环境（可选）

ECS runner 集群——五个香港池，每池 32 个逻辑 runner，每池有一个 runner 带 `ecs-update-hk-N` 标签，本 workflow 依此路由到那台机器。

## 风险与范围

- 主要风险/取舍：安装目标现在固定为 `/usr/local`，而不再跟随每台主机的 npm 配置。这正是本意——校验步骤一直假定的就是 `/usr/local/bin/qwen`——但一台被刻意配置为将全局包放在别处的主机，现在也会被写入该位置。
- 未验证 / 不在范围内：本 PR 并未让"装错位置"这件事更容易诊断。如果将来再次出现前缀分歧，日志仍然只会说版本不对，而不会说文件去了哪里。在校验失败时打印 npm 解析出的前缀以及 `/usr/local/bin/qwen` 背后的真实路径可以解决这一点，但它应当作为独立的改动提出，而不是扩大本 PR 的范围——而当初这个修复正是因为范围问题被移除的。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无——本 PR 恢复了 c64936d6，该提交此前被移出 #10921。同时关闭 #11403，即这一问题触发的 fleet 过期告警。

</details>

