### PR TITLE
fix(core): recover from rejected Responses encrypted reasoning

### DIFF
--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts
@@ -13,7 +13,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import type { GenerateContentParameters } from '@google/genai';
+import type { Content, GenerateContentParameters } from '@google/genai';
 import { FunctionCallingConfigMode, FinishReason } from '@google/genai';
 import { inspect } from 'node:util';
 import {
@@ -2046,6 +2046,119 @@ describe('ResponsesPipeline', () => {
       expect(second.input).toEqual(retryInput);
       expect({ ...second, input: null }).toEqual({ ...first, input: null });
     }
+
+    const encryptedError = {
+      error: {
+        type: 'invalid_request_error',
+        code: 'invalid_encrypted_content',
+        message: 'The encrypted content could not be decrypted or parsed.',
+      },
+    };
+    const encryptedBodies = [
+      JSON.stringify(encryptedError),
+      'data: ' +
+        JSON.stringify({
+          routify_response: {
+            success: false,
+            status: 400,
+            error_detail: encryptedError,
+          },
+        }) +
+        '\n\n',
+    ];
+
+    it.each(encryptedBodies)(
+      'recovers once from rejected encrypted replay: %s',
+      async (body) => {
+        fetchMock.mockResolvedValueOnce(errorResponse(400, body));
+        fetchMock.mockResolvedValueOnce(okResponse(COMPLETED));
+        const request = replayRequest();
+        const original = structuredClone(request);
+        const pipeline = new ResponsesPipeline(
+          makeGeneratorConfig(),
+          makeCliConfig(),
+        );
+        expect(await drain(pipeline, request)).toBeUndefined();
+        expectRetryDiffersOnlyByInput(ALL_REASONING_INPUT);
+        expect(request).toEqual(original);
+      },
+    );
+
+    it('preserves tool call/result pairs when recovering encrypted replay', async () => {
+      fetchMock.mockResolvedValueOnce(errorResponse(400, encryptedBodies[0]!));
+      fetchMock.mockResolvedValueOnce(okResponse(COMPLETED));
+      const request = replayRequest();
+      request.contents = [
+        ...(request.contents as Content[]),
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'lookup',
+                args: { value: 1 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call_1',
+                name: 'lookup',
+                response: { output: 'found' },
+              },
+            },
+          ],
+        },
+      ];
+      const pipeline = new ResponsesPipeline(
+        makeGeneratorConfig(),
+        makeCliConfig(),
+      );
+      expect(await drain(pipeline, request)).toBeUndefined();
+      const first = parsedCall(0);
+      const second = parsedCall(1);
+      expect(first.input.filter((i) => i.type === 'reasoning')).toHaveLength(3);
+      expect(second.input.filter((i) => i.type === 'reasoning')).toHaveLength(
+        0,
+      );
+      expect(second.input.slice(-2)).toEqual(first.input.slice(-2));
+      expect(second.input.slice(-2).map((i) => i.type)).toEqual([
+        'function_call',
+        'function_call_output',
+      ]);
+    });
+
+    it('surfaces the second encrypted rejection without looping', async () => {
+      fetchMock.mockResolvedValue(errorResponse(400, encryptedBodies[0]!));
+      const pipeline = new ResponsesPipeline(
+        makeGeneratorConfig(),
+        makeCliConfig(),
+      );
+      expect(await drain(pipeline, replayRequest())).toMatchObject({
+        status: 400,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry encrypted rejection without reasoning in the request', async () => {
+      fetchMock.mockResolvedValue(errorResponse(400, encryptedBodies[0]!));
+      const pipeline = new ResponsesPipeline(
+        makeGeneratorConfig(),
+        makeCliConfig(),
+      );
+      expect(
+        await drain(pipeline, {
+          model: 'gpt-5',
+          contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        }),
+      ).toMatchObject({ status: 400 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
 
     // ── RED behaviors ────────────────────────────────────────────────────
 

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.ts
@@ -23,6 +23,8 @@ import {
 } from './responses-converter.js';
 import {
   countReasoningItems,
+  downgradeEncryptedReasoningItems,
+  isEncryptedReasoningRejection,
   downgradeRejectedReasoningItems,
   parseReasoningIdRejection,
 } from './responses-reasoning-rejection.js';
@@ -285,8 +287,8 @@ export class ResponsesPipeline {
 
   /**
    * Connect, and if the endpoint explicitly refuses a replayed reasoning item
-   * id, send the same request once more with those items downgraded (issue
-   * #9452).
+   * id or encrypted content, send the same request once more with those items
+   * downgraded (issue #9452).
    *
    * The first request always goes out exactly as built. Recovery matters
    * because the offending ids live in persisted history: without it, every
@@ -311,7 +313,7 @@ export class ResponsesPipeline {
   }
 
   /**
-   * The retry request, or undefined when the error is not a reasoning-id
+   * The retry request, or undefined when the error is not a reasoning replay
    * rejection or nothing in this body would change. Builds a new request
    * object -- the caller's request, the input array, and every item it holds
    * are left untouched.
@@ -323,17 +325,21 @@ export class ResponsesPipeline {
     if (typeof error !== 'object' || error === null) return undefined;
     const { reasoningIdRejection: rejection } =
       error as Partial<ResponsesApiError>;
-    if (!rejection) return undefined;
-
-    const input = downgradeRejectedReasoningItems(apiRequest.input, rejection);
+    const encryptedRejected = (error as Partial<ResponsesApiError>)
+      .encryptedReasoningRejected;
+    const input = rejection
+      ? downgradeRejectedReasoningItems(apiRequest.input, rejection)
+      : encryptedRejected
+        ? downgradeEncryptedReasoningItems(apiRequest.input)
+        : apiRequest.input;
     if (input === apiRequest.input) return undefined;
 
     const reasoningItems = countReasoningItems(apiRequest.input);
     // Metadata only: no id, no encrypted content, no endpoint.
     debugLogger.debug(
       'Retrying once with downgraded reasoning replay',
-      `namedIndex=${rejection.namedIndex}`,
-      `maxLengthReported=${rejection.maxLength !== null}`,
+      `namedIndex=${rejection?.namedIndex ?? 'all'}`,
+      `maxLengthReported=${rejection?.maxLength != null}`,
       `reasoningItems=${reasoningItems}`,
       `downgradedItems=${reasoningItems - countReasoningItems(input)}`,
     );
@@ -701,6 +707,10 @@ export class ResponsesPipeline {
       ) as ResponsesApiError;
       err.status = response.status;
       err.reasoningIdRejection = rejection;
+      err.encryptedReasoningRejected = isEncryptedReasoningRejection(
+        response.status,
+        errBody,
+      );
       throw redactProxyError(err);
     }
 
@@ -1096,6 +1106,7 @@ function sanitizePromptCacheKey(key: string): string {
 interface ResponsesApiError extends Error {
   status: number;
   reasoningIdRejection?: ReasoningIdRejection;
+  encryptedReasoningRejected?: boolean;
 }
 
 export function mergeStreamResponses(

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-reasoning-rejection.test.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-reasoning-rejection.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   countReasoningItems,
+  isEncryptedReasoningRejection,
   downgradeRejectedReasoningItems,
   parseReasoningIdRejection,
 } from './responses-reasoning-rejection.js';
@@ -532,5 +533,54 @@ describe('downgradeRejectedReasoningItems', () => {
     ];
     expect(countReasoningItems(items)).toBe(2);
     expect(countReasoningItems([])).toBe(0);
+  });
+});
+
+describe('isEncryptedReasoningRejection', () => {
+  const error = {
+    code: 'invalid_encrypted_content',
+    type: 'invalid_request_error',
+  };
+  const direct = JSON.stringify({ error });
+  const gateway = JSON.stringify({
+    routify_response: { success: false, status: 400, error_detail: { error } },
+  });
+
+  it.each([direct, gateway, `data: ${gateway}\n\n`])(
+    'recognizes an explicit encrypted-content rejection: %s',
+    (body) => {
+      expect(isEncryptedReasoningRejection(400, body)).toBe(true);
+    },
+  );
+
+  it.each([
+    ['wrong status', direct, 500],
+    [
+      'unknown code',
+      JSON.stringify({
+        error: {
+          code: 'invalid_request_error',
+          message: 'invalid_encrypted_content',
+        },
+      }),
+      400,
+    ],
+    ['quoted request', JSON.stringify({ debug: { error } }), 400],
+    ['contradictory gateway', gateway.replace('false', 'true'), 400],
+    ['wrong gateway status', gateway.replace('400', '500'), 400],
+    [
+      'duplicate error key',
+      `{"error":{},"error":${JSON.stringify(error)}}`,
+      400,
+    ],
+    ['oversized', direct.padEnd(64001, ' '), 400],
+    ['trailing garbage', direct + 'garbage', 400],
+    ['multiple frames', `data: ${gateway}\n\ndata: ${gateway}\n\n`, 400],
+    ['malformed', '{', 400],
+    ['array', `[${direct}]`, 400],
+  ])('does not recover on %s', (_label, body, status) => {
+    expect(isEncryptedReasoningRejection(Number(status), String(body))).toBe(
+      false,
+    );
   });
 });

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-reasoning-rejection.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-reasoning-rejection.ts
@@ -477,3 +477,36 @@ function readStringLiteral(
 export function countReasoningItems(items: ResponsesApiInputItem[]): number {
   return items.filter(isReasoningItem).length;
 }
+
+export function isEncryptedReasoningRejection(
+  status: number,
+  responseBody: string,
+): boolean {
+  if (status !== 400 || responseBody.length > MAX_BODY_CHARS) return false;
+  // Some gateways return one SSE data frame even on a non-2xx response.
+  const text = toEnvelopeText(responseBody.replace(/^data: ?/, ''));
+  if (!text) return false;
+  const envelope = readEnvelope(text, MAX_OBJECT_CANDIDATES, false);
+  if (!envelope || !isPlainObject(envelope.value)) return false;
+  const direct = readErrorMember(envelope.value);
+  if (direct) return direct['code'] === 'invalid_encrypted_content';
+
+  const gateway = envelope.value['routify_response'];
+  if (
+    !isPlainObject(gateway) ||
+    gateway['success'] !== false ||
+    gateway['status'] !== 400
+  )
+    return false;
+  const error = readErrorMember(gateway['error_detail']);
+  return error?.['code'] === 'invalid_encrypted_content';
+}
+
+export function downgradeEncryptedReasoningItems(
+  items: ResponsesApiInputItem[],
+): ResponsesApiInputItem[] {
+  return downgradeRejectedReasoningItems(items, {
+    namedIndex: items.findIndex(isReasoningItem),
+    maxLength: null,
+  });
+}


### PR DESCRIPTION
## What this PR does

When a Responses endpoint explicitly rejects replayed reasoning with HTTP 400 and `invalid_encrypted_content`, retry once with readable reasoning summaries in place of encrypted reasoning items. Preserve ordinary conversation, tool calls and their results, and the caller's original history. The first request remains unchanged; a second failure is surfaced normally. Recognize direct JSON errors and the observed single-frame Routify error envelope.

## Why it's needed

A multi-turn session currently stops on this rejection even when the model already completed useful tool calls. We reproduced it against a real endpoint and verified that the rejected ciphertext matched what the endpoint had returned. The same ciphertext was accepted in a later resumed request. This change provides bounded recovery; it does not claim to fix or identify the upstream validation failure.

## Reviewer Test Plan

### How to verify

Use a controlled Responses endpoint that first returns encrypted reasoning and a file-reading tool call, then rejects the next request with `invalid_encrypted_content`. Confirm the CLI retries once, preserves the tool call/result pair, does not execute the tool twice, and completes. Verify a second rejection remains terminal, unrelated errors are not rewritten, and normal requests retain their encrypted reasoning. Repeat with direct JSON and the observed gateway envelope.

### Evidence (Before & After)

Before: the controlled endpoint received one replay request and the CLI/pipeline stopped on HTTP 400; four new regression assertions failed. After: the bundled headless CLI completed with three total API requests, two model turns, one actual `read_file` execution, exit 0 and `OK`. The retry preserved tool history. All 314 focused pipeline, converter and reasoning-rejection tests passed; build, bundle, workspace typechecks and changed-file lint passed. The final integration typecheck reports TS2322 in unchanged ACP process-table code (`string | NonSharedBuffer` versus `string`).

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ✅ unit tests, build, bundled CLI and real-endpoint diagnosis |
| 🪟 Windows | ✅ downstream Astra code-mode desktop smoke |
| 🐧 Linux | ⚠️ not tested locally |

### Environment (optional)

Node.js 24.18.0; isolated CLI home and temporary test workspace; loopback mock endpoint with synthetic ciphertext. Real-endpoint diagnosis used Astra through Responses, recording ciphertext hashes rather than ciphertext or credentials.

## Risk & Scope

- Main risk or tradeoff: recovery loses the rejected encrypted reasoning state while preserving its readable summary. It occurs only after the explicit rejection and at most once per connection attempt.
- Not validated / out of scope: upstream root cause, restricted-user/AP integration and full benchmark success. HTTP 200 mid-stream encrypted-content errors are not covered by this recovery.
- Breaking changes / migration notes: none; no model-specific configuration or default stripping of reasoning.

## Linked Issues

Related: #9452 (existing reasoning replay recovery).

<details>
<summary>中文说明</summary>

### 本 PR 的改动

当 Responses 服务明确以 HTTP 400 和 `invalid_encrypted_content` 拒绝历史 reasoning 时，用可读摘要替代加密 reasoning 项并重试一次。普通对话、工具调用及其结果、调用方原始历史均保留。首次请求不变；第二次失败正常抛出。支持直接 JSON 错误和实际观察到的 Routify 单帧错误包装。

### 为什么需要

当前多轮会话会因这类拒绝直接停止，即使模型已经完成了有效的工具调用。我们在真实接口复现过，确认被拒绝的密文与接口先前返回的内容一致；同一密文后来在恢复会话的请求中又被接受。此改动提供有限恢复能力，不代表已修复或定位上游校验故障。

### 审查者测试计划

使用可控的 Responses 接口：先返回加密 reasoning 和读文件工具调用，再以 `invalid_encrypted_content` 拒绝下一轮请求。确认 CLI 只重试一次，保留工具调用与结果，不重复执行工具，并正常完成。确认第二次拒绝仍然终止，其他错误不触发改写，正常请求仍保留加密 reasoning。分别验证直接 JSON 和实际网关包装格式。

### 修改前后证据

修改前：可控接口只收到一次历史回传请求，CLI/请求管线在 HTTP 400 后停止；四个新增回归断言失败。修改后：打包后的无界面 CLI 通过三次 API 请求、两轮模型调用、一次实际 `read_file` 执行完成任务，退出码为 0，返回 OK；重试保留工具历史。管线、转换器和 reasoning 拒绝处理的 314 个针对性测试全部通过；构建、打包、各工作区类型检查和修改文件 lint 通过。最后的集成类型检查在未改动的 ACP 进程表代码报告 TS2322（`string | NonSharedBuffer` 与 `string` 类型不匹配）。

### 已测试平台

- macOS：已通过单元测试、构建、打包 CLI 验证和真实接口诊断。
- Windows：下游 Astra code mode 桌面 smoke 已通过。
- Linux：未在本地测试。

### 环境

Node.js 24.18.0；隔离的 CLI 配置目录和临时测试工作区；使用模拟密文的本地可控接口。真实接口诊断通过 Responses 调用 Astra，仅记录密文哈希，不记录密文或凭证。

### 风险与范围

- 主要取舍：恢复会丢失被拒绝的加密 reasoning 状态，保留可读摘要。仅在明确拒绝后发生，每次连接尝试最多恢复一次。
- 未验证或不在范围内：上游根因、受限用户/AP 集成和完整 benchmark 成功。该恢复不覆盖 HTTP 200 流中途发生的加密内容错误。
- 无破坏性变更或迁移要求；没有按模型写特殊配置，也不默认删除 reasoning。

### 关联问题

关联 #9452：已有的 reasoning 回传恢复逻辑。

</details>

