### PR TITLE
fix(core): redact error text in usage-statistics telemetry sink

### DIFF
--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -28,6 +28,7 @@ import {
   ProtocolTagSanitizedEvent,
   RipgrepRuntimeRecoveryEvent,
   SubagentExecutionEvent,
+  InvalidChunkEvent,
   type ToolCallEvent,
 } from '../types.js';
 import type { RumEvent, RumPayload } from './event-types.js';
@@ -1130,6 +1131,91 @@ describe('QwenLogger', () => {
       const rumEvent = enqueueSpy.mock.calls[0][0];
       expect(rumEvent.properties).not.toHaveProperty('function_args');
       expect(rumEvent.properties).not.toHaveProperty('mcp_server_name');
+    });
+  });
+
+  describe('error text redaction', () => {
+    it('redacts URL credentials from telemetry error text', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'Command: git clone https://x-access-token:ghs_testsecret123@github.com/org/repo.git',
+      );
+      expect(redacted).not.toContain('ghs_testsecret123');
+      expect(redacted).toContain('***REDACTED***');
+    });
+
+    it('redacts Authorization headers from telemetry error text', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'curl -H "Authorization: Bearer ghs_testsecret123" https://api.github.com/repos',
+      );
+      expect(redacted).not.toContain('ghs_testsecret123');
+    });
+
+    it('redacts secret flags from telemetry error text', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'npm publish --_authToken npm_testsecret123 --registry https://registry.npmjs.org',
+      );
+      expect(redacted).not.toContain('npm_testsecret123');
+    });
+
+    it('redacts KEY=value env-style secrets from telemetry error text', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'env GITHUB_TOKEN=ghs_testsecret123 npm publish',
+      );
+      expect(redacted).not.toContain('ghs_testsecret123');
+      expect(redacted).toContain('***REDACTED***');
+    });
+
+    it('redacts database DSN credentials', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'connect postgres://user:supersecret123@db.internal:5432/app',
+      );
+      expect(redacted).not.toContain('supersecret123');
+    });
+
+    it('preserves non-sensitive error text', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError('Request failed with status 429'),
+      ).toBe('Request failed with status 429');
+    });
+
+    it('redacts error_message on the enqueue boundary', () => {
+      const logger = QwenLogger.getInstance(mockConfig)!;
+      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
+      const event = {
+        'event.name': 'tool_call',
+        'event.timestamp': '2025-01-01T12:00:00.000Z',
+        function_name: 'shell',
+        function_args: {},
+        duration_ms: 1,
+        status: 'error',
+        success: false,
+        error:
+          'Command: git clone https://token:ghs_testsecret123@github.com/org/repo.git',
+        error_type: 'exit_code',
+        prompt_id: 'prompt-tool',
+        tool_type: 'native',
+      } as ToolCallEvent;
+
+      logger.logToolCallEvent(event);
+
+      const errorMessage = enqueueSpy.mock.calls[0][0].properties?.[
+        'error_message'
+      ] as string;
+      expect(errorMessage).not.toContain('ghs_testsecret123');
+      expect(errorMessage).toContain('***REDACTED***');
+    });
+
+    it('redacts top-level message on the enqueue boundary', () => {
+      const logger = QwenLogger.getInstance(mockConfig)!;
+      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
+
+      logger.logInvalidChunkEvent(
+        new InvalidChunkEvent('Authorization: Bearer ghs_testsecret123'),
+      );
+
+      const rumEvent = enqueueSpy.mock.calls[0][0] as { message?: string };
+      expect(rumEvent.message).not.toContain('ghs_testsecret123');
+      expect(rumEvent.message).toContain('***REDACTED***');
     });
   });
 });

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -1217,5 +1217,84 @@ describe('QwenLogger', () => {
       expect(rumEvent.message).not.toContain('ghs_testsecret123');
       expect(rumEvent.message).toContain('***REDACTED***');
     });
+
+    it('redacts canonical LLM credential env vars (*_API_KEY, *_ACCESS_KEY*)', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'env OPENAI_API_KEY=sk_testsecret123 npm publish',
+        ),
+      ).not.toContain('sk_testsecret123');
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'env AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG npm run',
+        ),
+      ).not.toContain('wJalrXUtnFEMI/K7MDENG');
+    });
+
+    it('redacts non-Bearer Authorization schemes', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'curl -H "Authorization: Basic dXNlcjpwYXNz" https://api.example.com',
+      );
+      expect(redacted).not.toContain('dXNlcjpwYXNz');
+      expect(redacted).toContain('***REDACTED***');
+    });
+
+    it('redacts secrets delimited by tabs and newlines', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'npm publish --_authToken\tnpm_testsecret123 --registry x',
+        ),
+      ).not.toContain('npm_testsecret123');
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'npm publish --_authToken\nnpm_testsecret123 --registry x',
+        ),
+      ).not.toContain('npm_testsecret123');
+    });
+
+    it('redacts quote-opened secret values', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError('TOKEN="ghs_testsecret123"'),
+      ).not.toContain('ghs_testsecret123');
+      expect(
+        TEST_ONLY.redactTelemetryError("--token 'ghs_testsecret123'"),
+      ).not.toContain('ghs_testsecret123');
+    });
+
+    it('redacts long flags containing a secret keyword', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'aws --aws-access-key AKIA_testsecret123',
+        ),
+      ).not.toContain('AKIA_testsecret123');
+    });
+
+    it('redacts the hook error property on the enqueue boundary', () => {
+      const configWithLogPrompts = makeFakeConfig({
+        getTelemetryLogPromptsEnabled: () => true,
+      });
+      const logger = QwenLogger.getInstance(configWithLogPrompts)!;
+      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
+
+      logger.logHookCallEvent(
+        new HookCallEvent(
+          'PostToolUse',
+          'command',
+          'cleanup.sh',
+          { tool_name: 'shell' },
+          200,
+          false,
+          undefined,
+          1,
+          '',
+          'stderr',
+          'hook failed: Authorization: Bearer ghs_testsecret123',
+        ),
+      );
+
+      const error = enqueueSpy.mock.calls[0][0].properties?.['error'] as string;
+      expect(error).not.toContain('ghs_testsecret123');
+      expect(error).toContain('***REDACTED***');
+    });
   });
 });

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -28,7 +28,6 @@ import {
   ProtocolTagSanitizedEvent,
   RipgrepRuntimeRecoveryEvent,
   SubagentExecutionEvent,
-  InvalidChunkEvent,
   type ToolCallEvent,
 } from '../types.js';
 import type { RumEvent, RumPayload } from './event-types.js';
@@ -815,7 +814,7 @@ describe('QwenLogger', () => {
             duration_ms: 200,
             success: 0,
             exit_code: 1,
-            error: 'Command failed',
+            error: '***REDACTED***',
           }),
         }),
       );
@@ -1124,7 +1123,7 @@ describe('QwenLogger', () => {
             success: 0,
             duration_ms: 42,
             error_type: 'unknown',
-            error_message: 'failed',
+            error_message: '***REDACTED***',
           }),
         }),
       );
@@ -1135,253 +1134,29 @@ describe('QwenLogger', () => {
   });
 
   describe('error text redaction', () => {
-    it('redacts URL credentials from telemetry error text', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'Command: git clone https://x-access-token:ghs_testsecret123@github.com/org/repo.git',
-        ),
-      ).toBe(
-        'Command: git clone https://***REDACTED***@github.com/org/repo.git',
-      );
-    });
-
-    it('redacts Authorization headers from telemetry error text', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'curl -H "Authorization: Bearer ghs_testsecret123" https://api.github.com/repos',
-        ),
-      ).toBe(
-        'curl -H "Authorization: ***REDACTED*** https://api.github.com/repos',
-      );
-    });
-
-    it('redacts secret flags from telemetry error text', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'npm publish --_authToken npm_testsecret123 --registry https://registry.npmjs.org',
-        ),
-      ).toBe(
-        'npm publish --_authToken ***REDACTED*** --registry https://registry.npmjs.org',
-      );
-    });
-
-    it('redacts KEY=value env-style secrets from telemetry error text', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'env GITHUB_TOKEN=ghs_testsecret123 npm publish',
-        ),
-      ).toBe('env GITHUB_TOKEN=***REDACTED*** npm publish');
-    });
-
-    it('redacts database DSN credentials', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'connect postgres://user:supersecret123@db.internal:5432/app',
-        ),
-      ).toBe('connect postgres://***REDACTED***@db.internal:5432/app');
-    });
-
-    it('preserves non-sensitive error text', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError('Request failed with status 429'),
-      ).toBe('Request failed with status 429');
-    });
-
-    it('preserves non-secret key=value assignments and short counters', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'env USER=alice PATH=/usr/bin max_tokens=8192',
-        ),
-      ).toBe('env USER=alice PATH=/usr/bin max_tokens=8192');
-    });
-
-    it('treats short counters the same in flag and env spellings', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError('run --max-tokens 8192 max_tokens=8192'),
-      ).toBe('run --max-tokens 8192 max_tokens=8192');
-    });
-
-    it('redacts error_message on the enqueue boundary', () => {
+    it('replaces error text at the enqueue boundary', () => {
       const logger = QwenLogger.getInstance(mockConfig)!;
-      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
-      const event = {
-        'event.name': 'tool_call',
-        'event.timestamp': '2025-01-01T12:00:00.000Z',
-        function_name: 'shell',
-        function_args: {},
-        duration_ms: 1,
-        status: 'error',
-        success: false,
-        error:
-          'Command: git clone https://token:ghs_testsecret123@github.com/org/repo.git',
+      const event: RumEvent & { message: string } = {
+        type: 'exception',
+        name: 'test',
+        message: 'raw top-level error',
+        properties: {
+          error_message: 'raw error message',
+          error_excerpt: 'raw error excerpt',
+          error: 'raw hook error',
+          error_type: 'exit_code',
+        },
+      };
+
+      logger.enqueueLogEvent(event);
+
+      expect(event.message).toBe('***REDACTED***');
+      expect(event.properties).toEqual({
+        error_message: '***REDACTED***',
+        error_excerpt: '***REDACTED***',
+        error: '***REDACTED***',
         error_type: 'exit_code',
-        prompt_id: 'prompt-tool',
-        tool_type: 'native',
-      } as ToolCallEvent;
-
-      logger.logToolCallEvent(event);
-
-      const errorMessage = enqueueSpy.mock.calls[0][0].properties?.[
-        'error_message'
-      ] as string;
-      expect(errorMessage).not.toContain('ghs_testsecret123');
-      expect(errorMessage).toContain('***REDACTED***');
-    });
-
-    it('redacts top-level message on the enqueue boundary', () => {
-      const logger = QwenLogger.getInstance(mockConfig)!;
-      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
-
-      logger.logInvalidChunkEvent(
-        new InvalidChunkEvent('Authorization: Bearer ghs_testsecret123'),
-      );
-
-      const rumEvent = enqueueSpy.mock.calls[0][0] as { message?: string };
-      expect(rumEvent.message).not.toContain('ghs_testsecret123');
-      expect(rumEvent.message).toContain('***REDACTED***');
-    });
-
-    it('redacts canonical LLM credential env vars (*_API_KEY, *_ACCESS_KEY*)', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'env OPENAI_API_KEY=sk_testsecret123 npm publish',
-        ),
-      ).toBe('env OPENAI_API_KEY=***REDACTED*** npm publish');
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'env AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG npm run',
-        ),
-      ).toBe('env AWS_SECRET_ACCESS_KEY=***REDACTED*** npm run');
-    });
-
-    it('redacts non-Bearer Authorization schemes', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'curl -H "Authorization: Basic dXNlcjpwYXNz" https://api.example.com',
-        ),
-      ).toBe('curl -H "Authorization: ***REDACTED*** https://api.example.com');
-    });
-
-    it('redacts secrets delimited by tabs and newlines', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'npm publish --_authToken\tnpm_testsecret123 --registry x',
-        ),
-      ).not.toContain('npm_testsecret123');
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'npm publish --_authToken\nnpm_testsecret123 --registry x',
-        ),
-      ).not.toContain('npm_testsecret123');
-    });
-
-    it('redacts quote-opened secret values', () => {
-      expect(TEST_ONLY.redactTelemetryError('TOKEN="ghs_testsecret123"')).toBe(
-        'TOKEN=***REDACTED***',
-      );
-      expect(
-        TEST_ONLY.redactTelemetryError("--token 'ghs_testsecret123'"),
-      ).toBe('--token ***REDACTED***');
-    });
-
-    it('redacts long flags containing a secret keyword', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'aws --aws-access-key AKIA_testsecret123',
-        ),
-      ).toBe('aws --aws-access-key ***REDACTED***');
-    });
-
-    it('redacts a secret value with an interior quote', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError("--password P@ss'w0rd123"),
-      ).not.toContain('w0rd123');
-    });
-
-    it('redacts a quoted flag value containing spaces', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          "mysql -u root --password='my secret pw'",
-        ),
-      ).not.toContain('secret pw');
-    });
-
-    it('redacts a quoted env value containing spaces', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'export API_TOKEN="correct horse battery staple"',
-        ),
-      ).not.toContain('horse');
-    });
-
-    it('redacts a secret preceded by an ANSI escape sequence', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'Authorization: \x1b[31mBearer ghs_testsecret123\x1b[0m',
-        ),
-      ).not.toContain('ghs_testsecret123');
-    });
-
-    it('redacts a secret containing a form-feed control character', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError('GITHUB_TOKEN=ghs\fSECRET1234567'),
-      ).not.toContain('SECRET1234567');
-    });
-
-    it('redacts a secret value split by a shell line continuation', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'npm publish --token=\\' + '\n' + 'greatsecret1234',
-      );
-      expect(redacted).not.toContain('greatsecret1234');
-      expect(redacted).toContain('***REDACTED***');
-    });
-
-    it('redacts a whitespace-separated secret split by a line continuation', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError(
-          'npm publish --token \\\n ghs_secret123',
-        ),
-      ).not.toContain('ghs_secret123');
-    });
-
-    it('does not emit a marker for a lone trailing backslash', () => {
-      expect(TEST_ONLY.redactTelemetryError('npm publish --token=\\')).toBe(
-        'npm publish --token=\\',
-      );
-    });
-
-    it('does not swallow the next argument after an empty secret flag value', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError('git push --password= origin main'),
-      ).toBe('git push --password= origin main');
-    });
-
-    it('redacts the hook error property on the enqueue boundary', () => {
-      const configWithLogPrompts = makeFakeConfig({
-        getTelemetryLogPromptsEnabled: () => true,
       });
-      const logger = QwenLogger.getInstance(configWithLogPrompts)!;
-      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
-
-      logger.logHookCallEvent(
-        new HookCallEvent(
-          'PostToolUse',
-          'command',
-          'cleanup.sh',
-          { tool_name: 'shell' },
-          200,
-          false,
-          undefined,
-          1,
-          '',
-          'stderr',
-          'hook failed: Authorization: Bearer ghs_testsecret123',
-        ),
-      );
-
-      const error = enqueueSpy.mock.calls[0][0].properties?.['error'] as string;
-      expect(error).not.toContain('ghs_testsecret123');
-      expect(error).toContain('***REDACTED***');
     });
   });
 });

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -1136,46 +1136,63 @@ describe('QwenLogger', () => {
 
   describe('error text redaction', () => {
     it('redacts URL credentials from telemetry error text', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'Command: git clone https://x-access-token:ghs_testsecret123@github.com/org/repo.git',
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'Command: git clone https://x-access-token:ghs_testsecret123@github.com/org/repo.git',
+        ),
+      ).toBe(
+        'Command: git clone https://***REDACTED***@github.com/org/repo.git',
       );
-      expect(redacted).not.toContain('ghs_testsecret123');
-      expect(redacted).toContain('***REDACTED***');
     });
 
     it('redacts Authorization headers from telemetry error text', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'curl -H "Authorization: Bearer ghs_testsecret123" https://api.github.com/repos',
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'curl -H "Authorization: Bearer ghs_testsecret123" https://api.github.com/repos',
+        ),
+      ).toBe(
+        'curl -H "Authorization: ***REDACTED*** https://api.github.com/repos',
       );
-      expect(redacted).not.toContain('ghs_testsecret123');
     });
 
     it('redacts secret flags from telemetry error text', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'npm publish --_authToken npm_testsecret123 --registry https://registry.npmjs.org',
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'npm publish --_authToken npm_testsecret123 --registry https://registry.npmjs.org',
+        ),
+      ).toBe(
+        'npm publish --_authToken ***REDACTED*** --registry https://registry.npmjs.org',
       );
-      expect(redacted).not.toContain('npm_testsecret123');
     });
 
     it('redacts KEY=value env-style secrets from telemetry error text', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'env GITHUB_TOKEN=ghs_testsecret123 npm publish',
-      );
-      expect(redacted).not.toContain('ghs_testsecret123');
-      expect(redacted).toContain('***REDACTED***');
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'env GITHUB_TOKEN=ghs_testsecret123 npm publish',
+        ),
+      ).toBe('env GITHUB_TOKEN=***REDACTED*** npm publish');
     });
 
     it('redacts database DSN credentials', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'connect postgres://user:supersecret123@db.internal:5432/app',
-      );
-      expect(redacted).not.toContain('supersecret123');
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'connect postgres://user:supersecret123@db.internal:5432/app',
+        ),
+      ).toBe('connect postgres://***REDACTED***@db.internal:5432/app');
     });
 
     it('preserves non-sensitive error text', () => {
       expect(
         TEST_ONLY.redactTelemetryError('Request failed with status 429'),
       ).toBe('Request failed with status 429');
+    });
+
+    it('preserves non-secret key=value assignments and short counters', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'env USER=alice PATH=/usr/bin max_tokens=8192',
+        ),
+      ).toBe('env USER=alice PATH=/usr/bin max_tokens=8192');
     });
 
     it('redacts error_message on the enqueue boundary', () => {
@@ -1223,20 +1240,20 @@ describe('QwenLogger', () => {
         TEST_ONLY.redactTelemetryError(
           'env OPENAI_API_KEY=sk_testsecret123 npm publish',
         ),
-      ).not.toContain('sk_testsecret123');
+      ).toBe('env OPENAI_API_KEY=***REDACTED*** npm publish');
       expect(
         TEST_ONLY.redactTelemetryError(
           'env AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG npm run',
         ),
-      ).not.toContain('wJalrXUtnFEMI/K7MDENG');
+      ).toBe('env AWS_SECRET_ACCESS_KEY=***REDACTED*** npm run');
     });
 
     it('redacts non-Bearer Authorization schemes', () => {
-      const redacted = TEST_ONLY.redactTelemetryError(
-        'curl -H "Authorization: Basic dXNlcjpwYXNz" https://api.example.com',
-      );
-      expect(redacted).not.toContain('dXNlcjpwYXNz');
-      expect(redacted).toContain('***REDACTED***');
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'curl -H "Authorization: Basic dXNlcjpwYXNz" https://api.example.com',
+        ),
+      ).toBe('curl -H "Authorization: ***REDACTED*** https://api.example.com');
     });
 
     it('redacts secrets delimited by tabs and newlines', () => {
@@ -1255,10 +1272,10 @@ describe('QwenLogger', () => {
     it('redacts quote-opened secret values', () => {
       expect(
         TEST_ONLY.redactTelemetryError('TOKEN="ghs_testsecret123"'),
-      ).not.toContain('ghs_testsecret123');
+      ).toBe('TOKEN=***REDACTED***');
       expect(
         TEST_ONLY.redactTelemetryError("--token 'ghs_testsecret123'"),
-      ).not.toContain('ghs_testsecret123');
+      ).toBe('--token ***REDACTED***');
     });
 
     it('redacts long flags containing a secret keyword', () => {
@@ -1266,7 +1283,23 @@ describe('QwenLogger', () => {
         TEST_ONLY.redactTelemetryError(
           'aws --aws-access-key AKIA_testsecret123',
         ),
-      ).not.toContain('AKIA_testsecret123');
+      ).toBe('aws --aws-access-key ***REDACTED***');
+    });
+
+    it('does not consume a lone backslash as a complete secret value', () => {
+      const redacted = TEST_ONLY.redactTelemetryError(
+        'npm publish --token=\\' + '\n' + 'greatsecret1234',
+      );
+      // The trailing `\` is a shell line continuation, not a value. The
+      // redactor must not emit a redaction marker while leaving the real
+      // credential in cleartext immediately after it.
+      expect(redacted).not.toContain('***REDACTED***');
+    });
+
+    it('does not swallow the next argument after an empty secret flag value', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError('git push --password= origin main'),
+      ).toBe('git push --password= origin main');
     });
 
     it('redacts the hook error property on the enqueue boundary', () => {

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -1286,14 +1286,62 @@ describe('QwenLogger', () => {
       ).toBe('aws --aws-access-key ***REDACTED***');
     });
 
-    it('does not consume a lone backslash as a complete secret value', () => {
+    it('redacts a secret value with an interior quote', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError("--password P@ss'w0rd123"),
+      ).not.toContain('w0rd123');
+    });
+
+    it('redacts a quoted flag value containing spaces', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          "mysql -u root --password='my secret pw'",
+        ),
+      ).not.toContain('secret pw');
+    });
+
+    it('redacts a quoted env value containing spaces', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'export API_TOKEN="correct horse battery staple"',
+        ),
+      ).not.toContain('horse');
+    });
+
+    it('redacts a secret preceded by an ANSI escape sequence', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'Authorization: \x1b[31mBearer ghs_testsecret123\x1b[0m',
+        ),
+      ).not.toContain('ghs_testsecret123');
+    });
+
+    it('redacts a secret containing a form-feed control character', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError('GITHUB_TOKEN=ghs\fSECRET1234567'),
+      ).not.toContain('SECRET1234567');
+    });
+
+    it('redacts a secret value split by a shell line continuation', () => {
       const redacted = TEST_ONLY.redactTelemetryError(
         'npm publish --token=\\' + '\n' + 'greatsecret1234',
       );
-      // The trailing `\` is a shell line continuation, not a value. The
-      // redactor must not emit a redaction marker while leaving the real
-      // credential in cleartext immediately after it.
-      expect(redacted).not.toContain('***REDACTED***');
+      expect(redacted).not.toContain('greatsecret1234');
+      expect(redacted).toContain('***REDACTED***');
+    });
+
+    it('redacts a whitespace-separated secret split by a line continuation', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError(
+          'npm publish --token \\\n ghs_secret123',
+        ),
+      ).not.toContain('ghs_secret123');
+    });
+
+    it('does not emit a marker for a lone trailing backslash', () => {
+      expect(TEST_ONLY.redactTelemetryError('npm publish --token=\\')).toBe(
+        'npm publish --token=\\',
+      );
     });
 
     it('does not swallow the next argument after an empty secret flag value', () => {

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -1195,6 +1195,12 @@ describe('QwenLogger', () => {
       ).toBe('env USER=alice PATH=/usr/bin max_tokens=8192');
     });
 
+    it('treats short counters the same in flag and env spellings', () => {
+      expect(
+        TEST_ONLY.redactTelemetryError('run --max-tokens 8192 max_tokens=8192'),
+      ).toBe('run --max-tokens 8192 max_tokens=8192');
+    });
+
     it('redacts error_message on the enqueue boundary', () => {
       const logger = QwenLogger.getInstance(mockConfig)!;
       const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -779,7 +779,7 @@ describe('QwenLogger', () => {
       }
     });
 
-    it('should log a failed hook call event with error when telemetry log prompts enabled', () => {
+    it('should log a failed hook call event without forwarding raw error text', () => {
       const configWithLogPrompts = makeFakeConfig({
         getTelemetryLogPromptsEnabled: () => true,
       });
@@ -814,51 +814,13 @@ describe('QwenLogger', () => {
             duration_ms: 200,
             success: 0,
             exit_code: 1,
-            error: '***REDACTED***',
-          }),
-        }),
-      );
-    });
-
-    it('should not include error when telemetry log prompts disabled', () => {
-      const configWithoutLogPrompts = makeFakeConfig({
-        getTelemetryLogPromptsEnabled: () => false,
-      });
-      // Clear singleton to create new instance with different config
-      (QwenLogger as unknown as { instance: undefined }).instance = undefined;
-      const logger = QwenLogger.getInstance(configWithoutLogPrompts)!;
-      const enqueueSpy = vi.spyOn(logger, 'enqueueLogEvent');
-
-      const event = new HookCallEvent(
-        'PostToolUse',
-        'command',
-        'cleanup.sh',
-        { tool_name: 'shell' },
-        200,
-        false,
-        undefined,
-        1,
-        '',
-        'error output',
-        'Command failed with sensitive data',
-      );
-
-      logger.logHookCallEvent(event);
-
-      expect(enqueueSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          properties: expect.objectContaining({
-            hook_event_name: 'PostToolUse',
-            hook_type: 'command',
-            hook_name: 'cleanup.sh',
-            duration_ms: 200,
-            success: 0,
-            exit_code: 1,
           }),
         }),
       );
 
-      // Error should NOT be in properties
+      // Hook error text is dropped fail-closed: the failure is already
+      // signalled by `success` / `exit_code`, so no raw `error` property
+      // is forwarded to the sink even when telemetry log prompts are on.
       const callArgs = enqueueSpy.mock.calls[0][0];
       expect(callArgs.properties).not.toHaveProperty('error');
     });
@@ -1143,7 +1105,6 @@ describe('QwenLogger', () => {
         properties: {
           error_message: 'raw error message',
           error_excerpt: 'raw error excerpt',
-          error: 'raw hook error',
           error_type: 'exit_code',
         },
       };
@@ -1154,7 +1115,6 @@ describe('QwenLogger', () => {
       expect(event.properties).toEqual({
         error_message: '***REDACTED***',
         error_excerpt: '***REDACTED***',
-        error: '***REDACTED***',
         error_type: 'exit_code',
       });
     });

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.test.ts
@@ -1270,9 +1270,9 @@ describe('QwenLogger', () => {
     });
 
     it('redacts quote-opened secret values', () => {
-      expect(
-        TEST_ONLY.redactTelemetryError('TOKEN="ghs_testsecret123"'),
-      ).toBe('TOKEN=***REDACTED***');
+      expect(TEST_ONLY.redactTelemetryError('TOKEN="ghs_testsecret123"')).toBe(
+        'TOKEN=***REDACTED***',
+      );
       expect(
         TEST_ONLY.redactTelemetryError("--token 'ghs_testsecret123'"),
       ).toBe('--token ***REDACTED***');

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -103,7 +103,7 @@ const MAX_EVENTS = 1000;
  */
 const MAX_RETRY_EVENTS = 100;
 
-const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt', 'error'];
+const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt'];
 const REDACTED_ERROR_TEXT = '***REDACTED***';
 
 export interface LogResponse {
@@ -1118,10 +1118,6 @@ export class QwenLogger {
       success: event.success ? 1 : 0,
       exit_code: event.exit_code,
     };
-
-    if (event.error && this.config?.getTelemetryLogPromptsEnabled()) {
-      properties['error'] = event.error;
-    }
 
     const rumEvent = this.createActionEvent(
       'hook',

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -74,11 +74,6 @@ import { sanitizeHookName } from '../sanitize.js';
 import { InstallationManager } from '../../config/installationManager.js';
 import { FixedDeque } from 'mnemonist';
 import { AuthType } from '../../core/contentGenerator.js';
-import {
-  redactUrlCredentials,
-  REDACTED_URL_CREDENTIAL,
-} from '../../extension/redaction.js';
-import { stripAnsiAndControl } from '../../utils/textUtils.js';
 
 // Usage statistics collection endpoint
 const USAGE_STATS_HOSTNAME = 'gb4w8c3ygj-default-sea.rum.aliyuncs.com';
@@ -108,91 +103,8 @@ const MAX_EVENTS = 1000;
  */
 const MAX_RETRY_EVENTS = 100;
 
-/**
- * Error-text keys in `properties` that can carry raw shell output or error
- * text (command lines, HTTP headers, provider error bodies, hook failures).
- */
 const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt', 'error'];
-
-/**
- * A secret value in free-form error text: either a quoted run (matched up to
- * its matching closing quote, so interior spaces and quotes don't split it)
- * or an unquoted run of non-whitespace characters. A quoted value is consumed
- * whole, so `--password='my secret pw'` and `Authorization: Bearer "x"` redact
- * without leaking a suffix after the marker. The unquoted alternative refuses
- * a leading quote/backtick/backslash, so a lone shell line-continuation `\` is
- * never consumed as a complete value — continuations are normalised ahead of
- * this pass, and a leading escaped-quote backslash is skipped by the
- * separators.
- */
-const SECRET_VALUE = String.raw`(?:"[^"]+"|'[^']+'|[^\s"'\`\\][^\s]*)`;
-
-/**
- * `Authorization: <scheme> <value>` / `authorization=<scheme> <value>` inside a
- * shell command line. Any auth scheme (Bearer, Basic, Digest, token, …) is
- * skipped before the value rather than only `Bearer`.
- */
-const AUTHORIZATION_PATTERN = new RegExp(
-  String.raw`\b(authorization\s*[:=]\s*)(?:[A-Za-z0-9._~+/-]+\s+)?(?:\\\s*)?` +
-    SECRET_VALUE,
-  'gi',
-);
-
-/**
- * Secret-bearing long flags: `--token x`, `--password=y`, `--aws-access-key
- * w`. The secret keyword may sit anywhere inside the flag name, so long flags
- * like `--github-api-key` or `--_authToken` are caught too, not only the exact
- * spellings `--token` / `--password`. The value must be a quoted run or an
- * unquoted run of at least 10 characters, mirroring {@link ENV_SECRET_PATTERN}
- * so `--max-tokens 8192` and `max_tokens=8192` are treated the same.
- */
-const SECRET_FLAG_VALUE = String.raw`(?:"[^"]{10,}"|'[^']{10,}'|[^\s"'\`\\][^\s]{9,})`;
-
-const SECRET_FLAG_PATTERN = new RegExp(
-  String.raw`(--[A-Za-z0-9_-]{0,64}?(?:token|password|secret|credential|key)[A-Za-z0-9_-]{0,64}(?:[=:]|\s+)(?:\\\s*)?)` +
-    SECRET_FLAG_VALUE,
-  'gi',
-);
-
-/**
- * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_0123456789ab`,
- * `OPENAI_API_KEY=sk-0123456789ab`, `AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI`.
- * The key must name a secret — any of the canonical secret words, including
- * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — and
- * the value must be a quoted run or an unquoted run of at least 10 characters,
- * so short counters like `tokens_used=8192` and ordinary assignments like
- * `USER=alice` pass through untouched.
- */
-const ENV_SECRET_PATTERN = new RegExp(
-  String.raw`\b([A-Za-z0-9_]{0,64}(?:token|password|secret|credential|key)[A-Za-z0-9_]{0,64}\s*=\s*(?:\\\s*)?)(?:"[^"]{10,}"|'[^']{10,}'|[^\s&;,]{10,})`,
-  'gi',
-);
-
-/**
- * Redacts error text before it enters the usage-statistics sink. Shell
- * command lines are the dominant leak vector — they can embed URL
- * credentials, Authorization headers, or secret flags — so this pass runs on
- * the single enqueue choke point rather than each call site.
- *
- * Shell line continuations (`\` + newline + leading whitespace) are first
- * joined away, then tabs are widened to spaces and ANSI/control characters
- * are stripped per line, so an escape or C0 control character can't hide or
- * reassemble a credential the pattern pass never saw. Splitting on `\n` and
- * re-joining keeps the newline delimiters the whitespace-delimited patterns
- * still depend on.
- */
-function redactTelemetryError(text: string): string {
-  const joined = text.replace(/\\\r?\n[ \t]*/g, '');
-  const normalized = joined
-    .replace(/\t/g, ' ')
-    .split('\n')
-    .map((line) => stripAnsiAndControl(line))
-    .join('\n');
-  return redactUrlCredentials(normalized)
-    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-    .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-    .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`);
-}
+const REDACTED_ERROR_TEXT = '***REDACTED***';
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -298,14 +210,14 @@ export class QwenLogger {
       for (const key of ERROR_TEXT_PROPERTY_KEYS) {
         const value = properties[key];
         if (typeof value === 'string') {
-          properties[key] = redactTelemetryError(value);
+          properties[key] = REDACTED_ERROR_TEXT;
         }
       }
     }
 
     const message = (event as RumExceptionEvent).message;
     if (typeof message === 'string') {
-      (event as RumExceptionEvent).message = redactTelemetryError(message);
+      (event as RumExceptionEvent).message = REDACTED_ERROR_TEXT;
     }
   }
 
@@ -1281,5 +1193,4 @@ export const TEST_ONLY = {
   MAX_RETRY_EVENTS,
   MAX_EVENTS,
   FLUSH_INTERVAL_MS,
-  redactTelemetryError,
 };

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -115,16 +115,17 @@ const MAX_RETRY_EVENTS = 100;
 const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt', 'error'];
 
 /**
- * A secret value in free-form error text: an optional opening quote, a run of
- * non-whitespace/non-quote/non-backslash characters, and an optional closing
- * quote. Accepting the opening quote means `TOKEN="x"`, `--token 'x'` and
- * `Authorization: Bearer "x"` all redact instead of failing on the quote. It
- * never crosses whitespace, so a following token is left untouched. Backslash
- * is excluded so a lone shell line-continuation `\` (or an escaped nested
- * quote) is never consumed as a complete value, which would otherwise leave
- * the real credential cleartext immediately after the redaction marker.
+ * A secret value in free-form error text: either a quoted run (matched up to
+ * its matching closing quote, so interior spaces and quotes don't split it)
+ * or an unquoted run of non-whitespace characters. A quoted value is consumed
+ * whole, so `--password='my secret pw'` and `Authorization: Bearer "x"` redact
+ * without leaking a suffix after the marker. The unquoted alternative refuses
+ * a leading quote/backtick/backslash, so a lone shell line-continuation `\` is
+ * never consumed as a complete value — continuations are normalised ahead of
+ * this pass, and a leading escaped-quote backslash is skipped by the
+ * separators.
  */
-const SECRET_VALUE = String.raw`["'\`]?[^\s"'\`\\]+["'\`]?`;
+const SECRET_VALUE = String.raw`(?:"[^"]+"|'[^']+'|[^\s"'\`\\][^\s]*)`;
 
 /**
  * `Authorization: <scheme> <value>` / `authorization=<scheme> <value>` inside a
@@ -132,7 +133,7 @@ const SECRET_VALUE = String.raw`["'\`]?[^\s"'\`\\]+["'\`]?`;
  * skipped before the value rather than only `Bearer`.
  */
 const AUTHORIZATION_PATTERN = new RegExp(
-  String.raw`\b(authorization\s*[:=]\s*)(?:[A-Za-z0-9._~+/-]+\s+)?` +
+  String.raw`\b(authorization\s*[:=]\s*)(?:[A-Za-z0-9._~+/-]+\s+)?(?:\\\s*)?` +
     SECRET_VALUE,
   'gi',
 );
@@ -144,22 +145,22 @@ const AUTHORIZATION_PATTERN = new RegExp(
  * spellings `--token` / `--password`.
  */
 const SECRET_FLAG_PATTERN = new RegExp(
-  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:[=:]|\s+))` +
+  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:[=:]|\s+)(?:\\\s*)?)` +
     SECRET_VALUE,
   'gi',
 );
 
 /**
  * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_xxx`,
- * `OPENAI_API_KEY=sk_xxx`, `AWS_SECRET_ACCESS_KEY=…`, `DB_PASSWORD=secret`.
+ * `OPENAI_API_KEY=sk_xxx`, `AWS_SECRET_ACCESS_KEY=…`.
  * The key must name a secret — any of the canonical secret words, including
  * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — and
- * the value must be at least 10 non-whitespace characters, so short counters
- * like `tokens_used=8192` and ordinary assignments like `USER=alice` pass
- * through untouched.
+ * the value must be a quoted run or an unquoted run of at least 10 characters,
+ * so short counters like `tokens_used=8192` and ordinary assignments like
+ * `USER=alice` pass through untouched.
  */
 const ENV_SECRET_PATTERN = new RegExp(
-  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*)\S{10,}`,
+  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*(?:\\\s*)?)(?:"[^"]{10,}"|'[^']{10,}'|[^\s&;,]{10,})`,
   'gi',
 );
 
@@ -169,17 +170,24 @@ const ENV_SECRET_PATTERN = new RegExp(
  * credentials, Authorization headers, or secret flags — so this pass runs on
  * the single enqueue choke point rather than each call site.
  *
- * Redaction runs on the raw text (before `stripAnsiAndControl`) so the
- * whitespace-delimited patterns still see their `\n` / `\t` delimiters; the
- * control characters are stripped from the result afterwards.
+ * Shell line continuations (`\` + newline + leading whitespace) are first
+ * joined away, then tabs are widened to spaces and ANSI/control characters
+ * are stripped per line, so an escape or C0 control character can't hide or
+ * reassemble a credential the pattern pass never saw. Splitting on `\n` and
+ * re-joining keeps the newline delimiters the whitespace-delimited patterns
+ * still depend on.
  */
 function redactTelemetryError(text: string): string {
-  return stripAnsiAndControl(
-    redactUrlCredentials(text)
-      .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-      .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-      .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`),
-  );
+  const joined = text.replace(/\\\r?\n[ \t]*/g, '');
+  const normalized = joined
+    .replace(/\t/g, ' ')
+    .split('\n')
+    .map((line) => stripAnsiAndControl(line))
+    .join('\n');
+  return redactUrlCredentials(normalized)
+    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+    .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+    .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`);
 }
 
 export interface LogResponse {

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -116,12 +116,15 @@ const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt', 'error'];
 
 /**
  * A secret value in free-form error text: an optional opening quote, a run of
- * non-whitespace/non-quote characters, and an optional closing quote.
- * Accepting the opening quote means `TOKEN="x"`, `--token 'x'` and
+ * non-whitespace/non-quote/non-backslash characters, and an optional closing
+ * quote. Accepting the opening quote means `TOKEN="x"`, `--token 'x'` and
  * `Authorization: Bearer "x"` all redact instead of failing on the quote. It
- * never crosses whitespace, so a following token is left untouched.
+ * never crosses whitespace, so a following token is left untouched. Backslash
+ * is excluded so a lone shell line-continuation `\` (or an escaped nested
+ * quote) is never consumed as a complete value, which would otherwise leave
+ * the real credential cleartext immediately after the redaction marker.
  */
-const SECRET_VALUE = String.raw`["'\`]?[^\s"'\`]+["'\`]?`;
+const SECRET_VALUE = String.raw`["'\`]?[^\s"'\`\\]+["'\`]?`;
 
 /**
  * `Authorization: <scheme> <value>` / `authorization=<scheme> <value>` inside a
@@ -141,7 +144,7 @@ const AUTHORIZATION_PATTERN = new RegExp(
  * spellings `--token` / `--password`.
  */
 const SECRET_FLAG_PATTERN = new RegExp(
-  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:\s*[=:]\s*|\s+))` +
+  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:[=:]|\s+))` +
     SECRET_VALUE,
   'gi',
 );
@@ -150,12 +153,13 @@ const SECRET_FLAG_PATTERN = new RegExp(
  * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_xxx`,
  * `OPENAI_API_KEY=sk_xxx`, `AWS_SECRET_ACCESS_KEY=…`, `DB_PASSWORD=secret`.
  * The key must name a secret — any of the canonical secret words, including
- * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — so
- * ordinary assignments like `USER=alice` pass through untouched.
+ * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — and
+ * the value must be at least 10 non-whitespace characters, so short counters
+ * like `tokens_used=8192` and ordinary assignments like `USER=alice` pass
+ * through untouched.
  */
 const ENV_SECRET_PATTERN = new RegExp(
-  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*)` +
-    SECRET_VALUE,
+  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*)\S{10,}`,
   'gi',
 );
 

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -142,17 +142,21 @@ const AUTHORIZATION_PATTERN = new RegExp(
  * Secret-bearing long flags: `--token x`, `--password=y`, `--aws-access-key
  * w`. The secret keyword may sit anywhere inside the flag name, so long flags
  * like `--github-api-key` or `--_authToken` are caught too, not only the exact
- * spellings `--token` / `--password`.
+ * spellings `--token` / `--password`. The value must be a quoted run or an
+ * unquoted run of at least 10 characters, mirroring {@link ENV_SECRET_PATTERN}
+ * so `--max-tokens 8192` and `max_tokens=8192` are treated the same.
  */
+const SECRET_FLAG_VALUE = String.raw`(?:"[^"]{10,}"|'[^']{10,}'|[^\s"'\`\\][^\s]{9,})`;
+
 const SECRET_FLAG_PATTERN = new RegExp(
-  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:[=:]|\s+)(?:\\\s*)?)` +
-    SECRET_VALUE,
+  String.raw`(--[A-Za-z0-9_-]{0,64}?(?:token|password|secret|credential|key)[A-Za-z0-9_-]{0,64}(?:[=:]|\s+)(?:\\\s*)?)` +
+    SECRET_FLAG_VALUE,
   'gi',
 );
 
 /**
- * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_xxx`,
- * `OPENAI_API_KEY=sk_xxx`, `AWS_SECRET_ACCESS_KEY=…`.
+ * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_0123456789ab`,
+ * `OPENAI_API_KEY=sk-0123456789ab`, `AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI`.
  * The key must name a secret — any of the canonical secret words, including
  * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — and
  * the value must be a quoted run or an unquoted run of at least 10 characters,
@@ -160,7 +164,7 @@ const SECRET_FLAG_PATTERN = new RegExp(
  * `USER=alice` pass through untouched.
  */
 const ENV_SECRET_PATTERN = new RegExp(
-  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*(?:\\\s*)?)(?:"[^"]{10,}"|'[^']{10,}'|[^\s&;,]{10,})`,
+  String.raw`\b([A-Za-z0-9_]{0,64}(?:token|password|secret|credential|key)[A-Za-z0-9_]{0,64}\s*=\s*(?:\\\s*)?)(?:"[^"]{10,}"|'[^']{10,}'|[^\s&;,]{10,})`,
   'gi',
 );
 

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -74,6 +74,11 @@ import { sanitizeHookName } from '../sanitize.js';
 import { InstallationManager } from '../../config/installationManager.js';
 import { FixedDeque } from 'mnemonist';
 import { AuthType } from '../../core/contentGenerator.js';
+import {
+  redactUrlCredentials,
+  REDACTED_URL_CREDENTIAL,
+} from '../../extension/redaction.js';
+import { stripAnsiAndControl } from '../../utils/textUtils.js';
 
 // Usage statistics collection endpoint
 const USAGE_STATS_HOSTNAME = 'gb4w8c3ygj-default-sea.rum.aliyuncs.com';
@@ -102,6 +107,46 @@ const MAX_EVENTS = 1000;
  * Maximum events to retry after a failed RUM flush
  */
 const MAX_RETRY_EVENTS = 100;
+
+/**
+ * Error-text keys in `properties` that can carry raw shell output or error
+ * text (command lines, HTTP headers, provider error bodies).
+ */
+const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt'];
+
+/**
+ * `Authorization: Bearer <token>` / `authorization=token <value>` inside a
+ * shell command line. The value runs to the next whitespace or quote.
+ */
+const AUTHORIZATION_PATTERN =
+  /\b(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s"'`]+/gi;
+
+/**
+ * Secret-bearing long flags: `--token x`, `--password=y`, `--_authToken w`.
+ */
+const SECRET_FLAG_PATTERN =
+  /(--(?:token|password|secret|api-key|access-token|auth-token|_authToken|_password)(?:\s*[=:]\s*|\s+))[^\s"'`]+/gi;
+
+/**
+ * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_xxx`,
+ * `NPM_TOKEN=npm_xxx`, `DB_PASSWORD=secret`. The key must name a secret, so
+ * ordinary assignments like `USER=alice` pass through untouched.
+ */
+const ENV_SECRET_PATTERN =
+  /\b([A-Za-z0-9_]*(?:token|password|secret|credential)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
+
+/**
+ * Redacts error text before it enters the usage-statistics sink. Shell
+ * command lines are the dominant leak vector — they can embed URL
+ * credentials, Authorization headers, or secret flags — so this pass runs on
+ * the single enqueue choke point rather than each call site.
+ */
+function redactTelemetryError(text: string): string {
+  return redactUrlCredentials(stripAnsiAndControl(text))
+    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+    .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+    .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`);
+}
 
 export interface LogResponse {
   nextRequestWaitMs?: number;
@@ -181,6 +226,7 @@ export class QwenLogger {
 
   enqueueLogEvent(event: RumEvent): void {
     try {
+      this.redactEventErrorText(event);
       // Manually handle overflow for FixedDeque, which throws when full.
       const wasAtCapacity = this.events.size >= MAX_EVENTS;
 
@@ -197,6 +243,23 @@ export class QwenLogger {
       }
     } catch (error) {
       this.debugLogger.error('QwenLogger: Failed to enqueue log event.', error);
+    }
+  }
+
+  private redactEventErrorText(event: RumEvent): void {
+    const properties = event.properties;
+    if (properties) {
+      for (const key of ERROR_TEXT_PROPERTY_KEYS) {
+        const value = properties[key];
+        if (typeof value === 'string') {
+          properties[key] = redactTelemetryError(value);
+        }
+      }
+    }
+
+    const message = (event as RumExceptionEvent).message;
+    if (typeof message === 'string') {
+      (event as RumExceptionEvent).message = redactTelemetryError(message);
     }
   }
 
@@ -1172,4 +1235,5 @@ export const TEST_ONLY = {
   MAX_RETRY_EVENTS,
   MAX_EVENTS,
   FLUSH_INTERVAL_MS,
+  redactTelemetryError,
 };

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -110,42 +110,72 @@ const MAX_RETRY_EVENTS = 100;
 
 /**
  * Error-text keys in `properties` that can carry raw shell output or error
- * text (command lines, HTTP headers, provider error bodies).
+ * text (command lines, HTTP headers, provider error bodies, hook failures).
  */
-const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt'];
+const ERROR_TEXT_PROPERTY_KEYS = ['error_message', 'error_excerpt', 'error'];
 
 /**
- * `Authorization: Bearer <token>` / `authorization=token <value>` inside a
- * shell command line. The value runs to the next whitespace or quote.
+ * A secret value in free-form error text: an optional opening quote, a run of
+ * non-whitespace/non-quote characters, and an optional closing quote.
+ * Accepting the opening quote means `TOKEN="x"`, `--token 'x'` and
+ * `Authorization: Bearer "x"` all redact instead of failing on the quote. It
+ * never crosses whitespace, so a following token is left untouched.
  */
-const AUTHORIZATION_PATTERN =
-  /\b(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s"'`]+/gi;
+const SECRET_VALUE = String.raw`["'\`]?[^\s"'\`]+["'\`]?`;
 
 /**
- * Secret-bearing long flags: `--token x`, `--password=y`, `--_authToken w`.
+ * `Authorization: <scheme> <value>` / `authorization=<scheme> <value>` inside a
+ * shell command line. Any auth scheme (Bearer, Basic, Digest, token, …) is
+ * skipped before the value rather than only `Bearer`.
  */
-const SECRET_FLAG_PATTERN =
-  /(--(?:token|password|secret|api-key|access-token|auth-token|_authToken|_password)(?:\s*[=:]\s*|\s+))[^\s"'`]+/gi;
+const AUTHORIZATION_PATTERN = new RegExp(
+  String.raw`\b(authorization\s*[:=]\s*)(?:[A-Za-z0-9._~+/-]+\s+)?` +
+    SECRET_VALUE,
+  'gi',
+);
+
+/**
+ * Secret-bearing long flags: `--token x`, `--password=y`, `--aws-access-key
+ * w`. The secret keyword may sit anywhere inside the flag name, so long flags
+ * like `--github-api-key` or `--_authToken` are caught too, not only the exact
+ * spellings `--token` / `--password`.
+ */
+const SECRET_FLAG_PATTERN = new RegExp(
+  String.raw`(--[A-Za-z0-9_-]*?(?:token|password|secret|credential|key)[A-Za-z0-9_-]*(?:\s*[=:]\s*|\s+))` +
+    SECRET_VALUE,
+  'gi',
+);
 
 /**
  * `KEY=value` env-style secrets: `GITHUB_TOKEN=ghs_xxx`,
- * `NPM_TOKEN=npm_xxx`, `DB_PASSWORD=secret`. The key must name a secret, so
+ * `OPENAI_API_KEY=sk_xxx`, `AWS_SECRET_ACCESS_KEY=…`, `DB_PASSWORD=secret`.
+ * The key must name a secret — any of the canonical secret words, including
+ * `key` for the `*_API_KEY` / `*_ACCESS_KEY*` LLM credential variables — so
  * ordinary assignments like `USER=alice` pass through untouched.
  */
-const ENV_SECRET_PATTERN =
-  /\b([A-Za-z0-9_]*(?:token|password|secret|credential)[A-Za-z0-9_]*\s*=\s*)[^\s"'`]+/gi;
+const ENV_SECRET_PATTERN = new RegExp(
+  String.raw`\b([A-Za-z0-9_]*(?:token|password|secret|credential|key)[A-Za-z0-9_]*\s*=\s*)` +
+    SECRET_VALUE,
+  'gi',
+);
 
 /**
  * Redacts error text before it enters the usage-statistics sink. Shell
  * command lines are the dominant leak vector — they can embed URL
  * credentials, Authorization headers, or secret flags — so this pass runs on
  * the single enqueue choke point rather than each call site.
+ *
+ * Redaction runs on the raw text (before `stripAnsiAndControl`) so the
+ * whitespace-delimited patterns still see their `\n` / `\t` delimiters; the
+ * control characters are stripped from the result afterwards.
  */
 function redactTelemetryError(text: string): string {
-  return redactUrlCredentials(stripAnsiAndControl(text))
-    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-    .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
-    .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`);
+  return stripAnsiAndControl(
+    redactUrlCredentials(text)
+      .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+      .replace(SECRET_FLAG_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`)
+      .replace(ENV_SECRET_PATTERN, `$1${REDACTED_URL_CREDENTIAL}`),
+  );
 }
 
 export interface LogResponse {


### PR DESCRIPTION
## What this PR does

Usage-statistics telemetry forwards raw tool and provider error text to the RUM endpoint. This PR replaces the known free-form error fields (`error_message`, `error_excerpt`, and top-level `message`) with a fixed `***REDACTED***` marker at the single enqueue boundary before an event can leave the process. (The hook `error` property is removed at its producer `logHookCallEvent` rather than marker-replaced, so `hook_call#*.properties.error` is no longer collected at all.)

## Why it's needed

A failed shell command can contain a credential in a URL, an authorization header, a flag, an environment assignment, truncated output, or an unanticipated form. Parsing that untrusted text with a growing regex denylist cannot prove that the credential is gone and can itself become a CPU denial-of-service path. Replacing the whole error string is smaller and fails closed.

## Reviewer Test Plan

### How to verify

Run the focused unit suite:

```
cd packages/core && npx vitest run src/telemetry/qwen-logger/qwen-logger.test.ts
```

The regression drives the public enqueue boundary with all currently known error-text properties plus a top-level exception message. It asserts that every raw value is replaced while a non-text classification field is unchanged.

### Evidence (Before & After)

Before: an event whose error text contained `git clone https://x-access-token:ghs_testsecret123@github.com/...` was enqueued with the complete command and token.

After: the entire error-text field is enqueued as `***REDACTED***`; no input substring is retained or parsed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

Unit tests only — `npx vitest run` inside `packages/core`.

## Risk & Scope

The implementation now replaces whole error fields, superseding the earlier shape-based masking proposal recorded on #11198. The privacy/diagnostics tradeoff still needs maintainer confirmation; this PR must not automatically close that issue before the decision is recorded.

- Main risk or tradeoff: usage-statistics events retain the fact that an error occurred and their structured classifications, but no longer retain free-form error diagnostics. This is deliberate because the channel is default-on and any partial text policy can leak credentials.
- Not validated / out of scope: `snapshots` and `stack` are separate structured fields and are not changed here; any sensitive producer-to-sink path through them should be handled separately.
- Breaking changes / migration notes: none for the public API; backend users must rely on structured error fields instead of raw text.

## Linked Issues

Refs #11198

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

usage-statistics 遥测会把工具和 provider 的原始错误文本发送到 RUM endpoint。本 PR 在事件离开进程前的唯一入队边界，将当前已知的自由文本错误字段（`error_message`、`error_excerpt` 和顶层 `message`）统一替换为固定的 `***REDACTED***` 标记。（hook 的 `error` 属性在其生产者 `logHookCallEvent` 处被移除、而非替换为标记，因此 `hook_call#*.properties.error` 不再被采集。）

## 为什么需要它

失败的 shell 命令可能以 URL、Authorization header、命令参数、环境变量、截断输出或任意其他形式携带凭据。不断扩展正则黑名单无法证明凭据已被完整清除，还会为不可信错误文本引入 CPU 拒绝服务风险。整段替换更小，也能失败关闭。

## Reviewer 测试计划

### 如何验证

运行聚焦的单元测试：

```
cd packages/core && npx vitest run src/telemetry/qwen-logger/qwen-logger.test.ts
```

回归测试直接走公开的入队边界，覆盖当前所有已知错误文本属性和顶层异常消息；它断言原始值全部被替换，同时非文本分类字段保持不变。

### 证据（Before & After）

Before：错误文本包含 `git clone https://x-access-token:ghs_testsecret123@github.com/...` 的事件，会带着完整命令和 token 入队。

After：整段错误文本被替换为 `***REDACTED***`，不保留也不解析任何输入片段。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### 环境（可选）

仅单元测试——在 `packages/core` 内运行 `npx vitest run`。

## 风险与范围

当前实现替换整个错误字段，已不同于 #11198 先前记录的按内容模式遮罩方案。隐私与诊断信息之间的取舍仍需维护者确认，因此本 PR 不应在决策记录之前自动关闭该 issue。

- 主要风险或取舍：usage-statistics 事件仍保留“发生错误”的事实和结构化分类，但不再保留自由文本诊断信息。该取舍是有意的，因为此通道默认开启，任何保留部分文本的策略都可能泄漏凭据。
- 未验证 / 超出范围：`snapshots` 和 `stack` 是独立的结构化字段，本 PR 不修改；如果它们存在敏感的 producer-to-sink 路径，应单独处理。
- 破坏性变更 / 迁移说明：公共 API 无变化；后端分析应依赖结构化错误字段，而不是原始错误文本。

## 关联 Issue

Refs #11198

</details>
