### PR TITLE
feat(channels): show channel turns exactly as the model receives them

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -23,7 +23,6 @@ import { ChannelBase, CLEAR_CANCEL_TIMEOUT_MS } from './ChannelBase.js';
 import type { ChannelBaseOptions } from './ChannelBase.js';
 import type { ChannelLoop, ChannelLoopInput } from './ChannelLoopStore.js';
 import {
-  buildChannelWebhookDisplayText,
   buildChannelWebhookPrompt,
   resolveChannelWebhookTarget,
 } from './ChannelWebhookTask.js';
@@ -13016,7 +13015,7 @@ describe('ChannelBase', () => {
       expect(secondPrompt).not.toContain('Be concise.');
     });
 
-    it('keeps all model-only context out of the user-facing prompt text', async () => {
+    it('shows the exact model prompt in session history', async () => {
       const ch = createChannel({
         instructions: 'Be concise.',
         sessionScope: 'thread',
@@ -13049,16 +13048,16 @@ describe('ChannelBase', () => {
       expect(modelText).toContain('earlier message');
       expect(modelText).toContain('/tmp/hidden.txt');
       expect(modelText).toContain('Issue: hidden metadata');
-      expect(options).toMatchObject({ displayText: 'hello' });
+      expect(options).toMatchObject({ displayText: modelText });
     });
 
-    it('neutralizes display-unsafe controls in the raw-text display fallback', async () => {
+    it('neutralizes display-unsafe controls without truncating the prompt', async () => {
       const ch = createChannel();
       const rlo = String.fromCharCode(0x202e); // bidi override (trojan-source)
       const bel = String.fromCharCode(0x07); // C0 control
-      // Adapters that never set displayText fall back to the raw text; the
-      // projection must neutralize it before it reaches the session bus,
-      // transcript, and session previews.
+      // Session history receives the full model prompt, so unsafe controls
+      // are neutralized before it reaches the session bus, transcript, and
+      // session previews.
       await ch.handleInbound(
         envelope({ text: `line1${rlo}${bel}\nline2${'A'.repeat(9000)}` }),
       );
@@ -13066,11 +13065,10 @@ describe('ChannelBase', () => {
       const [, , options] = (bridge.prompt as ReturnType<typeof vi.fn>).mock
         .calls[0]!;
       const displayText = (options as { displayText: string }).displayText;
-      // Controls are replaced, the real newline survives, and the projection
-      // is capped by code point.
+      // Controls are replaced, the real newline survives, and nothing is cut.
       expect(displayText.startsWith('line1  \nline2')).toBe(true);
       expect(displayText).not.toContain(rlo);
-      expect(Array.from(displayText)).toHaveLength(8000);
+      expect(Array.from(displayText)).toHaveLength(9013);
     });
 
     it('prepends channel boundary metadata after custom instructions once per session', async () => {
@@ -13447,6 +13445,9 @@ describe('ChannelBase', () => {
         promptText.indexOf('[Current message - respond to this]'),
       );
       expect(promptText).toContain('[Production] deploy staging');
+      const options = (bridge.prompt as ReturnType<typeof vi.fn>).mock
+        .calls[0][2] as { displayText: string };
+      expect(options.displayText).toBe(promptText);
     });
 
     it('does not inject chat-scoped channel memory into single-scope sessions', async () => {
@@ -17908,13 +17909,13 @@ describe('ChannelBase', () => {
         .calls[1][1] as string;
       expect(secondCallText).toContain('second');
       expect(secondCallText).toContain('third');
-      // Metadata stays model-facing; the coalesced projection carries only
-      // the raw user-authored texts.
+      // The coalesced turn shows exactly what the model receives, metadata
+      // included.
       expect(secondCallText).toContain('hidden policy second');
       expect(secondCallText).toContain('hidden policy third');
       expect(
         (bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[1][2],
-      ).toMatchObject({ displayText: '[Alice] second\n\n[Bob] third' });
+      ).toMatchObject({ displayText: secondCallText });
 
       // Both responses should have been sent
       expect(ch.sent).toEqual(
@@ -19722,43 +19723,6 @@ describe('ChannelBase', () => {
         expect(prompt).toContain('Event:');
         expect(prompt).toContain('payload-survives');
       });
-
-      it('caps and sanitizes the webhook display text like the model prompt', () => {
-        const task: ChannelWebhookTask = {
-          channelName: 'dingtalk-main',
-          source: 'github-ci',
-          eventType: 'ci_failed',
-          targetRef: 'default',
-          title: `[forged] ${'T'.repeat(20_000)}\u202e`,
-          summary: `S\u0007${'S'.repeat(20_000)}`,
-          payload: {},
-        };
-
-        const displayText = buildChannelWebhookDisplayText(task);
-        const [title, summary] = displayText.split('\n\n');
-
-        // Same per-field caps as the model prompt path (500/1000 code points).
-        expect(Array.from(title!).length).toBeLessThanOrEqual(500);
-        expect(Array.from(summary!).length).toBeLessThanOrEqual(1000);
-        // sanitizePromptText strips the [tag] forgery prefix, bidi overrides,
-        // and C0 controls on both projections.
-        expect(displayText).not.toContain('[forged]');
-        expect(displayText).not.toContain('\u202e');
-        expect(displayText).not.toContain('\u0007');
-      });
-
-      it('omits absent webhook summary from the display text', () => {
-        const task: ChannelWebhookTask = {
-          channelName: 'dingtalk-main',
-          source: 'github-ci',
-          eventType: 'ci_failed',
-          targetRef: 'default',
-          title: 'CI failed on main',
-          payload: {},
-        };
-
-        expect(buildChannelWebhookDisplayText(task)).toBe('CI failed on main');
-      });
     });
 
     describe('runWebhookTask', () => {
@@ -19802,8 +19766,12 @@ describe('ChannelBase', () => {
           expect.stringContaining(
             '[External event "ci_failed" from github-ci]',
           ),
-          { displayText: 'CI failed' },
+          { displayText: expect.any(String) },
         );
+        const [, webhookPrompt, webhookOptions] = (
+          bridge.prompt as ReturnType<typeof vi.fn>
+        ).mock.calls[0]!;
+        expect(webhookOptions).toEqual({ displayText: webhookPrompt });
         expect(ch.proactive).toEqual([
           { chatId: 'group-1', text: 'CI failed because lint broke.' },
         ]);
@@ -20744,7 +20712,10 @@ describe('ChannelBase', () => {
       expect(bridge.prompt).toHaveBeenLastCalledWith(
         expect.any(String),
         '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
-        { displayText: 'post summary' },
+        {
+          displayText:
+            '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost summary',
+        },
       );
       expect(ch.proactive).toEqual([
         { chatId: 'group-1', text: 'loop response' },
@@ -22076,7 +22047,10 @@ describe('ChannelBase', () => {
         expect(bridge.prompt).toHaveBeenLastCalledWith(
           's-1',
           '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost again',
-          { displayText: 'post again' },
+          {
+            displayText:
+              '[Loop "daily summary" created by Alice] Scheduled task running unattended: no one is present to answer questions, and your final response is delivered to this chat automatically — do whatever work the task requires, then put the result in your final response instead of trying to deliver it to this chat yourself.\n\npost again',
+          },
         );
         expect(ch.proactive).toEqual([
           { chatId: 'chat1', text: 'second response' },

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -74,7 +74,6 @@ import type {
 import type { ChannelLoop, ChannelLoopInput } from './ChannelLoopStore.js';
 import { ChannelLoopSkippedError } from './ChannelLoopScheduler.js';
 import {
-  buildChannelWebhookDisplayText,
   buildChannelWebhookPrompt,
   resolveChannelWebhookTarget,
 } from './ChannelWebhookTask.js';
@@ -350,7 +349,6 @@ type PendingPermissionLookup =
   | { kind: 'ambiguous'; requestIds: string[] };
 type CollectBufferEntry = {
   text: string;
-  displayText: string;
   envelope: Envelope;
 };
 type NamedTurnBinding = {
@@ -421,7 +419,6 @@ const COMMAND_TOKEN_RE = new RegExp(`^[${COMMAND_TOKEN_CHARS}]+(?:@\\S+)?$`);
 const LOOP_ADD_RE = /^"([^"]+)"\s+(.+)$/su;
 const MAX_LOOP_JOBS_PER_TARGET = 10;
 const MAX_LOOP_PROMPT_CHARS = 4000;
-const MAX_DISPLAY_PROJECTION_CHARS = 8000;
 // Mirrors BTW_MAX_INPUT_LENGTH in core without adding core to channel-base.
 const CHANNEL_BTW_MAX_INPUT_LENGTH = 4096;
 
@@ -2023,13 +2020,11 @@ export abstract class ChannelBase {
     this.collectBuffers.delete(sessionId);
     const lost = buffer.length;
     const coalesced = buffer.map((b) => b.text).join('\n\n');
-    const coalescedDisplayText = buffer.map((b) => b.displayText).join('\n\n');
     const lastEnvelope = buffer[buffer.length - 1]!.envelope;
     this.notifyPromptBufferDrained(lastEnvelope.chatId, sessionId, buffer);
     const syntheticEnvelope: Envelope = {
       ...lastEnvelope,
       text: coalesced,
-      displayText: coalescedDisplayText,
       alreadyPrefixed: true,
       referencedText: undefined,
       mentionedMemberIds: undefined,
@@ -2257,7 +2252,6 @@ export abstract class ChannelBase {
           promptBridge,
           sessionId,
           promptToSend,
-          job.prompt,
           promptState,
           job.id,
           options.timeoutMs,
@@ -2429,7 +2423,6 @@ export abstract class ChannelBase {
       },
     );
     const promptText = buildChannelWebhookPrompt(task, target);
-    const displayText = buildChannelWebhookDisplayText(task);
     const taskId = `webhook:${task.source}:${task.eventType}`;
     const safeTaskId = sanitizeLogText(taskId, 64);
     const safeChannel = sanitizeLogText(this.name, 64);
@@ -2555,7 +2548,6 @@ export abstract class ChannelBase {
           promptBridge,
           sessionId,
           promptToSend,
-          displayText,
           promptState,
           taskId,
           options.timeoutMs,
@@ -2660,12 +2652,13 @@ export abstract class ChannelBase {
     promptBridge: ChannelAgentBridge,
     sessionId: string,
     promptText: string,
-    displayText: string,
     promptState: ActivePrompt,
     jobId: string,
     timeoutMs: number | undefined,
   ): Promise<string> {
-    const prompt = promptBridge.prompt(sessionId, promptText, { displayText });
+    const prompt = promptBridge.prompt(sessionId, promptText, {
+      displayText: sanitizeDisplayText(promptText),
+    });
     prompt.catch(() => {});
     if (timeoutMs === undefined) {
       return prompt;
@@ -6507,15 +6500,6 @@ export abstract class ChannelBase {
       await this.recordObservedContact(envelope);
       this.onObservedContact(envelope);
     }
-    // Adapters that never set `displayText` fall back to the raw message
-    // text; sanitize at this boundary so attacker-controlled bidi/zero-width/
-    // control chars cannot reach the session-bus echo, recorded transcript,
-    // or session previews.
-    const displayText = sanitizeDisplayText(
-      envelope.displayText ?? envelope.text,
-      MAX_DISPLAY_PROJECTION_CHARS,
-    );
-
     const parsed = this.parseCommand(envelope.text);
     let memoryIntent: ResolvedChannelMemoryIntent | null =
       parsed?.command === 'btw'
@@ -6915,17 +6899,7 @@ export abstract class ChannelBase {
             buffer = [];
             this.collectBuffers.set(sessionId, buffer);
           }
-          const bufferedDisplayText =
-            (envelope.isGroup || this.config.sessionScope === 'single') &&
-            !envelope.alreadyPrefixed &&
-            !recognizedSlashCommand
-              ? `[${sanitizeSenderName(envelope.senderName || envelope.senderId || 'unknown')}] ${sanitizePromptText(displayText)}`
-              : displayText;
-          buffer.push({
-            text: promptText,
-            displayText: bufferedDisplayText,
-            envelope,
-          });
+          buffer.push({ text: promptText, envelope });
           try {
             this.onPromptBuffered(
               envelope.chatId,
@@ -7249,7 +7223,9 @@ export abstract class ChannelBase {
           ...(images.length > 0 ? { images } : {}),
           imageBase64,
           imageMimeType,
-          displayText,
+          // Session history shows exactly what the model receives. Only the
+          // controls that can reorder or hide rendered text are neutralized.
+          displayText: sanitizeDisplayText(promptToSend),
         });
 
         await this.settleCancelRequested(promptState);

--- a/packages/channels/base/src/ChannelWebhookTask.ts
+++ b/packages/channels/base/src/ChannelWebhookTask.ts
@@ -108,32 +108,6 @@ export function buildChannelWebhookPrompt(
   return truncateCodePoints(lines.join('\n'), MAX_WEBHOOK_PROMPT_CHARS);
 }
 
-/**
- * User-visible projection of a webhook task (session-bus displayText,
- * transcript). Mirrors the model-prompt treatment in
- * buildChannelWebhookPrompt — same per-field caps and sanitizePromptText —
- * so an oversized or crafted title/summary cannot reach the transcript
- * uncapped while the model side stays bounded and sanitized.
- */
-export function buildChannelWebhookDisplayText(
-  task: ChannelWebhookTask,
-): string {
-  const title = truncateCodePoints(
-    sanitizePromptText(task.title),
-    MAX_WEBHOOK_TITLE_CHARS,
-  );
-  const summary =
-    task.summary === undefined
-      ? undefined
-      : truncateCodePoints(
-          sanitizePromptText(task.summary),
-          MAX_WEBHOOK_SUMMARY_CHARS,
-        );
-  return [title, summary]
-    .filter((part): part is string => Boolean(part))
-    .join('\n\n');
-}
-
 function truncateCodePoints(text: string, maxChars: number): string {
   const chars = Array.from(text);
   return chars.length > maxChars ? chars.slice(0, maxChars).join('') : text;

--- a/packages/channels/base/src/sanitize.test.ts
+++ b/packages/channels/base/src/sanitize.test.ts
@@ -422,4 +422,9 @@ describe('sanitizeDisplayText', () => {
     expect(out).toBe('a'.repeat(399) + EMOJI);
     expect(isHighSurrogate(out.charCodeAt(out.length - 1))).toBe(false);
   });
+
+  it('keeps the full text when no cap is given', () => {
+    const text = `${'a'.repeat(9000)}${EMOJI}tail`;
+    expect(sanitizeDisplayText(text)).toBe(text);
+  });
 });

--- a/packages/channels/base/src/sanitize.ts
+++ b/packages/channels/base/src/sanitize.ts
@@ -233,17 +233,17 @@ export function sanitizePromptText(text: string): string {
  * (session-bus display projections, transcripts, session-list previews):
  * strip the Unicode line/bidi/zero-width controls that can reorder or hide
  * rendered text, plus C0/DEL controls EXCEPT newline — multi-line user text
- * keeps its line structure in the transcript. Capped by CODE POINT so a cap
- * landing mid-surrogate-pair cannot leave a lone surrogate. Unlike
- * sanitizePromptText it preserves newlines and brackets: display text is
- * rendered to a human, not parsed as prompt structure.
+ * keeps its line structure in the transcript. An optional cap is applied by
+ * CODE POINT so it cannot leave a lone surrogate. Unlike sanitizePromptText
+ * it preserves newlines and brackets: display text is rendered to a human,
+ * not parsed as prompt structure.
  */
-export function sanitizeDisplayText(text: string, maxLen: number): string {
+export function sanitizeDisplayText(text: string, maxLen?: number): string {
   const cleaned = text
     .replace(PROMPT_UNSAFE_INVISIBLES, ' ')
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, ' ');
-  return truncateCodePoints(cleaned, maxLen);
+  return maxLen === undefined ? cleaned : truncateCodePoints(cleaned, maxLen);
 }
 
 /**

--- a/packages/channels/base/src/types.ts
+++ b/packages/channels/base/src/types.ts
@@ -90,8 +90,6 @@ export interface Envelope {
   chatId: string;
   chatName?: string;
   text: string;
-  /** User-authored text to display when `text` contains model-only context. */
-  displayText?: string;
   /**
    * `text` is an adapter-synthesized placeholder (`(image)`, `(voice
    * message)`, `(file: …)`) rather than something the user typed.

--- a/packages/channels/dws/src/dws-channel.test.ts
+++ b/packages/channels/dws/src/dws-channel.test.ts
@@ -4684,7 +4684,6 @@ describe('DwsChannel', () => {
         chatId: 'todo:task-new',
         threadId: 'task-new',
         senderId: 'alice',
-        displayText: 'Investigate the new failure',
         text: expect.stringContaining('Investigate the new failure'),
         metadata: expect.stringContaining('DWS native todo ID: task-new'),
       }),

--- a/packages/channels/dws/src/dws-channel.ts
+++ b/packages/channels/dws/src/dws-channel.ts
@@ -1715,7 +1715,6 @@ export class DwsChannel extends PollingChannelBase<DwsCursor> {
       threadId: summary.taskId,
       messageId: `todo-${fingerprint}`,
       text: `Process this DingTalk todo:\n${truncateCodePoints(title, MAX_COMMENT_CHARS)}`,
-      displayText: title,
       isGroup: true,
       isMentioned: true,
       isReplyToBot: false,

--- a/packages/channels/github/src/GithubAdapter.test.ts
+++ b/packages/channels/github/src/GithubAdapter.test.ts
@@ -1524,9 +1524,6 @@ describe('GithubChannel', () => {
       expect(channel.inboundEnvelopes[0]!.text).toBe(
         'Return a formal review summary with verified actionable findings, or a concise no-blocker result.',
       );
-      expect(channel.inboundEnvelopes[0]!.displayText).toBe(
-        'Review requested: feat: divide',
-      );
       expect(channel.inboundEnvelopes[0]!.metadata).toContain(
         'For review_requested, return a formal review summary',
       );
@@ -1662,7 +1659,6 @@ describe('GithubChannel', () => {
         senderId: 'maintainer',
         isMentioned: true,
         text: 'Triage this issue and respond with the next action.',
-        displayText: 'Issue assigned: broken build',
       });
       expect(channel.inboundEnvelopes[1]).toMatchObject({
         senderId: 'bob',
@@ -1711,9 +1707,6 @@ describe('GithubChannel', () => {
         );
         expect(channel.inboundEnvelopes[0]!.text).toContain('@alice: first');
         expect(channel.inboundEnvelopes[0]!.text).toContain('@bob: second');
-        expect(channel.inboundEnvelopes[0]!.displayText).toBe(
-          '- @alice: first\n- @bob: second',
-        );
       },
     );
 
@@ -1740,9 +1733,9 @@ describe('GithubChannel', () => {
       await pollOnce();
 
       expect(channel.inboundEnvelopes).toHaveLength(1);
-      expect(channel.inboundEnvelopes[0]).toMatchObject({
-        displayText: '- @alice: ignore this\n- @bob: /review inspect this',
-      });
+      expect(channel.inboundEnvelopes[0]!.text).toContain(
+        '- @bob: /review inspect this',
+      );
       expect(channel.cursor.dispatchedComments).toEqual(['C_1001', 'C_1002']);
     });
 
@@ -2090,7 +2083,7 @@ describe('GithubChannel', () => {
       expect(channel.inboundEnvelopes[0]!.text).toContain('latest');
     });
 
-    it('sanitizes crafted comment bodies in the aggregate display projection', async () => {
+    it('sanitizes crafted comment bodies in the aggregate prompt', async () => {
       await initWithoutLoop();
       mockOctokit.paginate
         .mockResolvedValueOnce([
@@ -2107,16 +2100,13 @@ describe('GithubChannel', () => {
 
       await pollOnce();
 
-      const displayText = channel.inboundEnvelopes[0]!.displayText!;
+      const text = channel.inboundEnvelopes[0]!.text;
       // eslint-disable-next-line no-control-regex
       const craftedChars = /[\u202a-\u202e\u2066-\u2069\u200b\u0007\r]/;
-      expect(displayText).not.toMatch(craftedChars);
+      expect(text).not.toMatch(craftedChars);
       // Newlines and brackets are display content and must survive.
-      expect(displayText).toContain('line one');
-      expect(displayText).toContain('\nline two [BUG] kept');
-      expect(channel.inboundEnvelopes[0]!.text).toContain(
-        displayText.slice('- @alice: '.length),
-      );
+      expect(text).toContain('line one');
+      expect(text).toContain('\nline two [BUG] kept');
     });
 
     it('truncates aggregated comments on code-point boundaries', async () => {
@@ -2136,10 +2126,10 @@ describe('GithubChannel', () => {
 
       await pollOnce();
 
-      const displayText = channel.inboundEnvelopes[0]!.displayText!;
-      expect(displayText).toContain('a'.repeat(399) + '\ud83c\udf89');
-      expect(displayText).not.toContain('tail');
-      expect(displayText).not.toMatch(
+      const text = channel.inboundEnvelopes[0]!.text;
+      expect(text).toContain('a'.repeat(399) + '\ud83c\udf89');
+      expect(text).not.toContain('tail');
+      expect(text).not.toMatch(
         /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/,
       );
     });

--- a/packages/channels/github/src/GithubAdapter.ts
+++ b/packages/channels/github/src/GithubAdapter.ts
@@ -27,8 +27,6 @@ import {
   PollingChannelBase,
   sanitizeDisplayText,
   sanitizeLogText,
-  sanitizePromptText,
-  truncateCodePoints,
 } from '@qwen-code/channel-base';
 import { testBotMention, stripBotMention } from './mention.js';
 
@@ -1419,7 +1417,6 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         ? await this.fetchPrMeta(ctx)
         : await this.fetchIssueMeta(ctx);
     const title = meta.title || ctx.subjectTitle;
-    const displayTitle = truncateCodePoints(sanitizePromptText(title), 500);
     const details =
       reason === 'review_requested'
         ? `Author: ${meta.user?.login || 'unknown'} | State: ${meta.state || 'unknown'} | Draft: ${meta.draft ? 'true' : 'false'} | Branch: ${meta.head?.ref || 'unknown'} → ${meta.base?.ref || 'unknown'}`
@@ -1437,10 +1434,6 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
         reason === 'review_requested'
           ? 'Return a formal review summary with verified actionable findings, or a concise no-blocker result.'
           : 'Triage this issue and respond with the next action.',
-      displayText:
-        reason === 'review_requested'
-          ? `Review requested: ${displayTitle}`
-          : `Issue assigned: ${displayTitle}`,
       isGroup: true,
       isMentioned: true,
       isReplyToBot: false,
@@ -1491,7 +1484,6 @@ export class GithubChannel extends PollingChannelBase<GithubCursor> {
       threadId: ctx.threadId,
       messageId: String(first.id),
       text: `Review these new comments and output exactly ${NO_REPLY_SENTINEL} if no public reply is needed:\n${summary}`,
-      displayText: summary,
       isGroup: true,
       isMentioned: true,
       isReplyToBot: false,

--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -2443,7 +2443,6 @@ export class QQChannel extends ChannelBase {
     cleanText: string;
     commandText: string;
     text: string;
-    displayText: string;
     senderName: string;
   } | null {
     // Keep identity values out of the display-name position. In particular,
@@ -2556,12 +2555,12 @@ export class QQChannel extends ChannelBase {
         ? `(${truncateCodePoints(sanitizeSenderName(senderIdentity), 8)}…)`
         : '';
     const head = `[atMention=${effectiveIsAtBot}]${openIdSuffix} [${safeName}${senderTag}]: `;
-    const displayText = sanitizePromptText(
+    const body = sanitizePromptText(
       this.qqConfig.allowMention !== false ? safeDisplayText : safeCleanText,
     );
     const text = isSlash
       ? sanitizePromptText(safeCleanText)
-      : `${head}${displayText}${suffixFromBotOpenId}`;
+      : `${head}${body}${suffixFromBotOpenId}`;
 
     return {
       isAtBot: effectiveIsAtBot,
@@ -2570,7 +2569,6 @@ export class QQChannel extends ChannelBase {
       cleanText,
       commandText,
       text,
-      displayText,
       senderName,
     };
   }
@@ -2612,17 +2610,14 @@ export class QQChannel extends ChannelBase {
       .replace(/\[botOpenId:[^\]]*]/g, '')
       .replace(/\[bot]/g, '');
     const isSlash = safeContent.startsWith('/');
-    const displayText = sanitizePromptText(safeContent);
-    const text = isSlash
-      ? displayText
-      : `[atMention=true] [${safeName}]: ${displayText}`;
+    const body = sanitizePromptText(safeContent);
+    const text = isSlash ? body : `[atMention=true] [${safeName}]: ${body}`;
     this.handleInbound({
       channelName: this.name,
       senderId: chatId,
       senderName,
       chatId,
       text,
-      displayText,
       messageId: event.id,
       isGroup: false,
       isMentioned: true,
@@ -2675,8 +2670,7 @@ export class QQChannel extends ChannelBase {
       forceAtMention: true,
     });
     if (!result) return;
-    const { isSlash, text, displayText, commandText, senderName, safeName } =
-      result;
+    const { isSlash, text, commandText, senderName, safeName } = result;
 
     // Deduplicate before handleInbound — prepareGroupMessage already ran
     // so side effects (extractBotOpenId) are applied regardless of dedup.
@@ -2710,7 +2704,6 @@ export class QQChannel extends ChannelBase {
       senderName,
       chatId,
       text,
-      displayText,
       messageId: event.id,
       isGroup: true,
       isMentioned: true,
@@ -2756,15 +2749,8 @@ export class QQChannel extends ChannelBase {
 
     const result = this.prepareGroupMessage(event, chatId);
     if (!result) return;
-    const {
-      isSlash,
-      text,
-      displayText,
-      commandText,
-      senderName,
-      isAtBot,
-      safeName,
-    } = result;
+    const { isSlash, text, commandText, senderName, isAtBot, safeName } =
+      result;
 
     // @-bot messages always pass through (passive reply).
     // Non-@-bot messages are subject to active-message and keyword policies.
@@ -2862,7 +2848,6 @@ export class QQChannel extends ChannelBase {
       channelName: this.name,
       chatId,
       text,
-      displayText,
       senderId,
       senderName,
       messageId: event.id,

--- a/packages/channels/qqbot/src/events.test.ts
+++ b/packages/channels/qqbot/src/events.test.ts
@@ -291,7 +291,6 @@ describe('handleC2C', () => {
     expect(env['senderId']).toBe('user-openid-1');
     expect(env['chatId']).toBe('user-openid-1');
     expect(env['text']).toBe('[atMention=true] [Alice]: 你好，帮我查一下天气');
-    expect(env['displayText']).toBe('你好，帮我查一下天气');
   });
 
   it('斜杠命令不包装 atMention', async () => {
@@ -427,7 +426,6 @@ describe('handleGroup', () => {
     expect(env['text']).toBe(
       '[atMention=true] [Bob(ABCDEF0123456789ABCDEF0123456789)]: 你好',
     );
-    expect(env['displayText']).toBe('你好');
   });
 
   it('可见文本只移除机器人 mention', async () => {
@@ -445,7 +443,7 @@ describe('handleGroup', () => {
     await vi.advanceTimersByTimeAsync(600);
 
     const env = mockHandleInbound.mock.calls[0][0] as Record<string, unknown>;
-    expect(env['displayText']).toBe('ask <@OPENID_ALICE> now');
+    expect(env['text']).toContain(']: ask <@OPENID_ALICE> now');
   });
 
   it('allowMention=false 时清理 <@OPENID> 标签', async () => {
@@ -556,8 +554,9 @@ describe('handleGroup', () => {
     await vi.advanceTimersByTimeAsync(600);
 
     const env = mockHandleInbound.mock.calls[0][0] as unknown as Envelope;
-    expect(env.displayText).toBe('<@OPENID_OTHER>  please review hello');
-    expect(env.text.split(env.displayText!)).toHaveLength(3);
+    expect(env.text.split('<@OPENID_OTHER>  please review hello')).toHaveLength(
+      3,
+    );
     expect(env.text).toContain('[atMention=');
     expect(env.text).toContain('[<@OPENID_OTHER>  please review hello(');
     expect(env.text).toContain(
@@ -603,7 +602,6 @@ describe('handleGroup', () => {
     await vi.advanceTimersByTimeAsync(600);
     const env = mockHandleInbound.mock.calls[0][0] as Record<string, unknown>;
     expect(env['text']).toBe('/schedule list');
-    expect(env['displayText']).toBe('<@OPENID_ALICE> /schedule list');
   });
 
   it('重复消息不触发', async () => {
@@ -1170,7 +1168,7 @@ describe('handleGroupAll', () => {
     const env = mockHandleInbound.mock.calls[0][0] as Record<string, unknown>;
     expect(env['isGroup']).toBe(true);
     expect(env['text']).toContain('[atMention=false]');
-    expect(env['displayText']).toBe('hello world');
+    expect(env['text']).toContain(']: hello world');
   });
 
   it('policy=keyword 时只有匹配关键词才触发', async () => {

--- a/packages/channels/qqbot/src/send.test.ts
+++ b/packages/channels/qqbot/src/send.test.ts
@@ -438,7 +438,6 @@ describe('group sender-name sanitization', () => {
 
     const env = inbound.mock.calls[0][0] as Envelope;
     expect(env.text).toBe('/clear');
-    expect(env.displayText).toBe('<@OPENID_OTHER> /clear');
   });
 
   it('keeps a sanitizer-shaped group command as attributed prose', () => {


### PR DESCRIPTION
## What this PR does

Channel turns in CLI resume, Web Shell and session previews now show exactly the prompt the model received. Every channel prompt path — ordinary inbound messages, coalesced collect-mode follow-ups, loop jobs and webhook tasks — sends the delivered model prompt as its display projection, with only the controls that can reorder or hide rendered text neutralized and no length cap. The adapter-level display override (`Envelope.displayText`, previously set by GitHub, dws and QQ) and the webhook display builder are removed because nothing reads them any more.

## Why it's needed

The transcript used to record a separate, shorter projection: the raw message body, or an adapter-chosen summary. Operators opening a channel session to understand or debug a turn could not see the recalled memory, operator instructions, backfilled group history, sender attribution, reply context, attachment paths or adapter metadata that actually drove the reply. The design decision to show the delivered prompt is recorded in #11645; this replaces #11638, whose earlier revision capped the display at 8000 code points (cutting off the current message behind injected context) and left the adapter overrides as dead code.

## Reviewer Test Plan

### How to verify

Configure a channel with `instructions`, channel memory and group history backfill, send a group message with a reply or attachment, and open the session in CLI resume or Web Shell: the user turn should be byte-for-byte the prompt sent to the model (control characters aside), including every injected block in delivery order. Repeat with a message long enough to exceed 8000 characters and confirm the tail is not cut. For scheduled loops and webhook tasks, confirm the turn shows the unattended-run wrapper, not only the task text.

Unit coverage, run locally:

```
packages/channels/base   vitest ChannelBase / sanitize / AcpBridge / DaemonChannelBridge   908 passed
packages/channels/github vitest                                                          209 passed
packages/channels/qqbot  vitest                                                          311 passed
packages/channels/dws    vitest                                                          377 passed
tsc --noEmit (base, github, qqbot, dws) and eslint on changed files: clean
```

The updated assertions pin `displayText` to the model prompt for the inbound context test, the memory-recall ordering test, the collect-mode coalesce test, `runWebhookTask`, and both loop prompt tests, plus an uncapped 9013-code-point prompt with neutralized bidi/C0 controls.

### Evidence (Before & After)

Display text recorded for the same turn, taken from the test fixtures:

| Turn | Before | After |
| --- | --- | --- |
| Group message with instructions, reply, attachment and metadata | `hello` | the full model prompt: instructions, boundary prompt, `[User 1] hello`, reply context, attachment path, metadata |
| Collect-mode coalesced follow-up | `[Alice] second` / `[Bob] third` | both attributed messages together with their `hidden policy …` metadata, identical to the model prompt |
| Webhook task | `CI failed` | `[External event "ci_failed" from github-ci]` followed by the unattended-run instructions, title and payload |
| Loop job | `post summary` | `[Loop "daily summary" created by Alice] Scheduled task running unattended: …` followed by `post summary` |
| 9000+ character message | truncated to 8000 code points | full 9013 code points, controls replaced |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: operator instructions, recalled channel memory and adapter metadata (for example the GitHub publication policy and the `<no-reply/>` sentinel, or QQ's `[atMention=…]` prefix) are now visible to anyone who can open the session in Web Shell or CLI resume. Those readers already have access to the recorded model message for the same session, so this closes a presentation gap rather than widening access. Session-list previews and generated titles now derive from the full prompt, so a session's first preview may start with channel instructions or memory instead of the user's words.
- Not validated / out of scope: no live channel run on any OS; macOS and Windows not run locally. Existing transcript records are not rewritten.
- Breaking changes / migration notes: `Envelope.displayText` and `buildChannelWebhookDisplayText` are removed from `@qwen-code/channel-base`; in-repo adapters are updated, and an out-of-tree adapter that set the field gets a type error and should drop it. `sanitizeDisplayText`'s length cap is now optional; existing callers are unchanged.

## Linked Issues

Closes #11645

Supersedes #11638

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

CLI resume、Web Shell 与会话预览中的 Channel 轮次，现在完整展示模型实际收到的 prompt。所有 Channel prompt 路径——普通入站消息、collect 模式合并后的追问、loop 任务和 webhook 任务——都把实际投递的模型 prompt 作为展示投影发送，只清理会重排或隐藏渲染文本的控制字符，且不截断长度。适配器层的展示覆盖（`Envelope.displayText`，此前由 GitHub、dws、QQ 设置）以及 webhook 展示构造函数已不再被读取，一并删除。

## 为什么需要

以前会话记录保存的是另一份更短的投影：原始消息正文，或适配器自选的摘要。运营者打开 Channel 会话理解或排查某一轮时，看不到实际驱动回复的召回记忆、运营者指令、补入的群聊历史、发送者标识、回复上下文、附件路径和适配器 metadata。"展示实际投递的 prompt"这一设计决定记录在 #11645；本 PR 取代 #11638——那个 PR 的早期版本把展示文本截断在 8000 码点（会把当前消息挤掉在注入的上下文之后），并把适配器覆盖留成了死代码。

## Reviewer Test Plan

### 如何验证

为 Channel 配置 `instructions`、Channel Memory 和群聊历史补录，发送一条带回复或附件的群聊消息，然后在 CLI resume 或 Web Shell 中打开该会话：用户消息应与发送给模型的 prompt 逐字一致（控制字符除外），并按投递顺序包含每个注入块。再发送一条超过 8000 字符的消息，确认结尾没有被截断。对定时 loop 和 webhook 任务，确认展示的是带无人值守包装说明的完整 prompt，而不只是任务文本。

本地运行的单元测试：

```
packages/channels/base   vitest ChannelBase / sanitize / AcpBridge / DaemonChannelBridge   908 通过
packages/channels/github vitest                                                          209 通过
packages/channels/qqbot  vitest                                                          311 通过
packages/channels/dws    vitest                                                          377 通过
tsc --noEmit（base、github、qqbot、dws）与改动文件的 eslint：无报错
```

更新后的断言把 `displayText` 固定为模型 prompt，覆盖入站上下文测试、Memory 召回顺序测试、collect 模式合并测试、`runWebhookTask` 和两个 loop prompt 测试，另有一个不截断的 9013 码点 prompt（bidi 与 C0 控制字符已清理）。

### Before 与 After 证据

同一轮记录下的展示文本，取自测试用例：

| 轮次 | Before | After |
| --- | --- | --- |
| 带指令、回复、附件和 metadata 的群聊消息 | `hello` | 完整模型 prompt：指令、boundary prompt、`[User 1] hello`、回复上下文、附件路径、metadata |
| collect 模式合并后的追问 | `[Alice] second` / `[Bob] third` | 两条带发送者标识的消息及其 `hidden policy …` metadata，与模型 prompt 一致 |
| webhook 任务 | `CI failed` | `[External event "ci_failed" from github-ci]` 加无人值守运行说明、标题和 payload |
| loop 任务 | `post summary` | `[Loop "daily summary" created by Alice] Scheduled task running unattended: …` 加 `post summary` |
| 9000+ 字符消息 | 截断为 8000 码点 | 完整 9013 码点，控制字符已替换 |

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

N/A，仅单元测试。

## 风险与范围

- 主要风险或取舍：运营者指令、召回的 Channel Memory 和适配器 metadata（例如 GitHub 的发布策略与 `<no-reply/>` 标记，或 QQ 的 `[atMention=…]` 前缀）现在对任何能在 Web Shell 或 CLI resume 打开该会话的人可见。这些读者本来就能访问同一会话记录的模型消息，因此这是消除展示层差异，而非扩大访问范围。会话列表预览和自动生成的标题现在基于完整 prompt，会话首条预览可能以 Channel 指令或记忆开头，而不是用户原话。
- 未验证或超出范围：未在任何系统上做真实 Channel 运行；macOS 与 Windows 未在本地运行。已有会话记录不改写。
- Breaking change 或迁移说明：`@qwen-code/channel-base` 移除了 `Envelope.displayText` 与 `buildChannelWebhookDisplayText`；仓库内适配器已同步修改，仓库外设置该字段的适配器会出现类型错误，删除该字段即可。`sanitizeDisplayText` 的长度上限改为可选，现有调用方不受影响。

## 关联 Issue

Closes #11645

取代 #11638

</details>
