### PR TITLE
fix(core): redact request-body prefix in Responses debug logs

### DIFF
--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts
@@ -228,6 +228,67 @@ describe('ResponsesPipeline', () => {
     ]);
   });
 
+  it('logs only request metadata, never raw request-body bytes (issue #11667)', async () => {
+    // Synthetic markers that must never reach the debug log: a user prompt,
+    // a tool name, a replayed reasoning id, and its encrypted content. The
+    // pre-fix code logged `body.substring(0, 500)` — which serializes `model`
+    // first and then `input` — so all four would leak into the per-session
+    // debug file.
+    const promptMarker = 'PROMPT_SECRET_MARKER_7f3a';
+    const toolMarker = 'TOOL_SECRET_MARKER_9c1b';
+    const reasoningIdMarker = 'REASONING_ID_SECRET_2d4e';
+    const encryptedMarker = 'ENCRYPTED_CONTENT_SECRET_5b6f';
+
+    mockResponse(
+      sseEvent('response.completed', { response: { status: 'completed' } }),
+    );
+    const pipeline = new ResponsesPipeline(
+      makeGeneratorConfig(),
+      makeCliConfig(),
+    );
+    const request: GenerateContentParameters = {
+      model: 'gpt-5',
+      contents: [
+        { role: 'user', parts: [{ text: `${promptMarker} hello` }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              thought: true,
+              thoughtSignature: JSON.stringify({
+                id: reasoningIdMarker,
+                encrypted_content: encryptedMarker,
+              }),
+            },
+          ],
+        },
+      ],
+      config: {
+        tools: [{ functionDeclarations: [{ name: toolMarker }] }],
+      },
+    };
+    for await (const _ of pipeline.executeStream(request, 'prompt-1')) {
+      // drain
+    }
+
+    const logged = debugMock.mock.calls
+      .flat()
+      .map((a) => String(a))
+      .join(' ');
+    // No raw content may leak into the debug log.
+    expect(logged).not.toContain(promptMarker);
+    expect(logged).not.toContain(toolMarker);
+    expect(logged).not.toContain(reasoningIdMarker);
+    expect(logged).not.toContain(encryptedMarker);
+    // …but the transport diagnostic must stay: method + redacted URL, byte
+    // length, and per-input-item-type counts.
+    expect(logged).toContain('POST https://api.openai.com/v1/responses');
+    expect(logged).toContain('bodyBytes=');
+    expect(logged).toContain('inputItems=');
+    expect(logged).toContain('message=1');
+    expect(logged).toContain('reasoning=1');
+  });
+
   it('keys prompt_cache_key on the session so it stays stable across turns', async () => {
     // userPromptId is `${sessionId}########${counter}` and changes on every
     // send, so keying on it directly gives each turn its own cache namespace
@@ -1499,7 +1560,8 @@ describe('ResponsesPipeline', () => {
 
     expect(debugMock).toHaveBeenCalledWith(
       'POST https://<redacted>@gateway.example/v1/responses',
-      expect.any(String),
+      expect.stringContaining('bodyBytes='),
+      expect.stringContaining('inputItems='),
     );
     expect(inspect(debugMock.mock.calls)).not.toContain('review-secret');
     expect(inspect(debugMock.mock.calls)).not.toContain('review-user');

--- a/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.ts
+++ b/packages/core/src/core/openaiResponsesContentGenerator/responses-pipeline.ts
@@ -9,6 +9,7 @@ import type { GenerateContentParameters } from '@google/genai';
 import type { ContentGeneratorConfig } from '../contentGenerator.js';
 import type { Config } from '../../config/config.js';
 import type {
+  ResponsesApiInputItem,
   ResponsesApiRequest,
   ResponsesApiReasoning,
   ResponsesSSEEvent,
@@ -594,7 +595,8 @@ export class ResponsesPipeline {
     const body = JSON.stringify(apiRequest);
     debugLogger.debug(
       `POST ${redactProxyCredentials(url)}`,
-      body.substring(0, 500),
+      `bodyBytes=${body.length}`,
+      `inputItems=${summarizeInputItemTypes(apiRequest.input)}`,
     );
 
     // Compose the caller's AbortSignal with a connect-timeout controller so a
@@ -1109,6 +1111,22 @@ function sanitizePromptCacheKey(key: string): string {
     .update(key)
     .digest('hex')
     .slice(0, PROMPT_CACHE_KEY_MAX_LENGTH);
+}
+
+/**
+ * Counts `input` items by type for the connect-phase debug log. Metadata only:
+ * the log must never carry message text, tool names/arguments, reasoning ids,
+ * or encrypted reasoning content (see the sibling convention at
+ * `buildReasoningReplayRetry` and issue #11667).
+ */
+function summarizeInputItemTypes(items: ResponsesApiInputItem[]): string {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item.type, (counts.get(item.type) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([type, count]) => `${type}=${count}`)
+    .join(',');
 }
 
 interface ResponsesApiError extends ResponsesHttpError {


### PR DESCRIPTION
## What this PR does

The Responses pipeline's connect-phase debug log currently writes the first 500 characters of the serialized request body (`body.substring(0, 500)`), which — because `model` serializes before `input` — leaks user/system/assistant message text, tool names and arguments, reasoning ids, and encrypted reasoning content into the per-session debug file. This PR replaces the raw body prefix with structured metadata: the redacted URL (unchanged), the byte length, and per-`input[].type` item counts.

## Why it's needed

Debug logging is opt-in (`QWEN_DEBUG_LOG_FILE`, `--debug`, `DEBUG=1`), but once enabled, every Responses request writes prompt and reasoning content into `~/.qwen/debug/<sessionId>.txt`. #8169 hardened the request URL and response-error surfaces but not this request-body site (issue #11667). This change closes that gap and removes the contradiction with the file's own "Metadata only: no id, no encrypted content, no endpoint" convention at the reasoning-replay retry log.

## Reviewer Test Plan

### How to verify

Run the Responses pipeline with a request carrying a unique prompt, a tool, and a replayed reasoning item (id + encrypted_content) against a mock SSE response, then assert the debug log carries none of those markers while still carrying the URL, byte length, and item counts.

`cd packages/core && npx vitest run src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts`

The new test `logs only request metadata, never raw request-body bytes (issue #11667)` fails on the pre-fix code (the prompt marker appears in the logged body prefix) and passes after the fix.

### Evidence (Before & After)

Before (real file logger, `QWEN_DEBUG_LOG_FILE=1`, loopback SSE server):

```
[DEBUG] [RESPONSES_PIPELINE] POST http://127.0.0.1:PORT/v1/responses {"model":"gpt-5","input":[{"type":"message","role":"user","content":"PROMPT_SECRET_MARKER_7f3a hello"},{"type":"reasoning","id":"REASONING_ID_SECRET_2d4e","encrypted_content":"ENCRYPTED_CONTENT_SECRET_5b6f","summary":[]}],"tools":[{"type":"function","name":"TOOL_SECRET_MARKER_9c1b"}],...}
```

After:

```
[DEBUG] [RESPONSES_PIPELINE] POST http://127.0.0.1:PORT/v1/responses bodyBytes=406 inputItems=message=1,reasoning=1
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (vitest) plus a local loopback SSE probe with the real file logger.

## Risk & Scope

- Main risk or tradeoff: the debug log loses the raw body prefix, which some transport debugging may have relied on; byte length + item counts retain the useful signal (what was sent, how large, what item types). No functional or wire behavior changes.
- Not validated / out of scope: the three response-side "Failed to parse SSE data" prefix logs (malformed-frame-only) are left unchanged, as they are outside the reported request-body scope.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11667

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Responses 管线的连接阶段调试日志此前会把序列化请求体的前 500 字符（`body.substring(0, 500)`）写入日志——由于 `model` 先于 `input` 序列化，会泄露用户/系统/助手消息文本、工具名与参数、reasoning id 以及加密推理内容到每会话调试文件。本 PR 将其替换为结构化元数据：已脱敏的 URL（保持不变）、字节长度、按 `input[].type` 统计的条目数。

## 为什么需要

调试日志是 opt-in 的（`QWEN_DEBUG_LOG_FILE`、`--debug`、`DEBUG=1`），但一旦开启，每次 Responses 请求都会把 prompt 与推理内容写进 `~/.qwen/debug/<sessionId>.txt`。#8169 加固了请求 URL 与响应错误两个面，但未覆盖此请求体记录点（issue #11667）。本改动补齐该缺口，并消除与本文件自身推理重放重试日志中“Metadata only: no id, no encrypted content, no endpoint”约定之间的矛盾。

## Reviewer 验证计划

### 如何验证

用一个携带唯一 prompt、工具以及重放 reasoning 条目（id + encrypted_content）的请求跑 Responses 管线（mock SSE 响应），断言调试日志不含任何这些 marker，同时仍含 URL、字节长度与条目计数。

`cd packages/core && npx vitest run src/core/openaiResponsesContentGenerator/responses-pipeline.test.ts`

新测试 `logs only request metadata, never raw request-body bytes (issue #11667)` 在修复前失败（prompt marker 出现在日志的 body 前缀里），修复后通过。

### 证据（Before & After）

Before（真实文件 logger，`QWEN_DEBUG_LOG_FILE=1`，loopback SSE 服务）：

```
[DEBUG] [RESPONSES_PIPELINE] POST http://127.0.0.1:PORT/v1/responses {"model":"gpt-5","input":[{"type":"message","role":"user","content":"PROMPT_SECRET_MARKER_7f3a hello"},{"type":"reasoning","id":"REASONING_ID_SECRET_2d4e","encrypted_content":"ENCRYPTED_CONTENT_SECRET_5b6f","summary":[]}],"tools":[{"type":"function","name":"TOOL_SECRET_MARKER_9c1b"}],...}
```

After：

```
[DEBUG] [RESPONSES_PIPELINE] POST http://127.0.0.1:PORT/v1/responses bodyBytes=406 inputItems=message=1,reasoning=1
```

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 运行环境（可选）

仅单元测试（vitest），外加本地 loopback SSE 探针 + 真实文件 logger。

## 风险与范围

- 主要风险/取舍：调试日志不再含原始 body 前缀，部分传输层排查可能曾依赖它；字节长度 + 条目计数保留了有用信号（发送了什么、多大、哪些条目类型）。无功能或线上行为变更。
- 未验证/不在范围内：三处响应侧“Failed to parse SSE data”前缀日志（仅畸形帧触发）保持不变，不属于本报告请求体范围。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #11667

</details>
