### PR TITLE
fix(web-shell): show source retry only after load failure

### DIFF
--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -3080,13 +3080,15 @@ function SourceDetail({
         <span className="truncate text-xs text-muted-foreground" title={path}>
           {path}
         </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setAttempt((value) => value + 1)}
-        >
-          {t('common.retry')}
-        </Button>
+        {error && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setAttempt((value) => value + 1)}
+          >
+            {t('common.retry')}
+          </Button>
+        )}
       </div>
       {error ? (
         <div className={styles.previewError} role="alert">
@@ -3130,6 +3132,7 @@ function SourceDetail({
           key={attempt}
           workspacePath={path}
           workspaceActions={workspaceActions!}
+          onLoadError={setError}
           previewData={data}
           previewOnly={locator.type === 'attachment'}
           previewMimeType={data?.type}
@@ -3188,6 +3191,7 @@ function WorkspaceFilePreview({
   imageMimeType,
   previewKind,
   previewOnly,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
@@ -3198,6 +3202,7 @@ function WorkspaceFilePreview({
   imageMimeType?: string;
   previewKind?: 'html' | 'markdown' | 'image' | 'source';
   previewOnly?: boolean;
+  onLoadError?: (error: string) => void;
 }) {
   if (previewData) {
     return (
@@ -3207,6 +3212,7 @@ function WorkspaceFilePreview({
         data={previewData}
         mimeType={previewMimeType}
         previewKind={previewKind}
+        onLoadError={onLoadError}
       />
     );
   }
@@ -3230,6 +3236,7 @@ function WorkspaceFilePreview({
         workspaceActions={workspaceActions}
         previewContent={previewContent}
         previewOnly={previewOnly}
+        onLoadError={onLoadError}
       />
     );
   }
@@ -3241,6 +3248,7 @@ function WorkspaceFilePreview({
         workspaceActions={workspaceActions}
         previewContent={previewContent}
         previewOnly={previewOnly}
+        onLoadError={onLoadError}
       />
     );
   }
@@ -3251,6 +3259,7 @@ function WorkspaceFilePreview({
         artifactVersion={artifactVersion}
         workspaceActions={workspaceActions}
         mimeType={resolvedImageMimeType}
+        onLoadError={onLoadError}
       />
     );
   }
@@ -3261,6 +3270,7 @@ function WorkspaceFilePreview({
       workspaceActions={workspaceActions}
       previewContent={previewContent}
       previewOnly={previewOnly}
+      onLoadError={onLoadError}
     />
   );
 }
@@ -3271,12 +3281,14 @@ function AttachmentBlobPreview({
   data,
   mimeType,
   previewKind,
+  onLoadError,
 }: {
   workspacePath: string;
   workspaceActions: ArtifactWorkspaceActions;
   data: Blob;
   mimeType?: string;
   previewKind?: 'html' | 'markdown' | 'image' | 'source';
+  onLoadError?: (error: string) => void;
 }) {
   const resolvedMimeType = (mimeType || data.type || 'application/octet-stream')
     .split(';', 1)[0]!
@@ -3306,6 +3318,7 @@ function AttachmentBlobPreview({
       workspaceActions={workspaceActions}
       data={data}
       previewKind={previewKind}
+      onLoadError={onLoadError}
     />
   );
 }
@@ -3315,11 +3328,13 @@ function TextAttachmentPreview({
   workspaceActions,
   data,
   previewKind,
+  onLoadError,
 }: {
   workspacePath: string;
   workspaceActions: ArtifactWorkspaceActions;
   data: Blob;
   previewKind?: 'html' | 'markdown' | 'image' | 'source';
+  onLoadError?: (error: string) => void;
 }) {
   const { t } = useI18n();
   const [content, setContent] = useState<string>();
@@ -3329,12 +3344,16 @@ function TextAttachmentPreview({
     setContent(undefined);
     setError(undefined);
     reader.onload = () => setContent(String(reader.result ?? ''));
-    reader.onerror = () => setError(t('attachment.readFailed'));
+    reader.onerror = () => {
+      const message = t('attachment.readFailed');
+      setError(message);
+      onLoadError?.(message);
+    };
     reader.readAsText(data);
     return () => {
       if (reader.readyState === FileReader.LOADING) reader.abort();
     };
-  }, [data, t]);
+  }, [data, onLoadError, t]);
   if (error) return <div className={styles.previewError}>{error}</div>;
   if (content === undefined) {
     return <div className={styles.empty}>{t('attachment.loadingFile')}</div>;
@@ -3405,11 +3424,13 @@ function ImageArtifactPreview({
   artifactVersion,
   workspaceActions,
   mimeType,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
   workspaceActions: ArtifactWorkspaceActions;
   mimeType: string;
+  onLoadError?: (error: string) => void;
 }) {
   const [src, setSrc] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -3435,13 +3456,15 @@ function ImageArtifactPreview({
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        onLoadError?.(message);
       });
     return () => {
       cancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [artifactVersion, mimeType, workspaceActions, workspacePath]);
+  }, [artifactVersion, mimeType, onLoadError, workspaceActions, workspacePath]);
 
   return (
     <div className={styles.imagePreviewWrap}>
@@ -3477,6 +3500,7 @@ function useWorkspaceFileContent({
   previewContent,
   previewOnly,
   truncatedMessage,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
@@ -3484,6 +3508,7 @@ function useWorkspaceFileContent({
   previewContent?: string;
   previewOnly?: boolean;
   truncatedMessage: string;
+  onLoadError?: (error: string) => void;
 }) {
   const [content, setContent] = useState<string | null>(previewContent ?? null);
   const [error, setError] = useState<string | null>(null);
@@ -3509,7 +3534,9 @@ function useWorkspaceFileContent({
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+        onLoadError?.(message);
       });
     return () => {
       cancelled = true;
@@ -3519,6 +3546,7 @@ function useWorkspaceFileContent({
     previewContent,
     previewOnly,
     truncatedMessage,
+    onLoadError,
     workspaceActions,
     workspacePath,
   ]);
@@ -3532,12 +3560,14 @@ function HtmlArtifactPreview({
   workspaceActions,
   previewContent,
   previewOnly,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
   workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   previewOnly?: boolean;
+  onLoadError?: (error: string) => void;
 }) {
   const { content, error } = useWorkspaceFileContent({
     workspacePath,
@@ -3546,6 +3576,7 @@ function HtmlArtifactPreview({
     previewContent,
     previewOnly,
     truncatedMessage: 'Preview is truncated because the file is too large.',
+    onLoadError,
   });
 
   return (
@@ -3572,12 +3603,14 @@ function FileArtifactPreview({
   workspaceActions,
   previewContent,
   previewOnly,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
   workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   previewOnly?: boolean;
+  onLoadError?: (error: string) => void;
 }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
@@ -3588,6 +3621,7 @@ function FileArtifactPreview({
     previewContent,
     previewOnly,
     truncatedMessage: 'File is truncated because it is too large.',
+    onLoadError,
   });
 
   useEffect(() => {
@@ -3634,12 +3668,14 @@ function MarkdownArtifactPreview({
   workspaceActions,
   previewContent,
   previewOnly,
+  onLoadError,
 }: {
   workspacePath: string;
   artifactVersion?: string;
   workspaceActions: ArtifactWorkspaceActions;
   previewContent?: string;
   previewOnly?: boolean;
+  onLoadError?: (error: string) => void;
 }) {
   const { content, error } = useWorkspaceFileContent({
     workspacePath,
@@ -3648,6 +3684,7 @@ function MarkdownArtifactPreview({
     previewContent,
     previewOnly,
     truncatedMessage: 'Preview is truncated because the file is too large.',
+    onLoadError,
   });
 
   return (

--- a/packages/web-shell/client/components/artifacts/SourcePreview.test.tsx
+++ b/packages/web-shell/client/components/artifacts/SourcePreview.test.tsx
@@ -109,6 +109,63 @@ afterEach(async () => {
 });
 
 describe('source preview', () => {
+  it('offers retry only after attachment loading fails', async () => {
+    mock.standalone = true;
+    mock.sessionActions.readAttachment
+      .mockRejectedValueOnce(new Error('Attachment read failed'))
+      .mockResolvedValueOnce({
+        data: btoa('Recovered attachment'),
+        mimeType: 'text/plain',
+      });
+    await render(source({ type: 'attachment', attachmentId: 'reference.txt' }));
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('Attachment read failed'),
+    );
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Try again',
+    );
+    expect(retry).not.toBeUndefined();
+    await act(async () => retry!.click());
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('Recovered attachment'),
+    );
+    expect(
+      Array.from(container.querySelectorAll('button')).some(
+        (button) => button.textContent === 'Try again',
+      ),
+    ).toBe(false);
+    expect(mock.sessionActions.readAttachment).toHaveBeenCalledTimes(2);
+  });
+
+  it('offers retry only after workspace file loading fails', async () => {
+    mock.actions.readWorkspaceFile
+      .mockRejectedValueOnce(new Error('Workspace read failed'))
+      .mockResolvedValueOnce({
+        content: 'Recovered workspace file',
+        truncated: false,
+      });
+    await render(
+      source({ type: 'workspace_file', workspacePath: 'reference.txt' }),
+    );
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('Workspace read failed'),
+    );
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Try again',
+    );
+    expect(retry).not.toBeUndefined();
+    await act(async () => retry!.click());
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('Recovered workspace file'),
+    );
+    expect(
+      Array.from(container.querySelectorAll('button')).some(
+        (button) => button.textContent === 'Try again',
+      ),
+    ).toBe(false);
+    expect(mock.actions.readWorkspaceFile).toHaveBeenCalledTimes(2);
+  });
+
   it.each(['text/plain', 'text/html'])(
     'previews standalone attachment bytes as %s without workspace access',
     async (mimeType) => {


### PR DESCRIPTION
## What this PR does

Source preview headers no longer show Try again after content loads successfully. Attachment and workspace-file load failures report into the source detail state, where Try again appears; a successful retry clears both the error and the action. Other artifact and attachment preview behavior is unchanged.

## Why it's needed

The unified Sources panel introduced a permanent Try again action beside every loaded file, even when the preview had succeeded. That made a recovery action look like a normal file operation and changed the established attachment-preview interaction without a failure to recover from.

## Reviewer Test Plan

### How to verify

Open a registered attachment source after its content loads and confirm its header contains only the filename. Make the attachment request fail and confirm Try again appears; allow the next request to succeed, click Try again, and confirm the content recovers and the action disappears. Repeat the failure and recovery flow with a registered workspace file.

### Evidence (Before & After)

Before: a successfully loaded registered attachment displayed one Try again action. After: a successful preview displays zero recovery actions; attachment and workspace-file failures each display one action, and both return to zero after a successful retry. The same isolated browser harness passed all three scenarios.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Source Web Shell through isolated Playwright mock-daemon ports; no external model calls.

## Risk & Scope

- Main risk or tradeoff: nested source preview readers now report load failures to their source tab; this is optional and does not affect ordinary artifact previews.
- Not validated / out of scope: native Windows and Linux browser execution; CI provides the platform checks after submission.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #11262.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

来源内容成功加载后，标题栏不再显示“重试”。附件或工作区文件加载失败时，内部预览会把错误上报到来源详情，此时显示“重试”；重试成功后错误和按钮都会消失。其他产物和附件预览行为保持不变。

## 为什么需要

统一来源面板此前在每个成功加载的文件旁常驻显示“重试”，让故障恢复操作看起来像普通文件操作，并在没有故障时改变了原附件预览交互。

## 审阅测试计划

打开已登记且成功加载的附件来源，确认标题栏只显示文件名。让附件请求失败，确认出现“重试”；允许下一次请求成功并点击“重试”，确认内容恢复且按钮消失。对已登记的工作区文件重复相同的失败与恢复流程。

## 验证证据

修复前：成功加载的已登记附件仍显示一个“重试”。修复后：成功状态为零个恢复操作；附件和工作区文件失败时各显示一个按钮，恢复成功后都回到零。同一套隔离浏览器场景三项全部通过。

## 风险与范围

内部来源预览现在会把加载失败上报给来源标签页；该回调是可选的，不影响普通产物预览。macOS 已验证，Windows 和 Linux 由提交后的 CI 验证。无破坏性变更或迁移要求。

</details>
