### PR TITLE
fix(core): route plain-text hook stdout to additionalContext for prompt and session events

### DIFF
--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -466,11 +466,11 @@ Hook output is returned via `stdout` (command) or HTTP response body (http) as J
 
 **Exit Code Behavior (Command Hooks):**
 
-| Exit Code | Behavior                                                                              |
-| :-------- | :------------------------------------------------------------------------------------ |
-| `0`       | Success. Parse JSON in `stdout` to control behavior.                                  |
-| `2`       | **Blocking error**. Ignores `stdout`, passes `stderr` as error feedback to the model. |
-| Other     | Non-blocking error. `stderr` only shown in debug mode, execution continues.           |
+| Exit Code | Behavior                                                                                                                                                                                                              |
+| :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`       | Success. Parse JSON in `stdout` to control behavior. Plain-text `stdout` is added to the model context on `SessionStart`, `UserPromptSubmit` and `UserPromptExpansion`, and kept as a system message on other events. |
+| `2`       | **Blocking error**. Ignores `stdout`, passes `stderr` as error feedback to the model.                                                                                                                                 |
+| Other     | Non-blocking error. `stderr` only shown in debug mode, execution continues.                                                                                                                                           |
 
 **Output Structure:**
 

--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -466,11 +466,11 @@ Hook output is returned via `stdout` (command) or HTTP response body (http) as J
 
 **Exit Code Behavior (Command Hooks):**
 
-| Exit Code | Behavior                                                                                                                                                                                                              |
-| :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0`       | Success. Parse JSON in `stdout` to control behavior. Plain-text `stdout` is added to the model context on `SessionStart`, `UserPromptSubmit` and `UserPromptExpansion`, and kept as a system message on other events. |
-| `2`       | **Blocking error**. Ignores `stdout`, passes `stderr` as error feedback to the model.                                                                                                                                 |
-| Other     | Non-blocking error. `stderr` only shown in debug mode, execution continues.                                                                                                                                           |
+| Exit Code | Behavior                                                                                                                                                                                                                                                                                                                                                                       |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`       | Success. A JSON object in `stdout` controls behavior. Any other `stdout`, including bare JSON values such as `42`, is plain text: it is added to the model context on `SessionStart`, `UserPromptSubmit` and `UserPromptExpansion`, and kept as a system message on other events. Output that looks like a JSON object but does not parse is never added to the model context. |
+| `2`       | **Blocking error**. Ignores `stdout`, passes `stderr` as error feedback to the model.                                                                                                                                                                                                                                                                                          |
+| Other     | Non-blocking error. `stderr` only shown in debug mode, execution continues.                                                                                                                                                                                                                                                                                                    |
 
 **Output Structure:**
 

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -693,6 +693,46 @@ describe('HookRunner', () => {
       expect(secondInput.submitted_prompt).toBe('Submitted prompt');
     });
 
+    it('should chain plain-text UserPromptSubmit stdout into the next hook input', async () => {
+      const firstProcess = createMockProcess(0, 'Plain hook context\n');
+      const secondProcess = createMockProcess(0, 'result');
+      mockSpawn
+        .mockImplementationOnce(() => firstProcess)
+        .mockImplementationOnce(() => secondProcess);
+
+      const hookConfigs: HookConfig[] = [
+        {
+          type: HookType.Command,
+          command: 'echo first',
+          source: HooksConfigSource.Project,
+        },
+        {
+          type: HookType.Command,
+          command: 'echo second',
+          source: HooksConfigSource.Project,
+        },
+      ];
+      const input: UserPromptSubmitInput = {
+        ...createMockInput({
+          hook_event_name: HookEventName.UserPromptSubmit,
+        }),
+        prompt: 'Base prompt',
+      };
+
+      await hookRunner.executeHooksSequential(
+        hookConfigs,
+        HookEventName.UserPromptSubmit,
+        input,
+      );
+
+      const secondInputJson = secondProcess.stdin.write.mock.calls[0]?.[0];
+      expect(typeof secondInputJson).toBe('string');
+      const secondInput = JSON.parse(secondInputJson as string) as {
+        prompt?: string;
+      };
+      expect(secondInput.prompt).toBe('Base prompt\n\nPlain hook context');
+    });
+
     it('should not append empty UserPromptSubmit additional context', async () => {
       const firstProcess = createMockProcess(
         0,
@@ -1006,6 +1046,98 @@ describe('HookRunner', () => {
       expect(result.success).toBe(true);
       expect(result.output?.decision).toBe('allow');
       expect(result.output?.systemMessage).toBe('plain text response');
+    });
+
+    it.each([
+      HookEventName.SessionStart,
+      HookEventName.UserPromptSubmit,
+      HookEventName.UserPromptExpansion,
+    ])(
+      'should route plain-text stdout to additionalContext on %s',
+      async (eventName) => {
+        const mockProcess = createMockProcess(0, 'context from hook\n');
+        mockSpawn.mockImplementation(() => mockProcess);
+
+        const result = await hookRunner.executeHook(
+          {
+            type: HookType.Command,
+            command: 'echo context',
+            source: HooksConfigSource.Project,
+          },
+          eventName,
+          createMockInput({ hook_event_name: eventName }),
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output?.decision).toBe('allow');
+        expect(result.output?.systemMessage).toBeUndefined();
+        expect(result.output?.hookSpecificOutput).toEqual({
+          hookEventName: eventName,
+          additionalContext: 'context from hook',
+        });
+      },
+    );
+
+    it.each([
+      HookEventName.PreToolUse,
+      HookEventName.Stop,
+      HookEventName.Notification,
+    ])(
+      'should keep plain-text stdout as a system message on %s',
+      async (eventName) => {
+        const mockProcess = createMockProcess(0, 'plain text response');
+        mockSpawn.mockImplementation(() => mockProcess);
+
+        const result = await hookRunner.executeHook(
+          {
+            type: HookType.Command,
+            command: 'echo text',
+            source: HooksConfigSource.Project,
+          },
+          eventName,
+          createMockInput({ hook_event_name: eventName }),
+        );
+
+        expect(result.output?.systemMessage).toBe('plain text response');
+        expect(result.output?.hookSpecificOutput).toBeUndefined();
+      },
+    );
+
+    it('should not promote the stderr fallback into SessionStart context', async () => {
+      const mockProcess = createMockProcess(0, '', 'diagnostic noise');
+      mockSpawn.mockImplementation(() => mockProcess);
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'echo noise >&2',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.SessionStart,
+        createMockInput({ hook_event_name: HookEventName.SessionStart }),
+      );
+
+      expect(result.output?.systemMessage).toBe('diagnostic noise');
+      expect(result.output?.hookSpecificOutput).toBeUndefined();
+    });
+
+    it('should keep plain-text stdout of a failed SessionStart hook as a warning', async () => {
+      const mockProcess = createMockProcess(1, 'partial output');
+      mockSpawn.mockImplementation(() => mockProcess);
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'echo partial && exit 1',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.SessionStart,
+        createMockInput({ hook_event_name: HookEventName.SessionStart }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.output?.systemMessage).toBe('Warning: partial output');
+      expect(result.output?.hookSpecificOutput).toBeUndefined();
     });
 
     it('should treat non-blocking non-zero exit codes as non-blocking warnings', async () => {

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -1103,6 +1103,101 @@ describe('HookRunner', () => {
       },
     );
 
+    it.each(['42', 'true', 'null', '[1, 2]'])(
+      'should treat bare JSON value %s as plain text on SessionStart',
+      async (text) => {
+        mockSpawn.mockImplementation(() => createMockProcess(0, text));
+
+        const result = await hookRunner.executeHook(
+          {
+            type: HookType.Command,
+            command: 'echo value',
+            source: HooksConfigSource.Project,
+          },
+          HookEventName.SessionStart,
+          createMockInput({ hook_event_name: HookEventName.SessionStart }),
+        );
+
+        expect(result.output?.hookSpecificOutput).toEqual({
+          hookEventName: HookEventName.SessionStart,
+          additionalContext: text,
+        });
+      },
+    );
+
+    it('should keep a bare JSON value as a system message on PreToolUse', async () => {
+      mockSpawn.mockImplementation(() => createMockProcess(0, '42'));
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'echo 42',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.PreToolUse,
+        createMockInput(),
+      );
+
+      expect(result.output?.systemMessage).toBe('42');
+      expect(result.output?.hookSpecificOutput).toBeUndefined();
+    });
+
+    it('should still block on exit code 2 when stderr is a bare JSON value', async () => {
+      mockSpawn.mockImplementation(() => createMockProcess(2, '', '1'));
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'echo 1 >&2; exit 2',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.PreToolUse,
+        createMockInput(),
+      );
+
+      expect(result.output?.decision).toBe('deny');
+      expect(result.output?.reason).toBe('1');
+    });
+
+    it('should not promote output shaped like a JSON object that fails to parse', async () => {
+      const malformed = '{"decision": "deny",}';
+      mockSpawn.mockImplementation(() => createMockProcess(0, malformed));
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'echo malformed',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.UserPromptSubmit,
+        createMockInput({ hook_event_name: HookEventName.UserPromptSubmit }),
+      );
+
+      expect(result.output?.hookSpecificOutput).toBeUndefined();
+      expect(result.output?.systemMessage).toBe(malformed);
+    });
+
+    it('should strip terminal escapes from promoted context and keep newlines', async () => {
+      mockSpawn.mockImplementation(() =>
+        createMockProcess(0, '\u001b[31mred\u001b[0m context\nline two\n'),
+      );
+
+      const result = await hookRunner.executeHook(
+        {
+          type: HookType.Command,
+          command: 'npm test --color=always',
+          source: HooksConfigSource.Project,
+        },
+        HookEventName.SessionStart,
+        createMockInput({ hook_event_name: HookEventName.SessionStart }),
+      );
+
+      expect(result.output?.hookSpecificOutput).toEqual({
+        hookEventName: HookEventName.SessionStart,
+        additionalContext: 'red context\nline two',
+      });
+    });
+
     it('should not promote the stderr fallback into SessionStart context', async () => {
       const mockProcess = createMockProcess(0, '', 'diagnostic noise');
       mockSpawn.mockImplementation(() => mockProcess);

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -254,6 +254,17 @@ let parentExitCleanupRegistered = false;
 const EXIT_CODE_SUCCESS = 0;
 const EXIT_CODE_NON_BLOCKING_ERROR = 1;
 
+/**
+ * Events whose plain-text stdout on a successful exit is handed to the model
+ * as additional context. On every other event plain text stays a system
+ * message, since those events have no prompt to attach context to.
+ */
+const PLAIN_TEXT_CONTEXT_EVENTS: ReadonlySet<HookEventName> = new Set([
+  HookEventName.SessionStart,
+  HookEventName.UserPromptSubmit,
+  HookEventName.UserPromptExpansion,
+]);
+
 function isNoSuchProcessError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException)?.code === 'ESRCH';
 }
@@ -1358,9 +1369,13 @@ export class HookRunner {
         const isBlockingError = exitCode === 2;
 
         // For exit code 2, only use stderr (ignore stdout)
+        const stdoutText = stdout.trim();
         const textToParse = isBlockingError
           ? stderr.trim()
-          : stdout.trim() || stderr.trim();
+          : stdoutText || stderr.trim();
+        // Only stdout is hook output. The stderr fallback is diagnostics and
+        // must never be promoted into model context.
+        const parsedFromStdout = !isBlockingError && stdoutText !== '';
 
         if (textToParse) {
           // Try parsing as JSON to preserve structured output like
@@ -1382,6 +1397,7 @@ export class HookRunner {
                 : exitCode === EXIT_CODE_SUCCESS
                   ? EXIT_CODE_SUCCESS
                   : EXIT_CODE_NON_BLOCKING_ERROR,
+              parsedFromStdout ? eventName : undefined,
             );
           }
         }
@@ -1438,14 +1454,28 @@ export class HookRunner {
   }
 
   /**
-   * Convert plain text output to structured HookOutput
+   * Convert plain text output to structured HookOutput.
+   *
+   * @param stdoutEvent The firing event, passed only when `text` is the
+   *   hook's stdout. On a successful exit, stdout of a
+   *   {@link PLAIN_TEXT_CONTEXT_EVENTS} event becomes additional context.
    */
   private convertPlainTextToHookOutput(
     text: string,
     exitCode: number,
+    stdoutEvent?: HookEventName,
   ): HookOutput {
     if (exitCode === EXIT_CODE_SUCCESS) {
-      // Success - treat as system message or additional context
+      if (stdoutEvent && PLAIN_TEXT_CONTEXT_EVENTS.has(stdoutEvent)) {
+        return {
+          decision: 'allow',
+          reason: 'Hook executed successfully',
+          hookSpecificOutput: {
+            hookEventName: stdoutEvent,
+            additionalContext: text,
+          },
+        };
+      }
       return {
         decision: 'allow',
         reason: 'Hook executed successfully',

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -23,6 +23,7 @@ import type {
   PromptHookConfig,
 } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { stripAnsiAndControl } from '../utils/textUtils.js';
 import {
   escapeShellArg,
   getShellConfiguration,
@@ -256,8 +257,11 @@ const EXIT_CODE_NON_BLOCKING_ERROR = 1;
 
 /**
  * Events whose plain-text stdout on a successful exit is handed to the model
- * as additional context. On every other event plain text stays a system
- * message, since those events have no prompt to attach context to.
+ * as additional context, matching the events Claude Code promotes. Other
+ * events keep converting plain text to a system message, even those whose
+ * JSON `additionalContext` does reach the model (PostToolUse, SubagentStart,
+ * ...), so a hook that merely prints a log line does not start injecting it
+ * into tool results or subagent prompts.
  */
 const PLAIN_TEXT_CONTEXT_EVENTS: ReadonlySet<HookEventName> = new Set([
   HookEventName.SessionStart,
@@ -1373,23 +1377,45 @@ export class HookRunner {
         const textToParse = isBlockingError
           ? stderr.trim()
           : stdoutText || stderr.trim();
-        // Only stdout is hook output. The stderr fallback is diagnostics and
-        // must never be promoted into model context.
+        // Only stdout is promoted as plain-text context; the stderr fallback
+        // stays a system message. JSON on stderr is still parsed as structured
+        // output when stdout is empty, as it was before.
         const parsedFromStdout = !isBlockingError && stdoutText !== '';
 
         if (textToParse) {
-          // Try parsing as JSON to preserve structured output like
-          // hookSpecificOutput.additionalContext (applies to both exit 0 and exit 2)
+          // Structured output is a JSON object, possibly double-encoded as a
+          // JSON string (applies to both exit 0 and exit 2). Anything else,
+          // including bare JSON values such as `42` or `[1, 2]`, is plain text.
+          let parsed: unknown;
+          let parseFailed = false;
           try {
-            let parsed = JSON.parse(textToParse);
+            parsed = JSON.parse(textToParse);
             if (typeof parsed === 'string') {
               parsed = JSON.parse(parsed);
             }
-            if (parsed && typeof parsed === 'object') {
-              output = parsed as HookOutput;
-            }
           } catch {
-            // Not JSON, convert plain text to structured output
+            parseFailed = true;
+          }
+          if (
+            !parseFailed &&
+            parsed !== null &&
+            typeof parsed === 'object' &&
+            !Array.isArray(parsed)
+          ) {
+            output = parsed as HookOutput;
+          } else {
+            // Output shaped like a JSON object that fails to parse is a broken
+            // structured payload, not context: as in Claude Code, it is kept
+            // out of the model.
+            const malformedObject =
+              parseFailed &&
+              textToParse.startsWith('{') &&
+              textToParse.endsWith('}');
+            if (malformedObject) {
+              debugLogger.warn(
+                `Hook "${hookConfig.name || hookConfig.command}" printed output that looks like a JSON object but is not valid JSON; it is not added to model context`,
+              );
+            }
             output = this.convertPlainTextToHookOutput(
               textToParse,
               isBlockingError
@@ -1397,7 +1423,7 @@ export class HookRunner {
                 : exitCode === EXIT_CODE_SUCCESS
                   ? EXIT_CODE_SUCCESS
                   : EXIT_CODE_NON_BLOCKING_ERROR,
-              parsedFromStdout ? eventName : undefined,
+              parsedFromStdout && !malformedObject ? eventName : undefined,
             );
           }
         }
@@ -1472,7 +1498,12 @@ export class HookRunner {
           reason: 'Hook executed successfully',
           hookSpecificOutput: {
             hookEventName: stdoutEvent,
-            additionalContext: text,
+            // Terminal escapes from colored tool output must not reach the
+            // model; strip per line so newlines survive.
+            additionalContext: text
+              .split('\n')
+              .map((line) => stripAnsiAndControl(line))
+              .join('\n'),
           },
         };
       }


### PR DESCRIPTION
## What this PR does

When a command hook exits 0 and prints plain text rather than JSON, that text now becomes additional context on the three events that carry a prompt: `SessionStart`, `UserPromptSubmit` and `UserPromptExpansion`. It reaches the model the same way `hookSpecificOutput.additionalContext` from a JSON hook does, and it chains into the next hook of a sequential group. On every other event plain text keeps its current conversion to a system message. Only stdout is promoted: when stdout is empty the runner still falls back to stderr, and plain text from that fallback stays a system message (a JSON object on stderr is still parsed as structured output, as before). Bare JSON values such as `42` count as plain text, output shaped like a JSON object that fails to parse is not promoted, and promoted text has terminal escapes stripped. Non-zero exit handling is unchanged, except that exit code 2 with a bare JSON value on stderr now blocks instead of being ignored.

## Why it's needed

Printing context with `echo` is the most common way to write a `SessionStart` or `UserPromptSubmit` hook, and it is how the Claude Code hook contract documents it. Today the runner turns that text into `systemMessage`, which these events' consumers never read and which is not displayed anywhere outside the Stop path, so the hook is a silent no-op. Users see nothing and the model gets nothing.

While checking the contract I also compared exit code 2 handling. Claude Code blocks on exit 2 regardless of stdout and takes the reason from stderr, which is what qwen-code already does, so that path is left alone.

## Reviewer Test Plan

### How to verify

Unit tests: `cd packages/core && npx vitest run src/hooks/hookRunner.test.ts`. The new cases cover plain-text stdout becoming `additionalContext` on each of the three events, plain text staying a system message on `PreToolUse`, `Stop` and `Notification`, the stderr fallback on `SessionStart` staying a system message, a failed `SessionStart` hook keeping its warning, and plain-text context chaining into the next sequential `UserPromptSubmit` hook. Four of these fail on `main`; the rest guard the unchanged paths.

End to end: put a `SessionStart` hook `echo "Session note: always end your reply with the word BANANA."` and a `UserPromptSubmit` hook `echo "Prompt note: the secret code word is PINEAPPLE."` in user settings, then run `qwen -p "What is the secret code word?"`. On `main` the reply knows neither; with this change it answers PINEAPPLE and ends with BANANA.

### Evidence (Before & After)

Both runs use the same isolated user settings with the two `echo` hooks above and no other hooks. The baseline is the installed release, which has the same conversion as `main`.

Before (installed `qwen` 0.22.3):

```text
$ qwen -p "What is the secret code word? Answer in one short sentence."
I don't have one — no secret code word was given in this conversation, and the working directory (`/tmp/.../smoke11/proj`) is empty.
```

After (this branch, `node dist/cli.js`):

```text
$ qwen -p "What is the secret code word? Answer in one short sentence."
The secret code word is PINEAPPLE. BANANA
```

Unit tests on this branch: `hookRunner.test.ts` 74 passed. With the source change reverted, the four new routing and chaining cases fail and the other 70 pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local build of this branch (`npm run build && npm run bundle`) with an isolated `QWEN_HOME`.

## Risk & Scope

- Main risk or tradeoff: a hook on one of the three events that already printed plain text for logging will now add that text to the model context. Such output was previously discarded without being shown, so it had no visible effect before; hooks that want to log should write to stderr or a file.
- Not validated / out of scope: surfacing system messages from non-Stop events in the UI, and any change to exit code 2 handling.
- Breaking changes / migration notes: none for JSON-emitting hooks.

## Linked Issues

Part of #11610

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当命令 hook 以退出码 0 结束、输出的是纯文本而不是 JSON 时，这段文本现在会在三个携带 prompt 的事件上成为附加上下文：`SessionStart`、`UserPromptSubmit` 和 `UserPromptExpansion`。它会像 JSON hook 的 `hookSpecificOutput.additionalContext` 一样到达模型，并在串行分组里传递给下一个 hook。其它事件上的纯文本仍按现状转成 system message。只有 stdout 会被提升：stdout 为空时执行器仍会回退读取 stderr，这种回退得到的纯文本仍保持为 system message（stderr 上的 JSON 对象仍像以前一样按结构化输出解析）。`42` 这样的裸 JSON 值按纯文本处理；形似 JSON 对象但解析失败的输出不会被提升；被提升的文本会去掉终端转义序列。非零退出的处理不变，只是退出码 2 时 stderr 为裸 JSON 值现在会阻断，而不是被忽略。

## 为什么需要

用 `echo` 输出上下文是编写 `SessionStart` 或 `UserPromptSubmit` hook 最常见的方式，Claude Code 的 hook 约定也是这样写的。目前执行器把这段文本转成 `systemMessage`，而这些事件的消费方从不读取它，Stop 路径以外也没有任何地方显示它，所以这个 hook 是静默的空操作：用户看不到任何东西，模型也拿不到任何东西。

核对约定时我也对比了退出码 2 的处理。Claude Code 在退出码 2 时无论 stdout 是什么都会阻断，并从 stderr 取原因，qwen-code 已经是这样做的，所以这条路径保持不动。

## 评审测试计划

### 如何验证

单元测试：`cd packages/core && npx vitest run src/hooks/hookRunner.test.ts`。新增用例覆盖：三个事件上纯文本 stdout 成为 `additionalContext`；`PreToolUse`、`Stop`、`Notification` 上纯文本仍为 system message；`SessionStart` 上 stderr 回退仍为 system message；失败的 `SessionStart` hook 保留警告；纯文本上下文传递给串行分组中的下一个 `UserPromptSubmit` hook。其中四条在 `main` 上失败，其余用于守护未改动的路径。

端到端：在用户设置里配置一个 `SessionStart` hook `echo "Session note: always end your reply with the word BANANA."` 和一个 `UserPromptSubmit` hook `echo "Prompt note: the secret code word is PINEAPPLE."`，然后运行 `qwen -p "What is the secret code word?"`。在 `main` 上回复两者都不知道；有了这个改动，回复答出 PINEAPPLE 并以 BANANA 结尾。

### 证据（前后对比）

两次运行使用同一份隔离的用户设置，只配置了上面两个 `echo` hook。基线是已安装的发行版，与 `main` 的转换逻辑相同。改动前（已安装的 `qwen` 0.22.3）回复说对话中没有给出任何暗号；改动后（本分支）回复 "The secret code word is PINEAPPLE. BANANA"。完整输出见上文英文部分。

本分支单元测试：`hookRunner.test.ts` 74 个通过。撤回源码改动后，新增的四个转换与串行传递用例失败，其余 70 个通过。

### 测试平台

仅在 Linux 上本地验证；macOS 和 Windows 未测试。

### 环境

本分支的本地构建（`npm run build && npm run bundle`），使用隔离的 `QWEN_HOME`。

## 风险与范围

- 主要风险或权衡：三个事件之一上原本为了记录日志而输出纯文本的 hook，现在会把这段文本加入模型上下文。此前这类输出被丢弃且不显示，没有可见效果；需要记录日志的 hook 应写到 stderr 或文件。
- 未验证 / 不在范围内：在 UI 中显示非 Stop 事件的 system message，以及对退出码 2 处理的任何修改。
- 破坏性变更 / 迁移说明：输出 JSON 的 hook 不受影响。

## 关联 Issue

Part of #11610

</details>
