### PR TITLE
fix(channels): show complete prompts in session history

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -13016,7 +13016,7 @@ describe('ChannelBase', () => {
       expect(secondPrompt).not.toContain('Be concise.');
     });
 
-    it('keeps all model-only context out of the user-facing prompt text', async () => {
+    it('shows the complete delivered channel prompt in session history', async () => {
       const ch = createChannel({
         instructions: 'Be concise.',
         sessionScope: 'thread',
@@ -13049,10 +13049,16 @@ describe('ChannelBase', () => {
       expect(modelText).toContain('earlier message');
       expect(modelText).toContain('/tmp/hidden.txt');
       expect(modelText).toContain('Issue: hidden metadata');
-      expect(options).toMatchObject({ displayText: 'hello' });
+      const displayText = (options as { displayText: string }).displayText;
+      expect(displayText).toContain('[User 1] hello');
+      expect(displayText).toContain('earlier message');
+      expect(displayText).toContain('/tmp/hidden.txt');
+      expect(displayText).toContain('Issue: hidden metadata');
+      expect(displayText).toContain('Be concise.');
+      expect(displayText).toBe(modelText);
     });
 
-    it('neutralizes display-unsafe controls in the raw-text display fallback', async () => {
+    it('neutralizes display-unsafe controls without truncating the delivered prompt', async () => {
       const ch = createChannel();
       const rlo = String.fromCharCode(0x202e); // bidi override (trojan-source)
       const bel = String.fromCharCode(0x07); // C0 control
@@ -13066,11 +13072,10 @@ describe('ChannelBase', () => {
       const [, , options] = (bridge.prompt as ReturnType<typeof vi.fn>).mock
         .calls[0]!;
       const displayText = (options as { displayText: string }).displayText;
-      // Controls are replaced, the real newline survives, and the projection
-      // is capped by code point.
-      expect(displayText.startsWith('line1  \nline2')).toBe(true);
+      // Controls are replaced and the complete delivered prompt remains
+      // visible in session history.
       expect(displayText).not.toContain(rlo);
-      expect(Array.from(displayText)).toHaveLength(8000);
+      expect(displayText).toBe(`line1  \nline2${'A'.repeat(9000)}`);
     });
 
     it('prepends channel boundary metadata after custom instructions once per session', async () => {
@@ -13447,6 +13452,9 @@ describe('ChannelBase', () => {
         promptText.indexOf('[Current message - respond to this]'),
       );
       expect(promptText).toContain('[Production] deploy staging');
+      const options = (bridge.prompt as ReturnType<typeof vi.fn>).mock
+        .calls[0][2] as { displayText: string };
+      expect(options.displayText).toBe(promptText);
     });
 
     it('does not inject chat-scoped channel memory into single-scope sessions', async () => {
@@ -17908,13 +17916,16 @@ describe('ChannelBase', () => {
         .calls[1][1] as string;
       expect(secondCallText).toContain('second');
       expect(secondCallText).toContain('third');
-      // Metadata stays model-facing; the coalesced projection carries only
-      // the raw user-authored texts.
+      // The coalesced display projection carries the complete current channel
+      // prompt, including adapter-provided metadata.
       expect(secondCallText).toContain('hidden policy second');
       expect(secondCallText).toContain('hidden policy third');
       expect(
         (bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[1][2],
-      ).toMatchObject({ displayText: '[Alice] second\n\n[Bob] third' });
+      ).toMatchObject({
+        displayText:
+          '[Alice] second\n\nhidden policy second\n\n[Bob] third\n\nhidden policy third',
+      });
 
       // Both responses should have been sent
       expect(ch.sent).toEqual(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -7249,7 +7249,7 @@ export abstract class ChannelBase {
           ...(images.length > 0 ? { images } : {}),
           imageBase64,
           imageMimeType,
-          displayText,
+          displayText: sanitizeDisplayText(promptToSend),
         });
 
         await this.settleCancelRequested(promptState);

--- a/packages/channels/base/src/sanitize.ts
+++ b/packages/channels/base/src/sanitize.ts
@@ -233,17 +233,17 @@ export function sanitizePromptText(text: string): string {
  * (session-bus display projections, transcripts, session-list previews):
  * strip the Unicode line/bidi/zero-width controls that can reorder or hide
  * rendered text, plus C0/DEL controls EXCEPT newline — multi-line user text
- * keeps its line structure in the transcript. Capped by CODE POINT so a cap
- * landing mid-surrogate-pair cannot leave a lone surrogate. Unlike
+ * keeps its line structure in the transcript. When a cap is provided, it is
+ * applied by CODE POINT so it cannot leave a lone surrogate. Unlike
  * sanitizePromptText it preserves newlines and brackets: display text is
  * rendered to a human, not parsed as prompt structure.
  */
-export function sanitizeDisplayText(text: string, maxLen: number): string {
+export function sanitizeDisplayText(text: string, maxLen?: number): string {
   const cleaned = text
     .replace(PROMPT_UNSAFE_INVISIBLES, ' ')
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, ' ');
-  return truncateCodePoints(cleaned, maxLen);
+  return maxLen === undefined ? cleaned : truncateCodePoints(cleaned, maxLen);
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Channel session transcripts now display the complete sanitized prompt delivered for an inbound channel message. CLI resume and Web Shell preserve channel instructions, identity and memory boundaries, recalled channel memory, backfilled group history, speaker attribution, reply context, mentions, attachment paths, and adapter metadata in the same order seen by the model.

## Why it's needed

Channel messages currently record only the raw user-authored body as their display text. A group message delivered to the model with channel context therefore appears as only the final body after resume and in Web Shell, which hides the information needed to understand and debug the actual turn.

## Reviewer Test Plan

### How to verify

Configure a channel with instructions, memory recall, and group-history backfill. Send an ordinary group message with a reply or attachment, then open its session in CLI resume or Web Shell. Confirm that the displayed user turn matches the sanitized prompt delivered to the model, including each injected context block in delivery order. Confirm that unsafe display characters are neutralized without truncating an oversized prompt.

### Evidence (Before & After)

Before: a group prompt delivered with instructions, memory, history, sender attribution, and attachment context was displayed as only the raw user body.

After: the displayed turn contains the same sanitized channel prompt delivered to the model, so CLI resume and Web Shell expose the full channel-side input used for that turn.

Local validation: `npm run typecheck` passed, and the focused ChannelBase suite passed with 692 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.17.0, local daemon-managed DingTalk channel.

## Risk & Scope

- Main risk or tradeoff: Channel context that was previously visible only in the stored model-facing message now also appears in session history; unsafe display controls are still sanitized before persistence.
- Not validated / out of scope: Windows and Linux runtime verification; raw platform webhook payloads are not persisted or displayed.
- Breaking changes / migration notes: Existing transcript records are unchanged; only newly recorded inbound channel prompts use the complete display projection.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Channel 会话记录现在展示入站消息实际发送给模型的完整安全化 prompt。CLI resume 与 Web Shell 会按模型看到的顺序保留 Channel 指令、身份与记忆边界、召回的 Channel Memory、补入的群聊历史、发送者标识、回复上下文、mention、附件路径和适配器 metadata。

## 为什么需要

目前 Channel 消息只把用户原始正文记录为展示文本。群聊消息即使携带 Channel 上下文发送给模型，在 resume 和 Web Shell 中也只显示最后的正文，无法查看和排查本轮实际输入。

## Reviewer Test Plan

### 如何验证

为 Channel 配置指令、Memory 召回和群聊历史补录，发送一条带回复或附件的群聊消息，然后在 CLI resume 或 Web Shell 中打开对应会话。确认展示的用户消息与实际发送给模型的安全化 prompt 一致，并按发送顺序包含各个上下文块。确认不安全展示字符会被清理，超长 prompt 不会被截断。

### Before 与 After 证据

Before：包含系统指令、Memory、群聊历史、发送者和附件上下文的模型输入，在界面中只显示用户原始正文。

After：界面展示与模型收到的安全化 Channel prompt 一致，CLI resume 和 Web Shell 可以查看本轮完整的 Channel 侧输入。

本地验证：`npm run typecheck` 通过，ChannelBase 定向测试 692 项全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.17.0，本地 daemon 管理的钉钉 Channel。

## 风险与范围

- 主要风险或取舍：此前只存在于模型输入记录中的 Channel 上下文现在也会显示在会话历史中；持久化前仍会清理不安全展示字符。
- 未验证或超出范围：未验证 Windows 和 Linux 运行时；不持久化或展示平台原始 webhook payload。
- Breaking change 或迁移说明：已有会话记录不变，只有新记录的 Channel 入站 prompt 使用完整展示投影。

## 关联 Issue

N/A

</details>
