### PR TITLE
perf(core): drop the redundant history clone in session recovery planning

### DIFF
--- a/packages/core/src/core/session-recovery.test.ts
+++ b/packages/core/src/core/session-recovery.test.ts
@@ -7,7 +7,10 @@
 import { describe, expect, it } from 'vitest';
 import type { Content } from '@google/genai';
 import type { ConversationRecord } from '../services/sessionService.js';
-import { buildSessionRecoveryPlan } from './session-recovery.js';
+import {
+  buildSessionRecoveryPlan,
+  buildSessionRecoveryPlanFromApiHistory,
+} from './session-recovery.js';
 
 function conversation(messages: Content[]): ConversationRecord {
   return {
@@ -103,6 +106,37 @@ describe('buildSessionRecoveryPlan', () => {
     expect(plan.apiHistory.at(-1)?.parts?.[0]?.functionResponse?.id).toBe(
       'call-1',
     );
+  });
+
+  it('leaves a caller-supplied history unmutated while repairing its own copy', () => {
+    const apiHistory: Content[] = [
+      { role: 'user', parts: [{ text: 'read file' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'call-1',
+              name: 'read_file',
+              args: { path: 'a.txt' },
+            },
+          },
+        ],
+      },
+    ];
+    const supplied = structuredClone(apiHistory);
+
+    const plan = buildSessionRecoveryPlanFromApiHistory({
+      sessionId: 'session-1',
+      apiHistory,
+    });
+
+    expect(plan.kind).toBe('interrupted_turn');
+    // The repair must land on the plan's own copy: a builder that mutated the
+    // argument would corrupt the live chat history the caller passed in.
+    expect(apiHistory).toEqual(supplied);
+    expect(plan.originalApiHistory.at(-1)?.role).toBe('model');
+    expect(plan.apiHistory.at(-1)?.role).toBe('user');
   });
 
   it('marks sessions with history gaps as degraded and disables continuation', () => {

--- a/packages/core/src/core/session-recovery.ts
+++ b/packages/core/src/core/session-recovery.ts
@@ -126,7 +126,9 @@ export function buildSessionRecoveryPlanFromApiHistory({
   historyGaps,
   options,
 }: BuildSessionRecoveryPlanFromApiHistoryInput): SessionRecoveryPlan {
-  const originalApiHistory = structuredClone(inputApiHistory);
+  // Never mutated below — interruption detection only reads it, and the repair
+  // runs on the clone — so the caller's array can be aliased instead of copied.
+  const originalApiHistory = inputApiHistory;
   const gaps = historyGaps ?? [];
   const planId = createPlanId(sessionId, originalApiHistory.length);
 


### PR DESCRIPTION
## What this PR does

When a session is resumed, the code that works out how the previous session ended — cleanly, mid-prompt, or mid-tool-call — used to make two full deep copies of the rebuilt conversation history before it looked at it. The first copy existed to keep a pristine version for interruption detection; the second was the one the orphaned-tool-use repair mutates in place.

Interruption detection only ever reads. So the pristine copy is now the array the caller passed in, and only the repair gets a deep copy. Every caller already hands over a snapshot it owns rather than live chat state, so nothing else can observe the difference, and the caller's array is still never modified.

On a synthetic 50,000-record transcript that takes roughly 85 ms off a resume where nothing was ever compressed, and roughly 15 ms off one that had compressed, out of a resume whose total cost is dominated by parsing the transcript.

## Why it's needed

Resuming a long session is one of the slower interactions in the CLI, and the deep copies scale with the size of the history being resumed. Cloning the same conversation twice in a row, when one of the two copies is only ever read, doubles that cost for no benefit.

The measurement that motivated this also ruled out a neighbouring change. Rebuilding the history currently walks every record from the start of the transcript and discards the accumulated result when it reaches a compression checkpoint, so the records before that checkpoint are copied for nothing. Skipping straight to the last checkpoint was measured to save about 8 ms on the same 50,000-record transcript — and to cost about 4 ms on a session that never compressed, because the backward scan itself is not free. That trade is not worth taking, and this PR does not take it. The redundant clone was worth 2–19× more depending on the session.

## Reviewer Test Plan

### How to verify

This is a non-user-visible change with no behaviour difference, so verification is that the returned plan is unchanged and the caller's argument is still untouched.

Run the recovery unit tests:

```
cd packages/core && npx vitest run src/core/session-recovery.test.ts
```

Expected: 5 passing. The pre-existing suite was 4; the new case builds a history ending in an unanswered tool call, passes it in as a caller-owned array, and asserts three things — the plan still classifies it as an interrupted tool turn, the array the caller passed in is structurally identical to a snapshot taken before the call, and the plan's repaired history ends in the synthesized tool result while its reported original history still ends on the dangling model turn.

That last pair is what keeps the test honest: the classification assertion proves the repair path actually ran, so the "argument unchanged" assertion cannot pass vacuously. Removing the remaining clone makes the test fail, and it fails on the classification first — repairing in place would let detection see the already-repaired history and report a different kind of ending. That ordering hazard is the reason this PR keeps the second clone.

Type checking and lint are clean for the changed package:

```
cd packages/core && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit   # exit 0, no output
npx eslint packages/core/src/core/session-recovery.ts packages/core/src/core/session-recovery.test.ts
npx prettier --check packages/core/src/core/session-recovery.ts packages/core/src/core/session-recovery.test.ts
```

The heap flag matters locally: at the default heap the type check runs out of memory part-way and emits spurious `Buffer<ArrayBufferLike>` errors in an unrelated file. With 8 GB it exits 0 with no output, both with and without this change.

For the performance claim itself, the numbers came from a throwaway harness that generated transcripts of 4k / 20k / 50k records with and without a compression checkpoint at the 80% mark, then timed the current strategy against this one and against a no-clone variant, median of 5 runs with an explicit GC before each. Across all six combinations the resulting plans were byte-identical on every field a caller reads — plan id, kind, repairs, the continuation payload, and the repaired history.

| Transcript | Current | This PR | No-clone variant (not taken) |
| --- | --- | --- | --- |
| 50k records, compressed | 33.5 ms | 18.7 ms | 2.1 ms |
| 50k records, uncompressed | 166.8 ms | 81.8 ms | 7.6 ms |
| 20k records, compressed | 12.5 ms | 6.7 ms | 1.8 ms |
| 20k records, uncompressed | 58.7 ms | 29.6 ms | 1.9 ms |

### Evidence (Before & After)

N/A — no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Windows and Linux are left to CI; the change is platform-independent core logic covered by unit tests.

### Environment (optional)

Local git worktree off `origin/main` at `07b1cd033e`, running vitest and tsc against TypeScript source. Performance harness ran through `tsx` with `--expose-gc` on Node v25.6.1.

## Risk & Scope

- Main risk or tradeoff: the plan's reported original history is now the same array object the caller passed in instead of a copy of it. Nothing in production reads that field — the only reader anywhere in the repository is one assertion in the recovery unit test — so this is not observable today. The residual risk is future-facing: a caller that mutated that field would now be mutating its own input. The comment at the change site records why no copy is made.
- Not validated / out of scope: the second clone stays, because the repair mutates its argument in place and detection must see the pre-repair history; removing it was measured (last column above) but requires reordering detection ahead of the repair and gives up the pristine field on a type this package exports publicly, so it needs its own change. Also out of scope: the wasted copies before a compression checkpoint when rebuilding history (measured at ~8 ms, and a regression on sessions that never compressed), and letting the interactive CLI resume use the selective transcript projection that the embedded hosts already use — that last one is the largest remaining cost on this path, since it is the transcript parse itself.
- Breaking changes / migration notes: none. The returned plan is field-for-field identical, and the argument is still not modified.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复一个会话时，判断「上一个会话是怎么结束的」（正常结束、停在用户输入后、停在工具调用中）的那段逻辑，之前会在查看历史之前把重建出来的会话历史完整深拷贝两次。第一次拷贝是为了给中断检测留一份未被修改的原始副本，第二次拷贝则是给「修复孤立工具调用」的那步用来原地改写的。

中断检测自始至终只读不写。所以现在那份「原始副本」直接使用调用方传进来的数组，只有修复那一步才做深拷贝。所有调用方传进来的本来就是它们自己持有的快照而不是活跃的会话状态，因此这个差别对外不可观察，而调用方的数组依然不会被修改。

在一个合成的 5 万条记录的 transcript 上，这为「从未发生过压缩」的恢复省下约 85 ms，为「发生过压缩」的恢复省下约 15 ms；而整个恢复流程的耗时主要花在解析 transcript 上。

## 为什么需要

恢复长会话是 CLI 里比较慢的交互之一，而深拷贝的开销随被恢复历史的规模增长。把同一份会话连续克隆两次、而其中一份只用于读取，等于白白把这部分开销翻倍。

促成这次改动的测量同时排除了一个相邻的改动。重建历史时目前会从 transcript 开头逐条遍历，走到压缩检查点就把已累积的结果整体丢弃，所以检查点之前那些记录的拷贝完全是白做的。直接跳到最后那个检查点，在同样的 5 万条记录 transcript 上测得只省约 8 ms —— 而在从未压缩过的会话上反而多花约 4 ms，因为反向扫描本身不是免费的。这个取舍不划算，本 PR 没有采用。冗余克隆的收益是它的 2–19 倍，取决于会话形态。

## 审阅测试计划

### 如何验证

这是一个用户不可见、且行为无差异的改动，所以验证点是「返回的 plan 不变」以及「调用方传入的数组仍未被改动」。

运行恢复相关的单元测试：

```
cd packages/core && npx vitest run src/core/session-recovery.test.ts
```

预期 5 个通过。原有测试是 4 个；新增的那个用例构造一段以「未被响应的工具调用」结尾的历史，以调用方自有数组的形式传入，并断言三件事：plan 仍把它判定为中断的工具轮次；调用方传入的数组与调用前的快照结构完全一致；plan 里修复后的历史以合成的工具结果结尾，而它报告的原始历史仍停在那个悬空的 model 轮次上。

最后这一对断言是保证测试不空转的关键：分类断言证明修复路径确实执行了，所以「入参未被修改」这条断言不可能空洞地通过。把剩下的那次克隆也去掉会让测试失败，而且首先失败在分类上 —— 原地修复会让检测看到已经修好的历史，从而报告出另一种结束方式。这个顺序上的陷阱正是本 PR 保留第二次克隆的原因。

改动所在包的类型检查与 lint 均干净：

```
cd packages/core && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit   # 退出码 0，无输出
npx eslint packages/core/src/core/session-recovery.ts packages/core/src/core/session-recovery.test.ts
npx prettier --check packages/core/src/core/session-recovery.ts packages/core/src/core/session-recovery.test.ts
```

本地那个堆参数是必要的：在默认堆大小下类型检查会中途内存溢出，并在一个无关文件里报出虚假的 `Buffer<ArrayBufferLike>` 错误。给到 8 GB 后，无论有没有本次改动都是退出码 0、无任何输出。

性能数字本身来自一个一次性测量脚本：生成 4k / 20k / 50k 条记录的 transcript，分别在 80% 位置有和没有压缩检查点两种形态下，对现状策略、本 PR 策略、以及一个「零克隆」变体计时，每种取 5 次运行的中位数，每次运行前显式 GC。在全部六种组合下，三个变体产出的 plan 在调用方会读取的每一个字段上都逐字节相同 —— plan id、kind、repairs、continuation 载荷、以及修复后的历史。

| Transcript | 现状 | 本 PR | 零克隆变体（未采用） |
| --- | --- | --- | --- |
| 5 万条，有压缩 | 33.5 ms | 18.7 ms | 2.1 ms |
| 5 万条，无压缩 | 166.8 ms | 81.8 ms | 7.6 ms |
| 2 万条，有压缩 | 12.5 ms | 6.7 ms | 1.8 ms |
| 2 万条，无压缩 | 58.7 ms | 29.6 ms | 1.9 ms |

### 前后对比证据

N/A —— 没有用户可见或 TUI 层面的变化。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Windows 与 Linux 交由 CI 覆盖；本次改动是与平台无关的核心逻辑，已有单元测试覆盖。

### 运行环境（可选）

基于 `origin/main`（`07b1cd033e`）的本地 git worktree，直接对 TypeScript 源码运行 vitest 与 tsc。性能测量脚本通过 `tsx` 加 `--expose-gc` 在 Node v25.6.1 上运行。

## 风险与范围

- 主要风险或取舍：plan 里报告的「原始历史」现在是调用方传入的同一个数组对象，而不再是它的副本。生产代码中没有任何地方读取该字段 —— 全仓库唯一的读者是恢复逻辑单元测试里的一条断言 —— 所以目前不可观察。残留风险是面向未来的：如果某个调用方去修改该字段，就等于在修改它自己的输入。改动处的注释记录了为什么这里不做拷贝。
- 未验证 / 不在范围内：第二次克隆保留，因为修复步骤会原地改写它的入参，而检测必须看到修复前的历史；去掉它的数据已经测出（见上表最后一列），但那需要把检测提前到修复之前，并且要在一个本包公开导出的类型上放弃「原始副本」这个字段，应当单独成一个改动。同样不在范围内：重建历史时压缩检查点之前那些白做的拷贝（测得约 8 ms，且在从未压缩的会话上是负收益），以及让交互式 CLI 的恢复也走嵌入式宿主已在使用的选择性 transcript 投影 —— 最后这项是这条路径上剩下的最大开销，因为它就是 transcript 解析本身。
- 破坏性变更 / 迁移说明：无。返回的 plan 逐字段一致，入参依然不会被修改。

## 关联 Issue

无。

</details>
