### PR TITLE
fix(core): stop mirroring reasoning_content into reasoning for Fireworks

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -19,6 +19,7 @@ import {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   CerebrasOpenAICompatibleProvider,
+  FireworksOpenAICompatibleProvider,
   type OpenAICompatibleProvider,
   DefaultOpenAICompatibleProvider,
 } from './provider/index.js';
@@ -35,6 +36,7 @@ export {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   CerebrasOpenAICompatibleProvider,
+  FireworksOpenAICompatibleProvider,
 } from './provider/index.js';
 
 export { OpenAIContentConverter } from './converter.js';
@@ -114,6 +116,14 @@ export function determineProvider(
   // Check for Cerebras provider
   if (CerebrasOpenAICompatibleProvider.isCerebrasProvider(config)) {
     return new CerebrasOpenAICompatibleProvider(
+      contentGeneratorConfig,
+      cliConfig,
+    );
+  }
+
+  // Check for Fireworks provider
+  if (FireworksOpenAICompatibleProvider.isFireworksProvider(config)) {
+    return new FireworksOpenAICompatibleProvider(
       contentGeneratorConfig,
       cliConfig,
     );

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -223,7 +223,7 @@ export class DefaultOpenAICompatibleProvider
     const requestWithTokenLimits = this.clampConfiguredReasoningEffort(
       this.applyOutputTokenLimit(request),
     );
-    const messages = isQwen3Model(request.model)
+    const messages = this.shouldMirrorReasoningContent(request.model)
       ? requestWithTokenLimits.messages.map(mirrorReasoningContentToReasoning)
       : requestWithTokenLimits.messages;
 
@@ -234,6 +234,16 @@ export class DefaultOpenAICompatibleProvider
     };
     this.flattenGptReasoningEffort(result);
     return result;
+  }
+
+  /**
+   * Whether outbound assistant messages get `reasoning_content` mirrored
+   * into the additional `reasoning` field. qwen3-class models on generic
+   * OpenAI-compatible endpoints read that field; endpoints that reject
+   * unknown message fields (e.g. Fireworks) override this to opt out.
+   */
+  protected shouldMirrorReasoningContent(model: string): boolean {
+    return isQwen3Model(model);
   }
 
   protected flattenGptReasoningEffort(body: Record<string, unknown>): void {

--- a/packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type OpenAI from 'openai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { determineProvider } from '../index.js';
+import { FireworksOpenAICompatibleProvider } from './fireworks.js';
+
+function createCliConfig(): Config {
+  return {
+    getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+    getProxy: vi.fn().mockReturnValue(undefined),
+  } as unknown as Config;
+}
+
+function createProviderConfig(
+  overrides: Partial<ContentGeneratorConfig>,
+): ContentGeneratorConfig {
+  return {
+    apiKey: 'test-api-key',
+    baseUrl: 'https://api.fireworks.ai/inference/v1',
+    model: 'accounts/fireworks/models/qwen3p8-max',
+    ...overrides,
+  } as ContentGeneratorConfig;
+}
+
+type AssistantWithReasoning =
+  OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+    reasoning_content?: string;
+    reasoning?: string;
+  };
+
+/** A tool-call continuation: the assistant's thinking turn followed by the tool result. */
+function createToolContinuationRequest(
+  model = 'accounts/fireworks/models/qwen3p8-max',
+): OpenAI.Chat.ChatCompletionCreateParams {
+  return {
+    model,
+    messages: [
+      { role: 'user', content: 'list the files here' },
+      {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'I should list the directory.',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'list_directory', arguments: '{"path":"."}' },
+          },
+        ],
+      } as AssistantWithReasoning,
+      { role: 'tool', tool_call_id: 'call_1', content: 'README.md' },
+    ],
+    max_tokens: 1000,
+  };
+}
+
+describe('Fireworks provider detection', () => {
+  it.each([
+    ['https://api.fireworks.ai/inference/v1', true],
+    ['https://API.Fireworks.AI/inference/v1', true],
+    ['https://proxy.api.fireworks.ai/inference/v1', true],
+    ['https://api.fireworks.ai.example.com/v1', false],
+    ['https://openrouter.ai/api/v1', false],
+    ['https://api.openai.com/v1', false],
+    ['', false],
+    ['not a url', false],
+  ])('classifies baseUrl %s as fireworks=%s', (baseUrl, expected) => {
+    expect(
+      FireworksOpenAICompatibleProvider.isFireworksProvider(
+        createProviderConfig({ baseUrl }),
+      ),
+    ).toBe(expected);
+  });
+
+  it('is selected by determineProvider for api.fireworks.ai', () => {
+    const provider = determineProvider(
+      createProviderConfig({}),
+      createCliConfig(),
+    );
+    expect(provider).toBeInstanceOf(FireworksOpenAICompatibleProvider);
+  });
+});
+
+describe('Fireworks qwen3 tool-call continuation (issue #11657)', () => {
+  it('keeps reasoning_content and does not add the mirrored reasoning field', () => {
+    const originalRequest = createToolContinuationRequest();
+    const provider = determineProvider(
+      createProviderConfig({}),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+    const assistant = result.messages[1] as AssistantWithReasoning;
+
+    expect(assistant.reasoning_content).toBe('I should list the directory.');
+    expect('reasoning' in assistant).toBe(false);
+    expect(assistant.tool_calls).toHaveLength(1);
+    expect(result.messages[2]).toEqual(originalRequest.messages[2]);
+    // The caller's request is left untouched.
+    expect(originalRequest.messages[1]).not.toHaveProperty('reasoning');
+  });
+
+  it('still mirrors reasoning_content for qwen3 models on other OpenAI-compatible endpoints', () => {
+    const originalRequest = createToolContinuationRequest('qwen3-coder-plus');
+    const provider = determineProvider(
+      createProviderConfig({
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen3-coder-plus',
+      }),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+    const assistant = result.messages[1] as AssistantWithReasoning;
+
+    expect(assistant.reasoning_content).toBe('I should list the directory.');
+    expect(assistant.reasoning).toBe('I should list the directory.');
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/fireworks.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/fireworks.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+const FIREWORKS_API_HOST = 'api.fireworks.ai';
+
+/**
+ * Hostname-only detection: Fireworks serves third-party model names
+ * (`accounts/fireworks/models/qwen3p8-max`, `llama-*`, ...), so a
+ * model-name fallback would misroute other providers' models.
+ */
+export function isFireworksProvider(config: ContentGeneratorConfig): boolean {
+  const baseUrl = config.baseUrl ?? '';
+  if (!baseUrl) return false;
+
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      hostname === FIREWORKS_API_HOST ||
+      hostname.endsWith(`.${FIREWORKS_API_HOST}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fireworks accepts `messages[].reasoning_content` on input but rejects the
+ * additional `reasoning` field the default provider mirrors it into for
+ * qwen3 models (`400 Extra inputs are not permitted, field:
+ * 'messages[N].reasoning'`), so every tool-call continuation after a
+ * thinking turn failed (issue #11657). Whether a field is mirrored is a
+ * property of the endpoint, not of the model family: keep the shared
+ * history and `reasoning_content` intact and skip the mirror at the
+ * outbound request boundary.
+ */
+export class FireworksOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  static isFireworksProvider = isFireworksProvider;
+
+  protected override shouldMirrorReasoningContent(_model: string): boolean {
+    return false;
+  }
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -5,6 +5,7 @@ export { ZaiOpenAICompatibleProvider } from './zai.js';
 export { MiniMaxOpenAICompatibleProvider } from './minimax.js';
 export { MistralOpenAICompatibleProvider } from './mistral.js';
 export { CerebrasOpenAICompatibleProvider } from './cerebras.js';
+export { FireworksOpenAICompatibleProvider } from './fireworks.js';
 export { MiMoOpenAICompatibleProvider } from './mimo.js';
 export { DefaultOpenAICompatibleProvider } from './default.js';
 export type {


### PR DESCRIPTION
## What this PR does

Makes reasoning-field mirroring a provider decision instead of a model-name decision, and adds a Fireworks provider (detected by the `api.fireworks.ai` hostname, including subdomains, the same way Cerebras is detected) that keeps `reasoning_content` on outbound assistant messages but does not add the mirrored `reasoning` field. Every other endpoint keeps today's behaviour: qwen3 models on generic OpenAI-compatible endpoints still get the mirror, and the shared conversation history is never mutated.

## Why it's needed

The default OpenAI-compatible provider copies `reasoning_content` into an additional `reasoning` field for any model id containing `qwen3`. Fireworks accepts `reasoning_content` on input but rejects the extra field with `400 Extra inputs are not permitted, field: 'messages[N].reasoning'`, so with Qwen 3.8 Max on Fireworks the first response (reasoning plus a tool call) succeeds and the continuation that sends the tool result back always fails. A model-family match does not establish that the endpoint supports the additional field; this follows the Cerebras precedent from #11049 where the decision was moved to the provider boundary.

## Reviewer Test Plan

### How to verify

Configure the OpenAI-compatible provider with `baseUrl` `https://api.fireworks.ai/inference/v1` and model `accounts/fireworks/models/qwen3p8-max`, ask the model to use a tool (for example list the files in the current directory), and let it continue after the tool result. Before: the request after the tool result fails with the 400 above. After: the continuation succeeds and the assistant's `reasoning_content` is still sent back. On a non-Fireworks endpoint (for example OpenRouter with a qwen3 model) the outbound assistant messages still carry both `reasoning_content` and `reasoning`.

Unit tests cover the hostname detection (exact host, upper case, subdomain, lookalike host, other providers, empty and invalid base URLs), provider selection, the tool-call continuation shape for Fireworks (reasoning_content kept, no `reasoning` field, tool calls and tool result untouched, caller's request not mutated), and the unchanged mirror on other endpoints.

```
packages/core: npx vitest run src/core/openaiContentGenerator/provider/fireworks.test.ts src/core/openaiContentGenerator/provider/cerebras.test.ts src/core/openaiContentGenerator/provider/default.test.ts
Test Files  3 passed (3)
     Tests  70 passed (70)
packages/core: npx tsc --noEmit   # clean
npx prettier --check / npx eslint on the changed files   # clean
```

### Evidence (Before & After)

N/A (no TUI change; request-shape evidence is in the unit tests above)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A, unit tests only.

## Risk & Scope

- Main risk or tradeoff: a Fireworks deployment that relied on the mirrored `reasoning` field would lose it; Fireworks documents `reasoning_content` as the field to pass back, and rejects `reasoning`, so no working configuration depends on it.
- Not validated / out of scope: no live call against Fireworks from this environment; other endpoints that also reject unknown message fields are not addressed here beyond making the provider hook available for them.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #11657

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 reasoning 字段的镜像行为从「按模型名判断」改为「按 provider 判断」，并新增一个 Fireworks provider（通过 `api.fireworks.ai` 主机名识别，包含子域名，与 Cerebras 的识别方式一致）：它在发出的 assistant 消息中保留 `reasoning_content`，但不再附加镜像出来的 `reasoning` 字段。其他端点的行为完全不变：通用 OpenAI 兼容端点上的 qwen3 模型仍然会带上镜像字段，共享的会话历史也不会被修改。

## 为什么需要它

默认的 OpenAI 兼容 provider 会为任何包含 `qwen3` 的模型 id 把 `reasoning_content` 复制到额外的 `reasoning` 字段。Fireworks 在输入上接受 `reasoning_content`，却会以 `400 Extra inputs are not permitted, field: 'messages[N].reasoning'` 拒绝这个额外字段。因此在 Fireworks 上使用 Qwen 3.8 Max 时，第一次响应（推理加一次工具调用）可以成功，而把工具结果送回去的后续请求必定失败。模型族匹配并不能说明端点支持这个额外字段；这里沿用 #11049 的 Cerebras 先例，把判断移到 provider 边界上。

## 评审者测试方案

### 如何验证

把 OpenAI 兼容 provider 的 `baseUrl` 配置为 `https://api.fireworks.ai/inference/v1`，模型配置为 `accounts/fireworks/models/qwen3p8-max`，让模型使用一次工具（例如列出当前目录的文件），并在工具结果返回后让它继续。修复前：工具结果之后的请求以上面的 400 失败。修复后：后续请求成功，并且 assistant 的 `reasoning_content` 仍然会被送回。在非 Fireworks 端点上（例如 OpenRouter 配 qwen3 模型），发出的 assistant 消息仍然同时带有 `reasoning_content` 和 `reasoning`。

单元测试覆盖了主机名识别（精确匹配、大写、子域名、相似域名、其他 provider、空的与非法的 base URL）、provider 选择、Fireworks 上工具调用续写的报文形状（保留 reasoning_content、没有 `reasoning` 字段、工具调用与工具结果不变、调用方传入的请求对象不被修改），以及其他端点上镜像行为保持不变。

```
packages/core: npx vitest run src/core/openaiContentGenerator/provider/fireworks.test.ts src/core/openaiContentGenerator/provider/cerebras.test.ts src/core/openaiContentGenerator/provider/default.test.ts
Test Files  3 passed (3)
     Tests  70 passed (70)
packages/core: npx tsc --noEmit   # 无错误
npx prettier --check / npx eslint 对改动文件   # 无错误
```

### 证据（修复前与修复后）

N/A（不涉及 TUI 改动；报文形状的证据见上面的单元测试）

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

N/A，仅单元测试。

## 风险与范围

- 主要风险或权衡：如果某个 Fireworks 部署依赖镜像出来的 `reasoning` 字段，它将不再收到该字段；Fireworks 文档规定回传时应使用 `reasoning_content`，并且会拒绝 `reasoning`，因此不存在依赖它的可用配置。
- 未验证 / 不在范围内：本环境没有对 Fireworks 发起真实调用；其他同样拒绝未知消息字段的端点，除了现在可以复用这个 provider 钩子之外，本 PR 不做处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Closes #11657

</details>
