### PR TITLE
fix(cli): resolve ACP core settings against the active target dir

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2285,6 +2285,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getDisableAllHooks: vi.fn().mockReturnValue(false),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
       getModel: vi.fn().mockReturnValue('test-model'),
+      getTargetDir: vi.fn().mockReturnValue('/tmp'),
       getModelsConfig: vi.fn().mockReturnValue({
         getCurrentAuthType: vi.fn().mockReturnValue('api-key'),
         syncAfterAuthRefresh: vi.fn(),
@@ -17460,6 +17461,40 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }) as AgentLike;
     return { agent, agentPromise };
   }
+
+  it('qwen/settings getCore and setCoreValue resolve the active target dir when cwd is omitted', async () => {
+    const settings = makeCoreSettings();
+    vi.mocked(loadSettings).mockReturnValue(settings);
+    vi.mocked(mockConfig.getTargetDir).mockReturnValue('/worktree/.qwen');
+    const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.extMethod('qwen/settings/getCore', {});
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      '/worktree/.qwen',
+    );
+
+    await agent.extMethod('qwen/settings/setCoreValue', {
+      scope: 'workspace',
+      key: 'model.name',
+      value: 'qwen3.7-max',
+    });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      '/worktree/.qwen',
+    );
+
+    // An explicit cwd still wins over the target dir.
+    await agent.extMethod('qwen/settings/getCore', { cwd: '/explicit' });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith('/explicit');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
 
   it('qwen/permissions/getSettings returns user workspace merged and trust state', async () => {
     const settings = makeCoreSettings();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17485,7 +17485,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agent.extMethod('qwen/settings/getCore', {
       sessionId: 'worktree-session',
     });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      worktreeRoot,
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
     expect(vi.mocked(ExtensionManager)).toHaveBeenLastCalledWith(
       expect.objectContaining({ workspaceDir: worktreeRoot }),
     );
@@ -17496,7 +17502,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       key: 'model.name',
       value: 'qwen3.7-max',
     });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      worktreeRoot,
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
 
     await agent.extMethod('qwen/settings/setMcpServer', {
       sessionId: 'worktree-session',
@@ -17508,7 +17520,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         versionNegotiation: 'auto',
       },
     });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      worktreeRoot,
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
 
     await agent.extMethod('qwen/settings/setHook', {
       sessionId: 'worktree-session',
@@ -17516,7 +17534,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       event: 'PreToolUse',
       hook: { hooks: [{ type: 'command', command: 'echo hi' }] },
     });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      worktreeRoot,
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
 
     // getMemoryPaths must resolve through the same helper as getMemory /
     // setMemory, so the project memory file points at the worktree rather
@@ -17530,7 +17554,38 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     // An explicit cwd still wins over the session target dir.
     await agent.extMethod('qwen/settings/getCore', { cwd: '/explicit' });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith('/explicit');
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      '/explicit',
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/permissions/setRules rejects an unresolvable sessionId instead of retargeting the bootstrap workspace', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    // An unknown, not-yet-published or already-removed session must fail loud:
+    // falling back to the daemon's bootstrap workspace would silently persist a
+    // workspace-scoped rule into a workspace the caller never selected.
+    vi.mocked(loadSettings).mockClear();
+    await expect(
+      agent.extMethod('qwen/permissions/setRules', {
+        sessionId: 'missing-session',
+        scope: 'workspace',
+        ruleType: 'allow',
+        rules: ['Bash(git:*)'],
+      }),
+    ).rejects.toMatchObject({
+      code: -32004,
+      data: { errorKind: 'session_not_found' },
+    });
+    expect(vi.mocked(loadSettings)).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17518,6 +17518,16 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
 
+    // getMemoryPaths must resolve through the same helper as getMemory /
+    // setMemory, so the project memory file points at the worktree rather
+    // than the daemon's boot directory.
+    const memoryPaths = (await agent.extMethod('qwen/settings/getMemoryPaths', {
+      sessionId: 'worktree-session',
+    })) as { paths: { projectMemoryFile: string } };
+    expect(memoryPaths.paths.projectMemoryFile).toBe(
+      path.join(worktreeRoot, 'QWEN.md'),
+    );
+
     // An explicit cwd still wins over the session target dir.
     await agent.extMethod('qwen/settings/getCore', { cwd: '/explicit' });
     expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith('/explicit');

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17464,6 +17464,28 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     return { agent, agentPromise };
   }
 
+  it('qwen/settings getCore resolves the bootstrap target dir when cwd and sessionId are omitted', async () => {
+    const settings = makeCoreSettings();
+    // The no-sessionId fallback is the branch every in-repo caller actually
+    // takes (`serve/workspace-service/index.ts` sends `cwd` and no
+    // `sessionId`). Pin it with a distinct target dir so a revert to
+    // `process.cwd()` goes red.
+    vi.mocked(mockConfig.getTargetDir).mockReturnValue('/boot-workspace-pin');
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/getCore', {});
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      '/boot-workspace-pin',
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('qwen/settings handlers resolve the active session target dir when cwd is omitted', async () => {
     const settings = makeCoreSettings();
     const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
@@ -17575,7 +17597,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   it('does not repoint the process-wide settings cache for a session-scoped read', async () => {
     const bootstrapSettings = makeCoreSettings();
     const worktreeSettings = makeCoreSettings();
-    const { agent, agentPromise } = await bootCoreSettingsAgent(bootstrapSettings);
+    const { agent, agentPromise } =
+      await bootCoreSettingsAgent(bootstrapSettings);
 
     const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
     vi.mocked(loadSettings).mockImplementation(
@@ -17604,9 +17627,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     // A bare sessionId read must stay request-local: the process-wide cache
     // (read by workspaceReload / getPath / workspace status) must still hold
     // the bootstrap workspace's instance, not the worktree's.
-    expect(
-      (agent as unknown as { settings: LoadedSettings }).settings,
-    ).toBe(bootstrapSettings);
+    expect((agent as unknown as { settings: LoadedSettings }).settings).toBe(
+      bootstrapSettings,
+    );
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -17685,6 +17708,51 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       code: -32004,
       data: { errorKind: 'session_not_found' },
     });
+    expect(vi.mocked(loadSettings)).not.toHaveBeenCalled();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/getCore honors an explicit cwd over an unresolvable sessionId', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    // A request that names its workspace explicitly must resolve against that
+    // cwd even when the sessionId is stale/unpublished; the sessionId lookup is
+    // only needed when cwd is absent.
+    await agent.extMethod('qwen/settings/getCore', {
+      cwd: '/explicit',
+      sessionId: 'missing-session',
+    });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
+      '/explicit',
+      expect.objectContaining({
+        consumeCorruptionEnvVars: true,
+        skipLoadEnvironment: true,
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/permissions/setRules rejects a malformed sessionId instead of silently retargeting the bootstrap workspace', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    // A present-but-malformed sessionId is a caller error, not "absent":
+    // treating it as absent would persist against the daemon's bootstrap
+    // workspace while the caller believes it addressed a specific session.
+    vi.mocked(loadSettings).mockClear();
+    await expect(
+      agent.extMethod('qwen/permissions/setRules', {
+        sessionId: 12345,
+        scope: 'workspace',
+        ruleType: 'allow',
+        rules: ['Bash(git:*)'],
+      }),
+    ).rejects.toThrow('Invalid sessionId: expected a non-empty string');
     expect(vi.mocked(loadSettings)).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1138,6 +1138,7 @@ import type {
   NewSessionResponse,
 } from '@agentclientprotocol/sdk';
 import { AgentSideConnection, RequestError } from '@agentclientprotocol/sdk';
+import { ExtensionManager } from '@qwen-code/qwen-code-core';
 import {
   loadSettings,
   reloadEnvironment,
@@ -17462,33 +17463,61 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     return { agent, agentPromise };
   }
 
-  it('qwen/settings getCore and setCoreValue resolve the active target dir when cwd is omitted', async () => {
+  it('qwen/settings handlers resolve the active session target dir when cwd is omitted', async () => {
     const settings = makeCoreSettings();
-    vi.mocked(loadSettings).mockReturnValue(settings);
-    vi.mocked(mockConfig.getTargetDir).mockReturnValue('/worktree/.qwen');
-    const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
-    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
-    const agent = capturedAgentFactory!({
-      get closed() {
-        return mockConnectionState.promise;
-      },
-    }) as AgentLike;
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
 
-    await agent.extMethod('qwen/settings/getCore', {});
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
-      '/worktree/.qwen',
+    // The bootstrap Config stays at the project root (`mockConfig`); the
+    // requesting session's own Config points at a worktree.
+    const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
+    (agent as unknown as { sessions: Map<string, unknown> }).sessions.set(
+      'worktree-session',
+      {
+        getId: () => 'worktree-session',
+        getConfig: () => ({
+          ...mockConfig,
+          getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+        }),
+      },
+    );
+
+    await agent.extMethod('qwen/settings/getCore', {
+      sessionId: 'worktree-session',
+    });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+    expect(vi.mocked(ExtensionManager)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ workspaceDir: worktreeRoot }),
     );
 
     await agent.extMethod('qwen/settings/setCoreValue', {
+      sessionId: 'worktree-session',
       scope: 'workspace',
       key: 'model.name',
       value: 'qwen3.7-max',
     });
-    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(
-      '/worktree/.qwen',
-    );
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
 
-    // An explicit cwd still wins over the target dir.
+    await agent.extMethod('qwen/settings/setMcpServer', {
+      sessionId: 'worktree-session',
+      scope: 'workspace',
+      name: 'local',
+      server: {
+        transport: 'stdio',
+        command: 'node',
+        versionNegotiation: 'auto',
+      },
+    });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+
+    await agent.extMethod('qwen/settings/setHook', {
+      sessionId: 'worktree-session',
+      scope: 'workspace',
+      event: 'PreToolUse',
+      hook: { hooks: [{ type: 'command', command: 'echo hi' }] },
+    });
+    expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith(worktreeRoot);
+
+    // An explicit cwd still wins over the session target dir.
     await agent.extMethod('qwen/settings/getCore', { cwd: '/explicit' });
     expect(vi.mocked(loadSettings)).toHaveBeenLastCalledWith('/explicit');
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1077,12 +1077,12 @@ import {
   selectVisibleHistoryRecords,
   createManagedExternalToolGuard,
 } from './acpAgent.js';
-import type { Config, GoalSnapshotV2 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../config/settings.js';
 import type { CliArgs } from '../config/config.js';
 import {
   AuthType,
   BranchPointInvalidError,
+  ExtensionManager,
   SessionEndReason,
   MCPServerConfig,
   SessionService,
@@ -1120,6 +1120,8 @@ import {
   GoalInvalidTransitionError,
   sessionIdContext,
   uiTelemetryService,
+  type Config,
+  type GoalSnapshotV2,
 } from '@qwen-code/qwen-code-core';
 import { ndJsonStream } from '@qwen-code/acp-bridge/ndJsonStream';
 import {
@@ -1138,7 +1140,6 @@ import type {
   NewSessionResponse,
 } from '@agentclientprotocol/sdk';
 import { AgentSideConnection, RequestError } from '@agentclientprotocol/sdk';
-import { ExtensionManager } from '@qwen-code/qwen-code-core';
 import {
   loadSettings,
   reloadEnvironment,

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17655,7 +17655,12 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getId: () => 'worktree-session',
       getConfig: () => ({
         ...mockConfig,
-        getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+        // The requesting session has `session/cd`-ed into a subdirectory:
+        // its live cwd differs from its admission root. The workspace filter
+        // must key on the stable admission root (`storage.getProjectRoot()`),
+        // not the live `getTargetDir()`, or the requesting session would be
+        // skipped by its own fan-out.
+        getTargetDir: vi.fn().mockReturnValue(`${worktreeRoot}/packages/core`),
         storage: { getProjectRoot: () => worktreeRoot },
         getPermissionManager: () => requestingPm,
       }),
@@ -17684,6 +17689,64 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     );
     expect(otherPm.addPersistentRule).not.toHaveBeenCalled();
     expect(otherPm.removePersistentRule).not.toHaveBeenCalled();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('a user-scoped setRules delta still fans out daemon-wide across workspaces', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
+    const otherRoot = '/work/project';
+    const requestingPm = {
+      addPersistentRule: vi.fn(),
+      removePersistentRule: vi.fn(),
+    };
+    const otherPm = {
+      addPersistentRule: vi.fn(),
+      removePersistentRule: vi.fn(),
+    };
+    const sessions = (agent as unknown as { sessions: Map<string, unknown> })
+      .sessions;
+    sessions.set('worktree-session', {
+      getId: () => 'worktree-session',
+      getConfig: () => ({
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+        storage: { getProjectRoot: () => worktreeRoot },
+        getPermissionManager: () => requestingPm,
+      }),
+    });
+    sessions.set('other-session', {
+      getId: () => 'other-session',
+      getConfig: () => ({
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue(otherRoot),
+        storage: { getProjectRoot: () => otherRoot },
+        getPermissionManager: () => otherPm,
+      }),
+    });
+
+    await agent.extMethod('qwen/permissions/setRules', {
+      sessionId: 'worktree-session',
+      scope: 'user',
+      ruleType: 'allow',
+      rules: ['Bash(git push:*)'],
+    });
+
+    // User scope is genuinely process-wide: the delta must reach the other
+    // workspace's live manager too, so removing the Workspace guard from the
+    // filter (making it unconditional) turns this red.
+    expect(requestingPm.addPersistentRule).toHaveBeenCalledWith(
+      'Bash(git push:*)',
+      'allow',
+    );
+    expect(otherPm.addPersistentRule).toHaveBeenCalledWith(
+      'Bash(git push:*)',
+      'allow',
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17469,7 +17469,10 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
 
     // The bootstrap Config stays at the project root (`mockConfig`); the
-    // requesting session's own Config points at a worktree.
+    // requesting session's own Config points at a worktree. Its live cwd has
+    // moved into a subdirectory (post `session/cd`), but its bound storage
+    // still resolves the admission worktree root — that stable root, not the
+    // live cwd, is what the handlers must load settings for.
     const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
     (agent as unknown as { sessions: Map<string, unknown> }).sessions.set(
       'worktree-session',
@@ -17477,7 +17480,10 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         getId: () => 'worktree-session',
         getConfig: () => ({
           ...mockConfig,
-          getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+          getTargetDir: vi
+            .fn()
+            .mockReturnValue(`${worktreeRoot}/packages/core`),
+          storage: { getProjectRoot: () => worktreeRoot },
         }),
       },
     );
@@ -17561,6 +17567,100 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         skipLoadEnvironment: true,
       }),
     );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('does not repoint the process-wide settings cache for a session-scoped read', async () => {
+    const bootstrapSettings = makeCoreSettings();
+    const worktreeSettings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(bootstrapSettings);
+
+    const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
+    vi.mocked(loadSettings).mockImplementation(
+      (cwd) =>
+        (path.resolve(cwd ?? '') === path.resolve(worktreeRoot)
+          ? worktreeSettings
+          : bootstrapSettings) as LoadedSettings,
+    );
+
+    (agent as unknown as { sessions: Map<string, unknown> }).sessions.set(
+      'worktree-session',
+      {
+        getId: () => 'worktree-session',
+        getConfig: () => ({
+          ...mockConfig,
+          getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+          storage: { getProjectRoot: () => worktreeRoot },
+        }),
+      },
+    );
+
+    await agent.extMethod('qwen/settings/getCore', {
+      sessionId: 'worktree-session',
+    });
+
+    // A bare sessionId read must stay request-local: the process-wide cache
+    // (read by workspaceReload / getPath / workspace status) must still hold
+    // the bootstrap workspace's instance, not the worktree's.
+    expect(
+      (agent as unknown as { settings: LoadedSettings }).settings,
+    ).toBe(bootstrapSettings);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('does not fan out a workspace-scoped setRules delta to sessions in other workspaces', async () => {
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    const worktreeRoot = '/work/project/.qwen/worktrees/slug-a';
+    const otherRoot = '/work/project';
+    const requestingPm = {
+      addPersistentRule: vi.fn(),
+      removePersistentRule: vi.fn(),
+    };
+    const otherPm = {
+      addPersistentRule: vi.fn(),
+      removePersistentRule: vi.fn(),
+    };
+    const sessions = (agent as unknown as { sessions: Map<string, unknown> })
+      .sessions;
+    sessions.set('worktree-session', {
+      getId: () => 'worktree-session',
+      getConfig: () => ({
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue(worktreeRoot),
+        storage: { getProjectRoot: () => worktreeRoot },
+        getPermissionManager: () => requestingPm,
+      }),
+    });
+    sessions.set('other-session', {
+      getId: () => 'other-session',
+      getConfig: () => ({
+        ...mockConfig,
+        getTargetDir: vi.fn().mockReturnValue(otherRoot),
+        storage: { getProjectRoot: () => otherRoot },
+        getPermissionManager: () => otherPm,
+      }),
+    });
+
+    await agent.extMethod('qwen/permissions/setRules', {
+      sessionId: 'worktree-session',
+      scope: 'workspace',
+      ruleType: 'allow',
+      rules: ['Bash(git push:*)'],
+    });
+
+    // The requesting session's manager is synced; the other workspace's is not.
+    expect(requestingPm.addPersistentRule).toHaveBeenCalledWith(
+      'Bash(git push:*)',
+      'allow',
+    );
+    expect(otherPm.addPersistentRule).not.toHaveBeenCalled();
+    expect(otherPm.removePersistentRule).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6463,6 +6463,25 @@ class QwenAgent implements Agent {
     return this.settings;
   }
 
+  /**
+   * Resolve the workspace root for the `qwen/settings/*` + `qwen/permissions/*`
+   * handlers. The requesting session relocates *its own* Config (not the
+   * daemon's bootstrap `this.config`), so `session.getConfig().getTargetDir()`
+   * points at a worktree while `process.cwd()` stays pinned to the daemon's
+   * boot workspace. Falls back to the bootstrap Config when the client sends no
+   * `sessionId`, matching the previous `process.cwd()` behaviour for
+   * non-session-scoped calls.
+   */
+  private settingsCwdFor(
+    requestedCwd: string | undefined,
+    params: Record<string, unknown>,
+  ): string {
+    const sessionId = params['sessionId'] as string | undefined;
+    const session = sessionId ? this.sessions.get(sessionId) : undefined;
+    const config = session ? session.getConfig() : this.config;
+    return requestedCwd || config.getTargetDir();
+  }
+
   private async buildCoreSettings(
     settings: LoadedSettings,
     cwd: string,
@@ -8941,7 +8960,8 @@ class QwenAgent implements Agent {
         return setManagedSkillEnabled(this.config, params, requestedCwd);
       }
       case 'qwen/settings/getMemory': {
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         this.settings = settings;
         return {
           settings: normalizeQwenMemorySettings(settings.merged.memory),
@@ -8952,7 +8972,8 @@ class QwenAgent implements Agent {
         // Mutate a freshly loaded settings object and adopt it, mirroring the
         // other settings mutation handlers, instead of writing through the
         // possibly-stale cached `this.settings` and reading it back.
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         for (const key of QWEN_MEMORY_SETTING_KEYS) {
           if (updates[key] === undefined) continue;
           if (typeof updates[key] !== 'boolean') {
@@ -13346,7 +13367,7 @@ class QwenAgent implements Agent {
         return { newSessionId, title, displayName: title };
       }
       case 'qwen/settings/getCore': {
-        const settingsCwd = requestedCwd || this.config.getTargetDir();
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
         const settings = loadSettings(settingsCwd);
         this.settings = settings;
         return this.buildCoreSettings(settings, settingsCwd);
@@ -13362,7 +13383,7 @@ class QwenAgent implements Agent {
             'Unsupported Qwen setting key',
           );
         }
-        const settingsCwd = requestedCwd || this.config.getTargetDir();
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
         const settings = loadSettings(settingsCwd);
         const settingKey = key as QwenCoreSettingKey;
         const normalizedValue = normalizeCoreSettingValue(
@@ -13403,7 +13424,8 @@ class QwenAgent implements Agent {
             'MCP server name is required',
           );
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13422,7 +13444,7 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/removeMcpServer': {
         const name = params['name'];
@@ -13432,7 +13454,8 @@ class QwenAgent implements Agent {
             'MCP server name is required',
           );
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13443,14 +13466,15 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setHook': {
         const event = params['event'];
         if (!isHookEvent(event)) {
           throw RequestError.invalidParams(undefined, 'Invalid hook event');
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13490,7 +13514,7 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/removeHook': {
         const event = params['event'];
@@ -13505,7 +13529,8 @@ class QwenAgent implements Agent {
         ) {
           throw RequestError.invalidParams(undefined, 'Invalid hook index');
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13526,7 +13551,7 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setExtensionSetting': {
         const extensionId = params['extensionId'];
@@ -13544,9 +13569,10 @@ class QwenAgent implements Agent {
         if (typeof value !== 'string') {
           throw RequestError.invalidParams(undefined, 'value must be a string');
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = loadSettings(settingsCwd);
         const extensionManager = new ExtensionManager({
-          workspaceDir: cwd,
+          workspaceDir: settingsCwd,
           isWorkspaceTrusted:
             isWorkspaceTrusted(settings.merged).isTrusted ?? true,
           locale: getCurrentLanguage(),
@@ -13574,10 +13600,11 @@ class QwenAgent implements Agent {
         // so `settings` here is just the snapshot loaded above and is reused to
         // build the response.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/permissions/getSettings': {
-        const settings = this.loadPermissionSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = this.loadPermissionSettings(settingsCwd);
         return buildPermissionSettings(settings) as unknown as Record<
           string,
           unknown
@@ -13599,7 +13626,8 @@ class QwenAgent implements Agent {
           );
         }
 
-        const settings = this.loadPermissionSettings(cwd);
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
+        const settings = this.loadPermissionSettings(settingsCwd);
         const before = readPermissionRuleSet(settings.merged);
         const settingScope =
           scope === 'workspace' ? SettingScope.Workspace : SettingScope.User;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -13346,9 +13346,10 @@ class QwenAgent implements Agent {
         return { newSessionId, title, displayName: title };
       }
       case 'qwen/settings/getCore': {
-        const settings = loadSettings(cwd);
+        const settingsCwd = requestedCwd || this.config.getTargetDir();
+        const settings = loadSettings(settingsCwd);
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setCoreValue': {
         const key = params['key'];
@@ -13361,7 +13362,8 @@ class QwenAgent implements Agent {
             'Unsupported Qwen setting key',
           );
         }
-        const settings = loadSettings(cwd);
+        const settingsCwd = requestedCwd || this.config.getTargetDir();
+        const settings = loadSettings(settingsCwd);
         const settingKey = key as QwenCoreSettingKey;
         const normalizedValue = normalizeCoreSettingValue(
           settingKey,
@@ -13391,7 +13393,7 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setMcpServer': {
         const name = params['name'];

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6459,30 +6459,54 @@ class QwenAgent implements Agent {
   }
 
   private loadPermissionSettings(cwd: string): LoadedSettings {
-    this.settings = loadSettings(cwd);
+    this.settings = this.loadRequestSettings(cwd);
     return this.settings;
   }
 
   /**
+   * Load settings for a single `qwen/settings/*` / `qwen/permissions/*`
+   * request. `skipLoadEnvironment` is set because a per-request read — and, for
+   * session-scoped calls, a foreign-workspace read — must not inject that
+   * workspace's `.env` into the daemon's process-wide `process.env`; env
+   * application stays with the daemon-global reload handlers that call
+   * `reloadEnvironment` deliberately. `consumeCorruptionEnvVars` is stated
+   * explicitly because passing an options object replaces `loadSettings`'s
+   * `= true` default.
+   */
+  private loadRequestSettings(settingsCwd: string): LoadedSettings {
+    return loadSettings(settingsCwd, {
+      consumeCorruptionEnvVars: true,
+      skipLoadEnvironment: true,
+    });
+  }
+
+  /**
    * Resolve the workspace root for the `qwen/settings/*` + `qwen/permissions/*`
-   * handlers. The requesting session relocates *its own* Config (not the
-   * daemon's bootstrap `this.config`), so `session.getConfig().getTargetDir()`
-   * points at a worktree while `process.cwd()` stays pinned to the daemon's
-   * boot workspace. Falls back to the bootstrap Config when the client sends no
-   * `sessionId`, following `this.config.getTargetDir()` rather than
-   * `process.cwd()`. The two coincide at boot, but diverge once that Config has
-   * been relocated (ACP relocation uses `skipProcessChdir: true`, leaving
-   * `process.cwd()` behind), so this is not a no-op preservation for
-   * non-session-scoped calls.
+   * handlers. `sessionId` names the requesting session, whose own Config is
+   * relocated to its worktree; without one the daemon's bootstrap
+   * `this.config` is used — nothing relocates the agent-level Config, so that
+   * is the boot workspace and swapping `process.cwd()` for
+   * `this.config.getTargetDir()` is a no-op there. An unresolvable `sessionId`
+   * is rejected rather than silently retargeting the read/write to the
+   * bootstrap workspace, whose trust decision and settings the caller never
+   * selected.
    */
   private settingsCwdFor(
     requestedCwd: string | undefined,
     params: Record<string, unknown>,
   ): string {
-    const sessionId = params['sessionId'] as string | undefined;
-    const session = sessionId ? this.sessions.get(sessionId) : undefined;
-    const config = session ? session.getConfig() : this.config;
-    return requestedCwd || config.getTargetDir();
+    const sessionId = params['sessionId'];
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      const session = this.sessions.get(sessionId);
+      if (!session) {
+        throw new RequestError(-32004, `Session not found: ${sessionId}`, {
+          errorKind: 'session_not_found',
+          sessionId,
+        });
+      }
+      return requestedCwd || session.getConfig().getTargetDir();
+    }
+    return requestedCwd || this.config.getTargetDir();
   }
 
   private async buildCoreSettings(
@@ -8964,7 +8988,7 @@ class QwenAgent implements Agent {
       }
       case 'qwen/settings/getMemory': {
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         this.settings = settings;
         return {
           settings: normalizeQwenMemorySettings(settings.merged.memory),
@@ -8976,7 +9000,7 @@ class QwenAgent implements Agent {
         // other settings mutation handlers, instead of writing through the
         // possibly-stale cached `this.settings` and reading it back.
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         for (const key of QWEN_MEMORY_SETTING_KEYS) {
           if (updates[key] === undefined) continue;
           if (typeof updates[key] !== 'boolean') {
@@ -13375,7 +13399,7 @@ class QwenAgent implements Agent {
       }
       case 'qwen/settings/getCore': {
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         this.settings = settings;
         return this.buildCoreSettings(settings, settingsCwd);
       }
@@ -13391,7 +13415,7 @@ class QwenAgent implements Agent {
           );
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const settingKey = key as QwenCoreSettingKey;
         const normalizedValue = normalizeCoreSettingValue(
           settingKey,
@@ -13432,7 +13456,7 @@ class QwenAgent implements Agent {
           );
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13462,7 +13486,7 @@ class QwenAgent implements Agent {
           );
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13481,7 +13505,7 @@ class QwenAgent implements Agent {
           throw RequestError.invalidParams(undefined, 'Invalid hook event');
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13537,7 +13561,7 @@ class QwenAgent implements Agent {
           throw RequestError.invalidParams(undefined, 'Invalid hook index');
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const settingScope = toSettingsScope(params['scope']);
         const scope =
           settingScope === SettingScope.Workspace ? 'workspace' : 'user';
@@ -13577,7 +13601,7 @@ class QwenAgent implements Agent {
           throw RequestError.invalidParams(undefined, 'value must be a string');
         }
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
-        const settings = loadSettings(settingsCwd);
+        const settings = this.loadRequestSettings(settingsCwd);
         const extensionManager = new ExtensionManager({
           workspaceDir: settingsCwd,
           isWorkspaceTrusted:

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6459,8 +6459,28 @@ class QwenAgent implements Agent {
   }
 
   private loadPermissionSettings(cwd: string): LoadedSettings {
-    this.settings = this.loadRequestSettings(cwd);
-    return this.settings;
+    return this.adoptRequestSettings(this.loadRequestSettings(cwd), cwd);
+  }
+
+  /**
+   * Publish a freshly loaded `LoadedSettings` into the process-wide
+   * `this.settings` cache only when it was loaded for the daemon's own
+   * workspace. `this.settings` is the "latest loaded" cache read by the
+   * daemon-global control handlers (`workspaceReload`,
+   * `workspaceModelProvidersReload`, `qwen/settings/getPath`, workspace
+   * status): a session-scoped load for a foreign workspace (worktree) must
+   * stay request-local, or that workspace's settings, approval mode, MCP
+   * servers, hooks and permission rules would bleed into every other live
+   * session. The load still returns the caller's instance either way.
+   */
+  private adoptRequestSettings(
+    settings: LoadedSettings,
+    settingsCwd: string,
+  ): LoadedSettings {
+    if (path.resolve(settingsCwd) === path.resolve(this.config.getTargetDir())) {
+      this.settings = settings;
+    }
+    return settings;
   }
 
   /**
@@ -6504,7 +6524,14 @@ class QwenAgent implements Agent {
           sessionId,
         });
       }
-      return requestedCwd || session.getConfig().getTargetDir();
+      // Resolve the session's stable workspace root, not its live cwd:
+      // `session/cd` relocates `config.targetDir` into a subdirectory that
+      // carries no `.qwen/settings.json`, while `storage` stays bound to the
+      // admission workspace (`relocateWorkingDirectory` runs with
+      // `skipArtifactMigration: true`, so it never replaces `storage`). The
+      // live cwd would make all twelve handlers read/write a stray
+      // `<subdir>/.qwen/settings.json` after a single cd.
+      return requestedCwd || session.getConfig().storage.getProjectRoot();
     }
     return requestedCwd || this.config.getTargetDir();
   }
@@ -6661,6 +6688,8 @@ class QwenAgent implements Agent {
   private syncLivePermissionManagers(
     before: PermissionRuleSet,
     after: PermissionRuleSet,
+    settingScope: SettingScope,
+    settingsCwd: string,
   ): void {
     for (const ruleType of PERMISSION_RULE_TYPES) {
       const oldRules = new Set(before[ruleType]);
@@ -6671,6 +6700,19 @@ class QwenAgent implements Agent {
       if (removed.length === 0 && added.length === 0) continue;
 
       for (const session of this.sessions.values()) {
+        if (settingScope === SettingScope.Workspace) {
+          // A workspace-scoped write only applies to sessions bound to the
+          // workspace it landed in. `settingsCwd` is the requesting session's
+          // stable workspace root; skip sessions in other workspaces so a
+          // worktree's grant/deny doesn't fan out to every live session with
+          // no record in their own settings files.
+          const sessionWorkspace = session
+            .getConfig()
+            .storage.getProjectRoot();
+          if (path.resolve(sessionWorkspace) !== path.resolve(settingsCwd)) {
+            continue;
+          }
+        }
         const pm = session.getConfig().getPermissionManager?.();
         if (!pm) continue;
         // Isolate per-session failures: a stale/broken permission manager for
@@ -8989,7 +9031,7 @@ class QwenAgent implements Agent {
       case 'qwen/settings/getMemory': {
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
         const settings = this.loadRequestSettings(settingsCwd);
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return {
           settings: normalizeQwenMemorySettings(settings.merged.memory),
         };
@@ -9011,7 +9053,7 @@ class QwenAgent implements Agent {
           }
           settings.setValue(SettingScope.User, `memory.${key}`, updates[key]);
         }
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return {
           settings: normalizeQwenMemorySettings(settings.merged.memory),
         };
@@ -13400,7 +13442,7 @@ class QwenAgent implements Agent {
       case 'qwen/settings/getCore': {
         const settingsCwd = this.settingsCwdFor(requestedCwd, params);
         const settings = this.loadRequestSettings(settingsCwd);
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setCoreValue': {
@@ -13444,7 +13486,7 @@ class QwenAgent implements Agent {
         }
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setMcpServer': {
@@ -13474,7 +13516,7 @@ class QwenAgent implements Agent {
         settings.setValue(settingScope, 'mcpServers', mcpServers);
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/removeMcpServer': {
@@ -13496,7 +13538,7 @@ class QwenAgent implements Agent {
         settings.setValue(settingScope, 'mcpServers', mcpServers);
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setHook': {
@@ -13544,7 +13586,7 @@ class QwenAgent implements Agent {
         settings.setValue(settingScope, 'hooks', hooksRoot);
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/removeHook': {
@@ -13581,7 +13623,7 @@ class QwenAgent implements Agent {
         settings.setValue(settingScope, 'hooks', hooksRoot);
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/settings/setExtensionSetting': {
@@ -13630,7 +13672,7 @@ class QwenAgent implements Agent {
         // `updateSetting` (extension settings store), not `settings.setValue`,
         // so `settings` here is just the snapshot loaded above and is reused to
         // build the response.
-        this.settings = settings;
+        this.adoptRequestSettings(settings, settingsCwd);
         return this.buildCoreSettings(settings, settingsCwd);
       }
       case 'qwen/permissions/getSettings': {
@@ -13685,7 +13727,7 @@ class QwenAgent implements Agent {
         // (avoids redundant I/O and a concurrency window where another handler
         // could mutate settings between the two loads).
         const after = readPermissionRuleSet(settings.merged);
-        this.syncLivePermissionManagers(before, after);
+        this.syncLivePermissionManagers(before, after, settingScope, settingsCwd);
         return buildPermissionSettings(settings) as unknown as Record<
           string,
           unknown

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6550,7 +6550,7 @@ class QwenAgent implements Agent {
       // `skipArtifactMigration: true`, so it never replaces `storage`). The
       // live cwd would make all twelve handlers read/write a stray
       // `<subdir>/.qwen/settings.json` after a single cd.
-      return session.getConfig().storage.getProjectRoot();
+      return this.sessionWorkspaceRoot(session.getConfig());
     }
     return this.config.getTargetDir();
   }
@@ -6725,7 +6725,9 @@ class QwenAgent implements Agent {
           // stable workspace root; skip sessions in other workspaces so a
           // worktree's grant/deny doesn't fan out to every live session with
           // no record in their own settings files.
-          const sessionWorkspace = session.getConfig().storage.getProjectRoot();
+          const sessionWorkspace = this.sessionWorkspaceRoot(
+            session.getConfig(),
+          );
           if (path.resolve(sessionWorkspace) !== path.resolve(settingsCwd)) {
             continue;
           }
@@ -6755,6 +6757,21 @@ class QwenAgent implements Agent {
 
   private workspaceCwd(config: Config): string {
     return config.getTargetDir();
+  }
+
+  /**
+   * The stable workspace root a session was admitted under. Unlike
+   * `workspaceCwd` (the live `getTargetDir()`) and `Config.getProjectRoot()`
+   * (also live `targetDir`), this reads the admission-bound `storage`, which
+   * `relocateWorkingDirectory` leaves untouched when `session/cd` moves a
+   * session into a subdirectory (`skipArtifactMigration: true`). Keying the
+   * twelve `qwen/settings/*` / `qwen/permissions/*` handlers and the
+   * workspace-scoped permission fan-out on this root — rather than the live
+   * cwd — is what keeps a post-`cd` request from reading/writing a stray
+   * `<subdir>/.qwen/settings.json`.
+   */
+  private sessionWorkspaceRoot(config: Config): string {
+    return config.storage.getProjectRoot();
   }
 
   private safeWorkspaceCwd(config: Config): string {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6469,7 +6469,10 @@ class QwenAgent implements Agent {
    * daemon's bootstrap `this.config`), so `session.getConfig().getTargetDir()`
    * points at a worktree while `process.cwd()` stays pinned to the daemon's
    * boot workspace. Falls back to the bootstrap Config when the client sends no
-   * `sessionId`, matching the previous `process.cwd()` behaviour for
+   * `sessionId`, following `this.config.getTargetDir()` rather than
+   * `process.cwd()`. The two coincide at boot, but diverge once that Config has
+   * been relocated (ACP relocation uses `skipProcessChdir: true`, leaving
+   * `process.cwd()` behind), so this is not a no-op preservation for
    * non-session-scoped calls.
    */
   private settingsCwdFor(
@@ -8993,12 +8996,16 @@ class QwenAgent implements Agent {
         return { path: this.settings.user.path };
       }
       case 'qwen/settings/getMemoryPaths': {
+        const settingsCwd = this.settingsCwdFor(requestedCwd, params);
         const projectRoot =
           typeof params['projectRoot'] === 'string'
             ? params['projectRoot']
-            : cwd;
+            : settingsCwd;
         return {
-          paths: await resolveQwenMemoryPaths({ cwd, projectRoot }),
+          paths: await resolveQwenMemoryPaths({
+            cwd: settingsCwd,
+            projectRoot,
+          }),
         };
       }
       case SERVE_STATUS_EXT_METHODS.workspaceMcp:

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6477,7 +6477,9 @@ class QwenAgent implements Agent {
     settings: LoadedSettings,
     settingsCwd: string,
   ): LoadedSettings {
-    if (path.resolve(settingsCwd) === path.resolve(this.config.getTargetDir())) {
+    if (
+      path.resolve(settingsCwd) === path.resolve(this.config.getTargetDir())
+    ) {
       this.settings = settings;
     }
     return settings;
@@ -6515,8 +6517,25 @@ class QwenAgent implements Agent {
     requestedCwd: string | undefined,
     params: Record<string, unknown>,
   ): string {
+    // An explicit `cwd` from the request wins outright: the `sessionId` lookup
+    // below only exists to resolve the session's own workspace root when the
+    // caller did not name one, so a well-targeted request must not be rejected
+    // over a field the resolver will not use.
+    if (requestedCwd) {
+      return requestedCwd;
+    }
     const sessionId = params['sessionId'];
-    if (typeof sessionId === 'string' && sessionId.length > 0) {
+    if (sessionId !== undefined && sessionId !== null) {
+      if (typeof sessionId !== 'string' || sessionId.length === 0) {
+        // A present-but-malformed `sessionId` (a number, an object, an empty
+        // string) is a caller error, not "absent": falling through would
+        // silently read/write the bootstrap workspace the caller never
+        // selected.
+        throw RequestError.invalidParams(
+          undefined,
+          'Invalid sessionId: expected a non-empty string',
+        );
+      }
       const session = this.sessions.get(sessionId);
       if (!session) {
         throw new RequestError(-32004, `Session not found: ${sessionId}`, {
@@ -6531,9 +6550,9 @@ class QwenAgent implements Agent {
       // `skipArtifactMigration: true`, so it never replaces `storage`). The
       // live cwd would make all twelve handlers read/write a stray
       // `<subdir>/.qwen/settings.json` after a single cd.
-      return requestedCwd || session.getConfig().storage.getProjectRoot();
+      return session.getConfig().storage.getProjectRoot();
     }
-    return requestedCwd || this.config.getTargetDir();
+    return this.config.getTargetDir();
   }
 
   private async buildCoreSettings(
@@ -6706,9 +6725,7 @@ class QwenAgent implements Agent {
           // stable workspace root; skip sessions in other workspaces so a
           // worktree's grant/deny doesn't fan out to every live session with
           // no record in their own settings files.
-          const sessionWorkspace = session
-            .getConfig()
-            .storage.getProjectRoot();
+          const sessionWorkspace = session.getConfig().storage.getProjectRoot();
           if (path.resolve(sessionWorkspace) !== path.resolve(settingsCwd)) {
             continue;
           }
@@ -13727,7 +13744,12 @@ class QwenAgent implements Agent {
         // (avoids redundant I/O and a concurrency window where another handler
         // could mutate settings between the two loads).
         const after = readPermissionRuleSet(settings.merged);
-        this.syncLivePermissionManagers(before, after, settingScope, settingsCwd);
+        this.syncLivePermissionManagers(
+          before,
+          after,
+          settingScope,
+          settingsCwd,
+        );
         return buildPermissionSettings(settings) as unknown as Record<
           string,
           unknown


### PR DESCRIPTION
## What this PR does

Changes how ACP settings handlers select the workspace used for reading and persisting settings. Core settings, memory, and permission handlers resolve the requesting session's worktree; the MCP/hook/extension write handlers resolve only an explicit cwd (or the bootstrap workspace), because their status and apply routes are workspace-global.

## Why it's needed

#8138 reports settings landing in the project root instead of the active worktree. Resolving settings from the selected configuration is relevant, but this PR does not yet demonstrate that the real worktree-entry flow supplies the new worktree as that configuration's target.

## Reviewer Test Plan

### How to verify

Verify the actual flow: enter a worktree, change a workspace setting without an explicit cwd, and confirm both the saved file and the live setting belong to that worktree. For MCP settings, verify save, list/status, and reload all use the same workspace.

The existing mocked ACP tests exercise settings-path selection but do not by themselves prove this end-to-end behavior. Previously reported test counts are not a substitute for that missing producer-to-consumer check.

### Evidence (Before & After)

Non-UI settings routing: N/A. Unit level: `packages/cli/src/acp-integration/acpAgent.test.ts` pins that session-aware handlers resolve the session worktree while MCP/hook/extension writes stay on the workspace-global coordinate the status routes read. Not yet verified end-to-end against a real worktree entry.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ focused ACP settings tests |

## Risk & Scope

- The write/read split reported on MCP set/remove is closed: those handlers no longer resolve `sessionId`, so writes land on the same workspace the status and reload routes read. Session-aware MCP discovery (per-workspace status/apply) remains a separate architecture decision.
- The settings-routing changes are in the shared CLI ACP implementation, not only VS Code UI.
- No claim that entering a worktree already relocates the ACP configuration; that wiring needs to be demonstrated or implemented before claiming #8138 is solved.

## Linked Issues

Refs #8138. This PR does not automatically close the issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

调整 ACP 设置处理器选择读取和保存工作区的方式。core 设置、memory、权限处理器解析请求 session 的 worktree；MCP/hook/extension 的写处理器只解析显式 cwd（或启动工作区），因为它们的状态与生效路由是工作区级的。

## 为什么需要

#8138 报告设置落在项目根目录而不是当前 worktree。根据选中的配置选择设置目录与问题相关，但当前 PR 尚未证明真实的进入 worktree 流程会将该配置的 target 切换到新 worktree。

## 评审验证计划

### 如何验证

验证真实流程：进入 worktree，不显式传 cwd 修改工作区设置，确认保存文件和实际生效的配置都属于该 worktree。MCP 设置还必须确认保存、列表/状态和重载使用同一工作区。

现有 mock ACP 测试覆盖路径选择，不能单独证明上述端到端行为。先前报告的通过数量不能代替缺失的调用方到消费方验证。

### 证据（Before & After）

非 UI 的设置路由改动：N/A。单元层面：`packages/cli/src/acp-integration/acpAgent.test.ts` 钉住 session 级处理器解析 session worktree，而 MCP/hook/extension 写入保持在状态路由读取的工作区级坐标。尚未对真实进入 worktree 流程做端到端验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 聚焦的 ACP 设置测试 |

## 风险与范围

- 此前上报的 MCP 读写割裂已闭合：这些处理器不再解析 `sessionId`，写入落在状态与重载路由读取的同一工作区。按 session 隔离的 MCP discovery（按工作区上报/生效）仍是单独的架构决策。
- 修改位于共享 CLI ACP 实现，不仅影响 VS Code UI。
- 不再声称进入 worktree 已会迁移 ACP 配置；在宣称解决 #8138 前，需要证明或补齐这条实际调用链。

## 关联 Issue

Refs #8138。不自动关闭该 issue。

</details>
