### PR TITLE
feat(desktop): gate sources panel add-source button on launch flag

### DIFF
--- a/packages/desktop/apps/electron/src/preload/bootstrap.ts
+++ b/packages/desktop/apps/electron/src/preload/bootstrap.ts
@@ -23,6 +23,7 @@ import { RoutedClient } from '../transport/routed-client'
 import { buildClientApi } from '../transport/build-api'
 import { CHANNEL_MAP } from '../transport/channel-map'
 import { createCallbackServer } from '@craft-agent/shared/auth/callback-server'
+import { isAddSourceButtonEnabled } from '@craft-agent/shared/feature-flags'
 import {
   CLIENT_OPEN_EXTERNAL,
   CLIENT_OPEN_PATH,
@@ -187,6 +188,7 @@ client.handleCapability(CLIENT_OPEN_FILE_DIALOG, async (spec: FileDialogSpec) =>
 const api = buildClientApi(client, CHANNEL_MAP, (ch) => client.isChannelAvailable(ch))
 
 ;(api as any).getRuntimeEnvironment = (): 'electron' | 'web' => 'electron'
+;(api as any).isAddSourceButtonEnabled = (): boolean => isAddSourceButtonEnabled()
 
 // ---------------------------------------------------------------------------
 // Transport connection state logging (for remote connections)

--- a/packages/desktop/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/packages/desktop/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -4970,8 +4970,8 @@ function AppShellContent({
                           </StyledDropdownMenuContent>
                         </DropdownMenu>
                       )}
-                      {/* Add Source button (only for sources mode) - uses filter-aware edit config */}
-                      {isSourcesNavigation(navState) && activeWorkspace && (
+                      {/* Add Source button (only for sources mode) - uses filter-aware edit config. Hidden unless enabled via launch flag. */}
+                      {isSourcesNavigation(navState) && activeWorkspace && window.electronAPI.isAddSourceButtonEnabled() && (
                         <EditPopover
                           trigger={
                             <HeaderIconButton

--- a/packages/desktop/apps/electron/src/renderer/playground/mock-utils.ts
+++ b/packages/desktop/apps/electron/src/renderer/playground/mock-utils.ts
@@ -141,6 +141,9 @@ export const mockElectronAPI = {
   // branch between Electron and web-UI rendering. Must be synchronous.
   getRuntimeEnvironment: (): 'electron' | 'web' => 'electron',
 
+  // Keep the sources panel "add source" button visible in the playground.
+  isAddSourceButtonEnabled: () => true,
+
   openFileDialog: async () => {
     console.log('[Playground] openFileDialog called')
     return [] // Let user use file input or drag-drop

--- a/packages/desktop/apps/electron/src/shared/types.ts
+++ b/packages/desktop/apps/electron/src/shared/types.ts
@@ -519,6 +519,8 @@ export interface ElectronAPI {
   getVersions(): { node: string; chrome: string; electron: string };
   /** Returns the renderer host environment without going through RPC. */
   getRuntimeEnvironment(): 'electron' | 'web';
+  /** Whether the sources panel "add source" header button is shown. Preload-local launch flag. */
+  isAddSourceButtonEnabled(): boolean;
   getHomeDir(): Promise<string>;
   isDebugMode(): Promise<boolean>;
 

--- a/packages/desktop/apps/electron/src/transport/__tests__/channel-map-parity.test.ts
+++ b/packages/desktop/apps/electron/src/transport/__tests__/channel-map-parity.test.ts
@@ -17,6 +17,7 @@ type ApiToChannelMapKeys = Exclude<
   | 'performOAuth'
   | 'getTransportConnectionState'
   | 'getRuntimeEnvironment'
+  | 'isAddSourceButtonEnabled' // reads launch env var in the preload — no IPC needed
   | 'onTransportConnectionStateChanged'
   | 'reconnectTransport'
   | 'isChannelAvailable'

--- a/packages/desktop/apps/webui/src/adapter/web-api.ts
+++ b/packages/desktop/apps/webui/src/adapter/web-api.ts
@@ -109,6 +109,7 @@ export function createWebApi(options: WebApiOptions): {
     // System info
     getVersions: () => ({ node: 'n/a', chrome: navigator.userAgent, electron: 'web' }),
     getRuntimeEnvironment: () => 'web',
+    isAddSourceButtonEnabled: () => false,
     getSystemWarnings: () => Promise.resolve({ vcredistMissing: false }),
     isDebugMode: () => Promise.resolve(import.meta.env.DEV),
 

--- a/packages/desktop/packages/shared/src/feature-flags.ts
+++ b/packages/desktop/packages/shared/src/feature-flags.ts
@@ -59,6 +59,17 @@ export function isEmbeddedServerEnabled(): boolean {
   return false;
 }
 
+/**
+ * Runtime-evaluated check for the sources panel "add source" header button.
+ *
+ * Defaults to disabled. Override with CRAFT_FEATURE_ADD_SOURCE_BUTTON=1|0.
+ */
+export function isAddSourceButtonEnabled(): boolean {
+  const override = parseBooleanEnv(getEnv('CRAFT_FEATURE_ADD_SOURCE_BUTTON'));
+  if (override !== undefined) return override;
+  return false;
+}
+
 export const FEATURE_FLAGS = {
   /** Enable Opus 4.7 fast mode (speed:"fast" + beta header). 6x pricing. */
   fastMode: false,
@@ -88,5 +99,13 @@ export const FEATURE_FLAGS = {
    */
   get embeddedServer(): boolean {
     return isEmbeddedServerEnabled();
+  },
+  /**
+   * Show the "add source" button in the sources panel header.
+   *
+   * Defaults to disabled. Override with CRAFT_FEATURE_ADD_SOURCE_BUTTON=1|0.
+   */
+  get addSourceButton(): boolean {
+    return isAddSourceButtonEnabled();
   },
 } as const;


### PR DESCRIPTION
## What this PR does

Hides the "+" button in the header of the sources panel by default. The button's code path is kept intact: launching the desktop app with the environment variable `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1` brings it back. The flag is evaluated in the preload process (the renderer cannot read environment variables) and exposed to the renderer through the existing preload-local API pattern, so checking it costs no IPC round-trip. The web build always reports the button as hidden, and the component playground keeps it visible so the add-source popover remains developable there. Other entry points for adding a source — the panel's empty state and the sidebar context menu — are unchanged.

## Why it's needed

The plus button in the sources panel header serves no practical purpose in the current product flow, but deleting the code outright would throw away a working add-source interaction that may still be wanted for debugging or future iterations. Hiding it behind a launch flag declutters the default UI while keeping the behavior one environment variable away.

## Reviewer Test Plan

### How to verify

1. From `packages/desktop`, run `bun run electron:dev`, open a workspace, and switch to the sources panel: the header shows no "+" button, and the rest of the panel (source list, item menus, empty state) behaves as before.
2. Relaunch with `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1 bun run electron:dev`: the "+" button reappears in the sources panel header and still opens the add-source popover.
3. Run `cd packages/desktop/apps/electron && bun test src/transport/__tests__/channel-map-parity.test.ts` — it passes, with the new preload-local API registered in the exclusion list.

### Evidence (Before & After)

Runtime smoke on macOS: the dev app boots cleanly both with the flag unset and with `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1` (window created, renderer connected over RPC, no preload or renderer errors in the app log), and the built preload bundle contains the flag evaluation. Visual before/after screenshots of the header were not captured — the dev launcher opens no remote-debugging port, so the window could not be inspected programmatically; the behavior change itself is a single conditional render on the flag.

### Tested on

|     OS     |      Status      |
| :--------: | :--------------: |
|  🍏 macOS  |       ✅ tested  |
| 🪟 Windows |  ⚠️ not tested   |
|  🐧 Linux  |  ⚠️ not tested   |

### Environment (optional)

`bun run electron:dev` from `packages/desktop` (Vite dev server + Electron).

## Risk & Scope

- Main risk or tradeoff: the renderer now calls a preload-local synchronous API while rendering the panel header; the method exists in all three API implementations (Electron preload, web adapter, playground mock), and the channel-map parity test guards the contract at compile time.
- Not validated / out of scope: Windows and Linux runtime behavior; the web UI keeps the button hidden unconditionally.
- Breaking changes / migration notes: none — the only default behavior change is the hidden button, and setting the environment variable restores it.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

默认隐藏来源面板头部的 "+" 按钮。按钮的代码路径完整保留：启动桌面应用时设置环境变量 `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1` 即可恢复显示。该开关在 preload 进程中求值（渲染进程无法读取环境变量），并通过现有的 preload 本地 API 模式暴露给渲染进程，因此读取开关不需要 IPC 往返。Web 版本始终报告按钮为隐藏状态；组件 playground 中保持可见，以便继续在其中开发"添加来源"弹层。添加来源的其他入口——面板的空状态按钮和侧边栏右键菜单——均不受影响。

## 为什么需要

来源面板头部的加号按钮在当前产品流程中没有实际意义，但直接删除代码会丢掉一个可用的添加来源交互，将来调试或迭代时可能仍需要。用启动开关把它隐藏起来，既让默认界面更干净，又让该行为只需一个环境变量即可找回。

## 评审者验证计划

### 如何验证

1. 在 `packages/desktop` 下运行 `bun run electron:dev`，打开一个工作区并切换到来源面板：头部不再显示 "+" 按钮，面板其余部分（来源列表、条目菜单、空状态）行为与之前一致。
2. 用 `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1 bun run electron:dev` 重新启动："+" 按钮重新出现在来源面板头部，且仍能打开添加来源弹层。
3. 运行 `cd packages/desktop/apps/electron && bun test src/transport/__tests__/channel-map-parity.test.ts`——测试通过，新的 preload 本地 API 已登记在排除列表中。

### 证据（前后对比）

macOS 上的运行时冒烟验证：不设置开关和设置 `CRAFT_FEATURE_ADD_SOURCE_BUTTON=1` 两种情况下开发应用均正常启动（窗口已创建，渲染进程通过 RPC 连接，应用日志中无 preload 或渲染进程错误），且构建出的 preload 包中包含开关求值逻辑。未截取头部的前后对比截图——开发启动器没有开放远程调试端口，无法以编程方式检查窗口；行为变化本身只是基于该开关的一处条件渲染。

### 已测试平台

macOS ✅ 已测试；Windows ⚠️ 未测试；Linux ⚠️ 未测试。

### 环境（可选）

在 `packages/desktop` 下运行 `bun run electron:dev`（Vite 开发服务器 + Electron）。

## 风险与范围

- 主要风险或权衡：渲染进程在渲染面板头部时会调用一个 preload 本地的同步 API；该方法在三处 API 实现（Electron preload、Web 适配器、playground mock）中均已提供，channel-map 一致性测试在编译期守护该契约。
- 未验证 / 不在范围内：Windows 和 Linux 的运行时行为；Web 界面无条件保持按钮隐藏。
- 破坏性变更 / 迁移说明：无——默认行为变化仅为隐藏按钮，设置环境变量即可恢复。

## 关联 Issue

无

</details>

