### PR TITLE
fix(core): mark reattached image snapshots as potentially outdated

### DIFF
--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -3830,7 +3830,9 @@ describe('LlmChat', async () => {
         parts: expect.arrayContaining([
           { text: 'continue' },
           {
-            text: expect.stringContaining('Recent images reattached'),
+            text: expect.stringContaining(
+              'Images read earlier in this session',
+            ),
           },
           {
             inlineData: {

--- a/packages/core/src/services/image-payload-references.test.ts
+++ b/packages/core/src/services/image-payload-references.test.ts
@@ -74,8 +74,9 @@ describe('prepareImagePayloadsForRequest', () => {
     expect(prepared.at(-1)?.role).toBe('user');
     expect(prepared.at(-1)?.parts?.[0]?.text).toBe('continue');
     expect(prepared.at(-1)?.parts?.[1]?.text).toContain(
-      'Recent images reattached',
+      'Images read earlier in this session',
     );
+    expect(prepared.at(-1)?.parts?.[1]?.text).toContain('may be OUTDATED');
   });
 
   it('reattaches an older image when the current request explicitly references its stable id', () => {
@@ -344,7 +345,7 @@ describe('buildReattachParts', () => {
     const replaced = replaceImagePayloadsInPlace(contents, store);
     const parts = buildReattachParts(replaced, 2);
     expect(parts).toHaveLength(3);
-    expect(parts[0]?.text).toContain('Recent images reattached');
+    expect(parts[0]?.text).toContain('Images read earlier in this session');
     const data = parts
       .filter((p) => p.inlineData)
       .map((p) => p.inlineData?.data);
@@ -355,6 +356,23 @@ describe('buildReattachParts', () => {
     const store = new InMemoryImagePayloadStore();
     const replaced = replaceImagePayloadsInPlace([toolImageTurn('a')], store);
     expect(buildReattachParts(replaced, 0)).toEqual([]);
+  });
+
+  it('labels reattached snapshots as potentially outdated, not current context (#11601)', () => {
+    const store = new InMemoryImagePayloadStore();
+    const contents = [
+      toolImageTurn('a'),
+      toolImageTurn('b'),
+      toolImageTurn('c'),
+      { role: 'user', parts: [{ text: 'continue' }] },
+    ];
+    replaceImagePayloadsInPlace(contents, store);
+
+    const parts = buildReattachParts([], 2, contents, store);
+    const prefix = parts[0]?.text ?? '';
+
+    expect(prefix).not.toContain('Recent images reattached');
+    expect(prefix).toMatch(/outdated|OUTDATED/);
   });
 
   it('resolves stored markers even when the current replacement pass is empty', () => {

--- a/packages/core/src/services/image-payload-references.ts
+++ b/packages/core/src/services/image-payload-references.ts
@@ -130,9 +130,7 @@ export function buildReattachParts(
   if (recent.length === 0) return [];
   return [
     {
-      text:
-        'Recent images reattached for visual context: ' +
-        recent.map((img) => `Image #${img.id}`).join(', '),
+      text: reattachContextText(recent.map((img) => img.id)),
     },
     ...recent.map(storedImageToPart),
   ];
@@ -201,9 +199,7 @@ export function prepareImagePayloadsForRequest(
 
   const reattachParts: Part[] = [
     {
-      text:
-        'Recent images reattached for visual context: ' +
-        [...reattachById.keys()].map((id) => `Image #${id}`).join(', '),
+      text: reattachContextText([...reattachById.keys()]),
     },
     ...[...reattachById.values()].map(storedImageToPart),
   ];
@@ -333,6 +329,13 @@ function imagePartToStoredPayload(part: Part): StoredImagePayload {
 
 function imageReferenceText(stored: StoredImagePayload): string {
   return `[Image #${stored.id}: ${safeImageMimeType(stored.mimeType)}, ${stored.bytes} bytes]`;
+}
+
+function reattachContextText(ids: readonly string[]): string {
+  return (
+    'Images read earlier in this session (may be OUTDATED, do not treat as current UI state): ' +
+    ids.map((id) => `Image #${id}`).join(', ')
+  );
 }
 
 function safeImageMimeType(mimeType: string): string {


### PR DESCRIPTION
## What this PR does

Changes the injected prefix used when image payloads are reattached for visual context so it no longer presents frozen eviction-time snapshots as "current" visual context. The prefix now reads "Images read earlier in this session (may be OUTDATED, do not treat as current UI state): …" instead of "Recent images reattached for visual context: …". The replay mechanics (which payloads get reattached, in what order, and the recency cap) are unchanged.

## Why it's needed

After a session's inline image count crosses `imagePayloadThreshold`, `buildReattachParts()` reattaches up to `maxRecentImages` frozen snapshots to every subsequent request. Those snapshots are the base64 captured at eviction time and are never refreshed, yet the label "Recent images reattached for visual context" told the model they were live evidence — so the model could keep reasoning over stale screenshots and burn tokens in an endless fix loop. This is the same failure mode #6380 fixed for the always-on variant; the threshold gate only delayed it. This PR takes the smallest correct slice of the reporter's proposal 1: mark the payloads as historical / potentially outdated, without redesigning the store to add path/mtime provenance (which the triage note flagged as out of scope for a drive-by patch).

## Reviewer Test Plan

### How to verify

Run the affected unit tests in `packages/core`:

```
npm -w packages/core run build
cd packages/core && npx vitest run src/services/image-payload-references.test.ts src/core/llm-chat.test.ts
```

Confirm: the new `#11601` test asserts `buildReattachParts()` output no longer contains "Recent images reattached" and instead carries the "may be OUTDATED" label; the existing reattach/recency tests (including the deliberate "resolves stored markers even when the current replacement pass is empty" case) still pass with only their label assertion updated.

### Evidence (Before & After)

Before: `Recent images reattached for visual context: Image #b4c4c1ca9a6e, Image #4505a3164dc3` (frozen `b`/`c` snapshot bytes presented as current).
After: `Images read earlier in this session (may be OUTDATED, do not treat as current UI state): Image #b4c4c1ca9a6e, Image #4505a3164dc3`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ✅   |

### Environment (optional)

Linux, Node.js 24, local unsandboxed unit tests only (no UI path touched).

## Risk & Scope

- Main risk or tradeoff: none functional — this is a prompt-wording change; no payload bytes, ordering, or recency behavior changes. The only risk is a model-behavior shift, which is the intended fix.
- Not validated / out of scope: refreshing payloads instead of replaying, adding source path/mtime provenance, making it configurable, and turn-distance expiry are all out of scope (proposals 2–4), as is coordination with #7207's redesign of the same area.
- Breaking changes / migration notes: none. No public API, schema, or wire format changes.

## Linked Issues

Fixes #11601

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把图片 payload 重附带时注入的前缀文案改掉，不再把冻结的淘汰时刻快照说成"当前"视觉上下文。前缀从 "Recent images reattached for visual context: …" 改为 "Images read earlier in this session (may be OUTDATED, do not treat as current UI state): …"。重附带的机制（附带哪些 payload、顺序、recency 上限）保持不变。

## 为什么需要它

当会话内联图片数超过 `imagePayloadThreshold` 后，`buildReattachParts()` 会把最多 `maxRecentImages` 张冻结快照附带进后续每个请求。这些快照是淘汰时刻捕获的 base64，从不刷新，但 "Recent images reattached for visual context" 这个标签却告诉模型它们是当前证据，导致模型可能反复基于过期截图推理、烧 token、陷入无限修复循环。这正是 #6380 修过的（针对 always-on 变体）同一失败模式，阈值门只是把它推迟了。本 PR 取了 reporter 提案 1 里最小的正确切片：把 payload 标记为历史/可能过期，而不去重构 store 加路径/mtime 来源信息（triage 已标注该项超出随手补丁范围）。

## Reviewer 测试计划

### 如何验证

在 `packages/core` 运行受影响的单元测试：

```
npm -w packages/core run build
cd packages/core && npx vitest run src/services/image-payload-references.test.ts src/core/llm-chat.test.ts
```

确认：新增的 `#11601` 测试断言 `buildReattachParts()` 输出不再包含 "Recent images reattached"，而是带上 "may be OUTDATED" 标签；已有的 reattach/recency 测试（包括刻意保留的 "resolves stored markers even when the current replacement pass is empty" 用例）仍通过，只是标签断言相应更新。

### 证据（Before & After）

Before：`Recent images reattached for visual context: Image #b4c4c1ca9a6e, Image #4505a3164dc3`（把冻结的 `b`/`c` 快照字节说成当前）。
After：`Images read earlier in this session (may be OUTDATED, do not treat as current UI state): Image #b4c4c1ca9a6e, Image #4505a3164dc3`。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux、Node.js 24，仅本地无 sandbox 单元测试（不涉及 UI 路径）。

## 风险与范围

- 主要风险或权衡：无功能性风险——这只是 prompt 文案改动，不改变 payload 字节、顺序或 recency 行为。唯一风险是模型行为变化，而这正是本次修复的目标。
- 未验证 / 范围外：改为刷新而非回放、加源路径/mtime 来源信息、做成可配置、按轮次距离过期（提案 2–4）都不在范围内，与 #7207 对同一区域的重构协调也不在范围内。
- 破坏性变更 / 迁移说明：无。不改变公共 API、schema 或 wire 格式。

## 关联 Issue

Fixes #11601

</details>
