### PR TITLE
fix(vscode): localize rewind preflight errors

### DIFF
--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
@@ -45,6 +45,12 @@ const mocks = vi.hoisted(() => ({
 
 const sdkMocks = vi.hoisted(() => ({
   listWorkspaceSessionsPage: vi.fn(),
+  getRewindSnapshots: vi.fn<
+    (sessionId: string) => Promise<{
+      snapshots: Array<{ turnIndex: number; promptId: string }>;
+    }>
+  >(async () => ({ snapshots: [] })),
+  rewindSession: vi.fn(async () => ({})),
 }));
 
 vi.mock('@qwen-code/sdk/daemon', () => ({
@@ -56,8 +62,8 @@ vi.mock('@qwen-code/sdk/daemon', () => ({
         deleteSessionsData: vi.fn(async () => ({})),
       };
     }
-    getRewindSnapshots = vi.fn(async () => ({ snapshots: [] }));
-    rewindSession = vi.fn(async () => ({}));
+    getRewindSnapshots = sdkMocks.getRewindSnapshots;
+    rewindSession = sdkMocks.rewindSession;
   },
 }));
 
@@ -147,6 +153,7 @@ function postMessagesOfType(
 
 beforeAll(async () => {
   document.body.dataset.qwenDaemonBaseUrl = 'http://localhost:4141';
+  document.body.dataset.qwenDaemonToken = 'test-token';
   document.body.dataset.qwenWorkspaceCwd = '/workspace';
   document.body.dataset.qwenSessionId = 'session-1';
   document.body.dataset.qwenHostKind = 'panel';
@@ -1096,5 +1103,62 @@ describe('web shell permission decision messages', () => {
     expect(container.textContent).toContain(
       'The approval decision could not be applied.',
     );
+  });
+});
+
+describe('EmbeddedApp rewind preflight localization', () => {
+  it('rethrows a localized error when getRewindSnapshots rejects', async () => {
+    await renderApp();
+    const props = mocks.embeddedProps.current as CapturedProps;
+
+    const onUserMessageEditRequest = callback<
+      (turnIndex: number, content: string) => boolean
+    >(props, 'onUserMessageEditRequest');
+    await act(async () => {
+      onUserMessageEditRequest(0, 'original text');
+      await Promise.resolve();
+    });
+
+    sdkMocks.getRewindSnapshots.mockRejectedValueOnce(new Error('HTTP 503'));
+
+    const prepareSubmit = callback<
+      (submission: {
+        prompt: string;
+        inputAnnotations: unknown[];
+      }) => Promise<{ prompt: string; inputAnnotations: unknown[] } | undefined>
+    >(mocks.embeddedProps.current as CapturedProps, 'prepareSubmit');
+
+    await expect(
+      prepareSubmit({ prompt: 'edited text', inputAnnotations: [] }),
+    ).rejects.toThrow('Failed to edit the message. Please try again.');
+  });
+
+  it('rethrows a localized error when rewindSession rejects', async () => {
+    await renderApp();
+    const props = mocks.embeddedProps.current as CapturedProps;
+
+    const onUserMessageEditRequest = callback<
+      (turnIndex: number, content: string) => boolean
+    >(props, 'onUserMessageEditRequest');
+    await act(async () => {
+      onUserMessageEditRequest(0, 'original text');
+      await Promise.resolve();
+    });
+
+    sdkMocks.getRewindSnapshots.mockResolvedValueOnce({
+      snapshots: [{ turnIndex: 0, promptId: 'p-1' }],
+    });
+    sdkMocks.rewindSession.mockRejectedValueOnce(new Error('HTTP 503'));
+
+    const prepareSubmit = callback<
+      (submission: {
+        prompt: string;
+        inputAnnotations: unknown[];
+      }) => Promise<{ prompt: string; inputAnnotations: unknown[] } | undefined>
+    >(mocks.embeddedProps.current as CapturedProps, 'prepareSubmit');
+
+    await expect(
+      prepareSubmit({ prompt: 'edited text', inputAnnotations: [] }),
+    ).rejects.toThrow('Failed to edit the message. Please try again.');
   });
 });

--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.test.tsx
@@ -153,7 +153,6 @@ function postMessagesOfType(
 
 beforeAll(async () => {
   document.body.dataset.qwenDaemonBaseUrl = 'http://localhost:4141';
-  document.body.dataset.qwenDaemonToken = 'test-token';
   document.body.dataset.qwenWorkspaceCwd = '/workspace';
   document.body.dataset.qwenSessionId = 'session-1';
   document.body.dataset.qwenHostKind = 'panel';

--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
@@ -1614,8 +1614,8 @@ export function EmbeddedApp() {
               try {
                 ({ snapshots } =
                   await daemonClient.getRewindSnapshots(sessionId));
-              } catch {
-                throw new Error(t('composer.editFailed'));
+              } catch (err) {
+                throw new Error(t('composer.editFailed'), { cause: err });
               }
               const snapshot =
                 editingMessage.turnIndex === undefined
@@ -1637,8 +1637,8 @@ export function EmbeddedApp() {
                   clientId: runtime.clientId,
                   rewindFiles: false,
                 });
-              } catch {
-                throw new Error(t('composer.editFailed'));
+              } catch (err) {
+                throw new Error(t('composer.editFailed'), { cause: err });
               }
               setEditingMessage(undefined);
               clearInsight();

--- a/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
+++ b/packages/vscode-ide-companion/src/webview/EmbeddedApp.tsx
@@ -1608,8 +1608,15 @@ export function EmbeddedApp() {
               if (!daemonClient || !sessionId) {
                 throw new Error(t('composer.editUnavailable'));
               }
-              const { snapshots } =
-                await daemonClient.getRewindSnapshots(sessionId);
+              let snapshots: Awaited<
+                ReturnType<typeof daemonClient.getRewindSnapshots>
+              >['snapshots'];
+              try {
+                ({ snapshots } =
+                  await daemonClient.getRewindSnapshots(sessionId));
+              } catch {
+                throw new Error(t('composer.editFailed'));
+              }
               const snapshot =
                 editingMessage.turnIndex === undefined
                   ? snapshots.reduce<(typeof snapshots)[number] | undefined>(
@@ -1625,10 +1632,14 @@ export function EmbeddedApp() {
               if (!snapshot) {
                 throw new Error(t('composer.editExpired'));
               }
-              await daemonClient.rewindSession(sessionId, snapshot.promptId, {
-                clientId: runtime.clientId,
-                rewindFiles: false,
-              });
+              try {
+                await daemonClient.rewindSession(sessionId, snapshot.promptId, {
+                  clientId: runtime.clientId,
+                  rewindFiles: false,
+                });
+              } catch {
+                throw new Error(t('composer.editFailed'));
+              }
               setEditingMessage(undefined);
               clearInsight();
             }

--- a/packages/vscode-ide-companion/src/webview/strings.ts
+++ b/packages/vscode-ide-companion/src/webview/strings.ts
@@ -81,6 +81,7 @@ const EN = {
   'composer.editUnavailable':
     'The message cannot be edited before the session is ready.',
   'composer.editExpired': 'The original message can no longer be edited.',
+  'composer.editFailed': 'Failed to edit the message. Please try again.',
   'context.included': 'Included',
   'context.excluded': 'Excluded',
   'context.include': 'Include active file context',
@@ -161,6 +162,7 @@ const ZH: Record<ChromeStringKey, string> = {
   'composer.cancelEditing': '取消编辑',
   'composer.editUnavailable': '会话尚未就绪，暂时无法编辑该消息。',
   'composer.editExpired': '该消息已无法再编辑。',
+  'composer.editFailed': '编辑消息失败，请重试。',
   'context.included': '已包含',
   'context.excluded': '已排除',
   'context.include': '包含当前文件上下文',


### PR DESCRIPTION
## What this PR does

When a user edits an already-sent message, the VS Code companion rewinds the conversation to that point by asking the daemon for its rewind snapshots and then rewinding the session. Both round-trips were awaited bare, so if the daemon was unreachable the raw transport error propagated out of the preflight untouched — a bare `HTTP 503` string that never passed through the translation layer every other user-visible message goes through.

This wraps both daemon calls and re-throws a localized failure instead, attaching the original error as `cause` so abort discrimination and diagnostics still see the real transport error. A new `composer.editFailed` string is added in English and Simplified Chinese.

## Why it's needed

Every other string the composer can show the user is translated. This one path was not, so a Chinese-locale user hitting a daemon outage while editing a message got an untranslated English protocol error. It is the localization gap described in #11432.

## Reviewer Test Plan

### How to verify

1. `cd packages/vscode-ide-companion && npx vitest run src/webview/EmbeddedApp.test.tsx` — 22 tests pass.
2. Check that the two new cases are load-bearing rather than vacuous: `git stash` the `EmbeddedApp.tsx` hunk (or revert the try/catch by hand) and re-run. Both should go red with `Received: "HTTP 503"`, which is the untranslated string this PR exists to remove. Restore the hunk and they pass again.
3. What a reviewer should confirm at the code level: the re-thrown error preserves `cause`. Today the only consumer is the web-shell preflight `catch`, which `console.warn`s the error and cancels the prompt — it does not branch on `cause`, so `cause` is here for the diagnostic log and for the `reportError` integration that still has to tell an abort apart from a real failure. Worth checking it is attached on both throw sites, not just the first.

Local run at this PR's head:

```
✓ src/webview/EmbeddedApp.test.tsx (22 tests) 482ms
Test Files  1 passed (1)
     Tests  22 passed (22)
```

### Evidence (Before & After)

N/A — nothing rendered changes in this PR. The rejection is still consumed by the preflight `catch` on `main`, which logs it with `console.warn` and pushes no toast, so there is no before/after screen to capture. What changes is the message carried by that rejection, which is why the evidence here is the test output above rather than a screenshot. Surfacing these failures to the user through `reportError` (so aborts stay silent and real failures render a toast) is the separate piece tracked in the issue.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Windows and Linux were not run locally; the change is platform-independent string handling and CI covers both lanes.

### Environment (optional)

Unit tests only, run with the package's own vitest config on macOS (darwin arm64, Node 22). No daemon, sandbox, or `npm run dev` session required.

## Risk & Scope

- Main risk or tradeoff: the original transport error is no longer the top-level rejection, so anything that pattern-matched its message rather than reading `cause` would stop matching. In practice the only consumer on this path is a `console.warn`, so nothing breaks today — but a future consumer has to read `cause`, not the message.
- Not validated / out of scope: no live VS Code host run against a real daemon outage — the failure is reproduced at the unit boundary only. Making these failures user-visible (toast on real errors, silence on abort) is deliberately not in this PR.
- Breaking changes / migration notes: none. One new translation key in both locales; no API, setting, or persisted-state change.

## Linked Issues

Refs #11432

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

用户编辑一条已发送的消息时，VS Code companion 会先向 daemon 请求 rewind 快照，再执行 session rewind，把对话回退到那个位置。这两次请求原来都是裸 await 的，所以 daemon 不可达时，原始传输错误会直接穿透 preflight 往外抛 —— 一个裸的 `HTTP 503` 字符串，完全没走其他所有用户可见文案都会经过的翻译层。

这次改动把两次 daemon 调用包起来，改为抛出一个已本地化的失败，并把原始错误挂在 `cause` 上，这样 abort 判定和诊断日志仍然能拿到真正的传输错误。同时新增 `composer.editFailed` 文案，英文和简体中文各一份。

## 为什么需要

composer 能展示给用户的其他文案都有翻译，只有这一条路径没有。结果就是中文用户在编辑消息时碰上 daemon 故障，看到的是一句没翻译的英文协议错误。这正是 #11432 里描述的本地化缺口。

## 评审验证方式

### 如何验证

1. `cd packages/vscode-ide-companion && npx vitest run src/webview/EmbeddedApp.test.tsx` —— 22 个测试通过。
2. 确认两个新增用例是真正吃住行为、而不是空转：把 `EmbeddedApp.tsx` 的改动 `git stash`（或手工还原 try/catch）后重跑，两个用例应该都变红，报 `Received: "HTTP 503"` —— 这正是本 PR 要消除的未翻译字符串。还原改动后又会通过。
3. 代码层面需要评审确认的点：重新抛出的错误保留了 `cause`。目前唯一的消费方是 web-shell 的 preflight `catch`，它只把错误 `console.warn` 出来并取消这次 prompt，并不会按 `cause` 分支。所以 `cause` 是为诊断日志、以及后续那个仍然需要区分 abort 和真实失败的 `reportError` 接入而保留的。值得确认的是两个 throw 点都挂上了 `cause`，不只是第一个。

本 PR head 的本地运行结果：

```
✓ src/webview/EmbeddedApp.test.tsx (22 tests) 482ms
Test Files  1 passed (1)
     Tests  22 passed (22)
```

### 证据（Before & After）

N/A —— 本 PR 没有任何渲染变化。`main` 上这个 rejection 依然被 preflight 的 `catch` 吃掉，只 `console.warn` 一行、不弹 toast，所以没有可截的前后画面。变的是这个 rejection 携带的文案本身，因此这里的证据是上面的测试输出而不是截图。把这类失败真正展示给用户（abort 静默、真实错误弹 toast）是 issue 里单独跟踪的另一件事。

### 测试平台

|    系统    |  状态  |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Windows 和 Linux 没有本地跑。这个改动是与平台无关的字符串处理，两条 CI lane 都会覆盖。

### 运行环境（可选）

只跑了单元测试，使用该 package 自带的 vitest 配置，macOS（darwin arm64，Node 22）。不需要 daemon、sandbox 或 `npm run dev` 会话。

## 风险与范围

- 主要风险／取舍：原始传输错误不再是最外层的 rejection，所以任何靠匹配错误 message 而不是读 `cause` 的地方都会匹配不上。实际情况是这条路径上唯一的消费方只是一句 `console.warn`，今天不会有任何东西被破坏 —— 但后续新增的消费方必须读 `cause` 而不是 message。
- 未验证／不在范围内：没有在真实 VS Code 宿主里对着真实的 daemon 故障跑一遍，故障只在单元边界上复现。把这类失败做成用户可见（真实错误弹 toast、abort 保持静默）刻意不在本 PR 内。
- 破坏性变更／迁移说明：没有。只新增一个双语文案 key，不涉及 API、设置项或持久化状态的变化。

## 关联 Issue

Refs #11432

</details>