### PR TITLE
feat(web-shell): hide sources panel add-source button behind URL flag

### DIFF
--- a/packages/web-shell/client/components/panels/EnvironmentPanel.test.tsx
+++ b/packages/web-shell/client/components/panels/EnvironmentPanel.test.tsx
@@ -3,7 +3,7 @@
 import type { DaemonSessionTaskStatus } from '@qwen-code/sdk/daemon';
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../i18n';
 import { EnvironmentPanel } from './EnvironmentPanel';
 import type { SourcesState } from './SourcesSection';
@@ -44,11 +44,17 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;
 
+beforeEach(() => {
+  // The add-source button is hidden by default; enable it for these tests.
+  window.history.replaceState({}, '', '/?addSource=1');
+});
+
 afterEach(() => {
   act(() => root?.unmount());
   container?.remove();
   container = null;
   root = null;
+  window.history.replaceState({}, '', '/');
 });
 
 function mount(

--- a/packages/web-shell/client/components/panels/SourcesSection.test.tsx
+++ b/packages/web-shell/client/components/panels/SourcesSection.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n';
+import { SourcesSection, type SourcesState } from './SourcesSection';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  window.history.replaceState({}, '', '/');
+});
+
+function supportedState(): SourcesState {
+  return {
+    supported: true,
+    sources: [],
+    owner: { isCurrent: () => true },
+    revision: 1,
+    hydrated: true,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    upsert: vi.fn(),
+    remove: vi.fn(),
+  };
+}
+
+function mount(): HTMLDivElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <I18nProvider language="en">
+        <SourcesSection state={supportedState()} />
+      </I18nProvider>,
+    );
+  });
+  return container;
+}
+
+describe('SourcesSection add-source button', () => {
+  it('is hidden by default', () => {
+    const el = mount();
+    expect(el.querySelector('button[aria-label="Add source"]')).toBeNull();
+  });
+
+  it('appears when the addSource URL parameter is set', () => {
+    window.history.replaceState({}, '', '/?addSource=1');
+    const el = mount();
+    expect(el.querySelector('button[aria-label="Add source"]')).not.toBeNull();
+  });
+});

--- a/packages/web-shell/client/components/panels/SourcesSection.tsx
+++ b/packages/web-shell/client/components/panels/SourcesSection.tsx
@@ -18,6 +18,13 @@ import styles from './EnvironmentPanel.module.css';
 
 export type SourcesState = ReturnType<typeof useSessionSources>;
 
+// Escape hatch: the add-source affordance is hidden by default; append
+// ?addSource=1 to the URL to bring it back.
+function isAddSourceEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('addSource') === '1';
+}
+
 interface SourcesSectionProps {
   hidden?: boolean;
   state?: SourcesState;
@@ -97,7 +104,7 @@ export function SourcesSection({
           {t('sources.title')}{' '}
           <span className="text-muted-foreground">{entries.length}</span>
         </h3>
-        {state?.supported && (
+        {state?.supported && isAddSourceEnabled() && (
           <button
             type="button"
             className={styles.sectionAction}


### PR DESCRIPTION
## What this PR does

Hides the "+" button in the header of the Web Shell sources panel by default. The button's code path — including the add-source dialog it opens — is kept intact: appending the URL parameter `?addSource=1` brings it back, following the same escape-hatch pattern the Web Shell already uses for switches like `?composer=`. Everything else in the panel (source list, attachments, empty state, view-all toggle) is unchanged. Existing panel tests opt into the flag in a shared setup hook, and new collocated tests cover both the hidden default and the enabled state.

## Why it's needed

The plus button in the sources panel header serves no practical purpose in the current product flow, but deleting the code outright would throw away a working add-source interaction that may still be wanted for debugging or future iterations. Hiding it behind a URL flag declutters the default UI while keeping the behavior one parameter away.

## Reviewer Test Plan

### How to verify

1. Open the Web Shell as usual and navigate to a session's environment panel: the sources section header shows the title and count but no "+" button.
2. Reload with `?addSource=1` appended to the URL: the "+" button reappears and opens the add-source dialog as before.
3. Run `cd packages/web-shell && npx vitest run client/components/panels/SourcesSection.test.tsx client/components/panels/EnvironmentPanel.test.tsx` — all 38 tests pass.

### Evidence (Before & After)

New collocated tests render the panel in jsdom and assert the button is absent by default and present with the flag; the full existing environment-panel suite (36 tests) passes unchanged against the enabled state. `tsc --noEmit` for the package is clean, and eslint passes on the touched files.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested   |
| 🪟 Windows | ⚠️ not tested  |
|  🐧 Linux  | ⚠️ not tested  |

### Environment (optional)

jsdom component tests via the package vitest config; Web Shell is browser- and OS-independent for this change.

## Risk & Scope

- Main risk or tradeoff: none beyond the intended default-hidden button — the gate is a single additional render condition evaluated from the URL.
- Not validated / out of scope: no new e2e coverage; no existing e2e spec exercises the sources panel, so nothing there could regress.
- Breaking changes / migration notes: the add-source interaction is no longer reachable by default; set `?addSource=1` to restore it.

## Linked Issues

N/A — supersedes the closed #11632, which targeted the retired Electron desktop package.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

默认隐藏 Web Shell 来源面板头部的 "+" 按钮。按钮的代码路径——包括它打开的添加来源对话框——完整保留：在 Web Shell URL 后追加参数 `?addSource=1` 即可恢复显示，沿用了 Web Shell 已有的 `?composer=` 等逃生开关模式。面板的其他部分（来源列表、附件、空状态、查看全部开关）均不受影响。现有面板测试在共享的 setup 钩子中开启该开关，新增的随源测试同时覆盖默认隐藏和开启两种状态。

## 为什么需要

来源面板头部的加号按钮在当前产品流程中没有实际意义，但直接删除代码会丢掉一个可用的添加来源交互，将来调试或迭代时可能仍需要。用 URL 开关把它隐藏起来，既让默认界面更干净，又让该行为只需一个参数即可找回。

## 评审者验证计划

### 如何验证

1. 照常打开 Web Shell 并进入某个会话的环境面板：来源区域的头部只显示标题和数量，没有 "+" 按钮。
2. 在 URL 后追加 `?addSource=1` 刷新："+" 按钮重新出现，且照常打开添加来源对话框。
3. 运行 `cd packages/web-shell && npx vitest run client/components/panels/SourcesSection.test.tsx client/components/panels/EnvironmentPanel.test.tsx`——38 个测试全部通过。

### 证据（前后对比）

新增的随源测试在 jsdom 中渲染面板，断言按钮默认不存在、带开关时存在；现有环境面板测试套件（36 个）在开启开关的状态下全部原样通过。该包的 `tsc --noEmit` 无错误，改动文件通过 eslint。

### 已测试平台

macOS ✅ 已测试；Windows ⚠️ 未测试；Linux ⚠️ 未测试（本改动为浏览器端条件渲染，与操作系统无关）。

### 环境（可选）

通过包的 vitest 配置运行 jsdom 组件测试。

## 风险与范围

- 主要风险或权衡：除预期的默认隐藏按钮外无其他影响——开关只是从 URL 读取的一处额外渲染条件。
- 未验证 / 不在范围内：未新增 e2e 覆盖；现有 e2e 没有用例涉及来源面板，因此无回归面。
- 破坏性变更 / 迁移说明：添加来源入口默认不再可达，设置 `?addSource=1` 即可恢复。

## 关联 Issue

无——替代已关闭的 #11632（该 PR 误投向已移除的 Electron 桌面包）。

</details>