### PR TITLE
fix(web-shell): suppress abort toasts on preflight rejection

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -21732,6 +21732,46 @@ describe('App session callbacks', () => {
     );
   });
 
+  // #11432: a daemon teardown rejects the preflight with an AbortError, which
+  // is a cancellation rather than a failure. reportError suppresses aborts, so
+  // no toast should surface — unlike a real (localized) rejection above.
+  it('stays silent when preparation rejects with an AbortError', async () => {
+    const abortError = new Error('cancelled');
+    abortError.name = 'AbortError';
+    const prepareSubmit = vi.fn().mockRejectedValue(abortError);
+    const onToast = vi.fn();
+    const { container } = renderApp({ prepareSubmit, onToast });
+    await flush();
+
+    await clickSubmit(container);
+    await flush();
+
+    expect(prepareSubmit).toHaveBeenCalled();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when a queued preparation rejects with an AbortError', async () => {
+    const abortError = new Error('cancelled');
+    abortError.name = 'AbortError';
+    const prepareSubmit = vi.fn().mockRejectedValue(abortError);
+    const onToast = vi.fn();
+    const { container, rerender } = renderApp({ prepareSubmit, onToast });
+    await flush();
+
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender({ prepareSubmit, onToast });
+    });
+
+    await clickSubmit(container);
+    await flush();
+
+    expect(prepareSubmit).toHaveBeenCalled();
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
   it('keeps the draft when preparation removes all prompt content', async () => {
     const prepareSubmit = vi.fn().mockResolvedValue({
       prompt: '',

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1377,6 +1377,8 @@ export interface WebShellProps {
    * direct or queued logical submit, after local command routing and before
    * session creation, composer commit, optimistic rendering, or admission.
    * Retries reuse the previously prepared payload and skip this callback.
+   * If this callback rejects, the submission is cancelled and the rejection's
+   * `Error.message` is surfaced to the user, so hosts must localize it.
    */
   prepareSubmit?: (
     submission: WebShellSubmitSnapshot,
@@ -1386,6 +1388,8 @@ export interface WebShellProps {
    * until the Promise resolves. If the Promise rejects, the prompt is cancelled.
    * `sessionId` is `undefined` when the session has not yet been created (deferred).
    * Also called for queued prompts (submitted while a turn is streaming).
+   * A rejection's `Error.message` is surfaced to the user, so hosts must
+   * localize it.
    */
   onSubmitBefore?: (params: {
     sessionId: string | undefined;
@@ -9710,6 +9714,25 @@ export function App({
   // to be recreated on every render, cascading into downstream effect chains.
   const dispatchSessionChangeRef = useRef(dispatchSessionChange);
   dispatchSessionChangeRef.current = dispatchSessionChange;
+  // Single error-to-toast helper: suppresses aborts, daemon-turn errors and
+  // already-dispatched notices before surfacing anything. Declared above
+  // sendPrompt / enqueuePrompt so their dep arrays can reference it (a
+  // reference below those callbacks would be a TDZ error).
+  const reportError = useCallback(
+    (error: unknown, fallback: string) => {
+      if (isAbortError(error)) return;
+      if (isDaemonTurnError(error)) {
+        return;
+      }
+      if (isAlreadyDispatched(error)) {
+        return;
+      }
+      const message = formatError(error, fallback);
+      console.error('[web-shell]', message, error);
+      pushToast('error', message);
+    },
+    [pushToast],
+  );
   const sendPrompt = useCallback(
     async (
       text: string,
@@ -9828,21 +9851,16 @@ export function App({
           }
         } catch (err) {
           if (!appMountedRef.current) return;
-          console.warn(
-            '[web-shell] prompt preflight rejected, prompt cancelled',
-            err,
-          );
           // Say so. Hosts put user-facing text in these errors — the VS Code
           // companion's message-edit rewind throws localized failures here —
-          // and cancelling on a console warning alone leaves the user in front
-          // of a composer that appeared to do nothing (#9911). Only when the
-          // user is still on the session this submission belonged to; a toast
-          // for a session they have left would be noise.
+          // and cancelling silently leaves the user in front of a composer
+          // that appeared to do nothing (#9911). Only when the user is still
+          // on the session this submission belonged to; a toast for a session
+          // they have left would be noise. reportError suppresses aborts and
+          // logs the error itself, so this catch no longer warns (that would
+          // double-log a real failure).
           if (admissionOwnerIsCurrent()) {
-            pushToast(
-              'error',
-              formatError(err, 'Message could not be submitted'),
-            );
+            reportError(err, 'Message could not be submitted');
           }
           // Restore retry-critical refs so Ctrl+Y doesn't resend the
           // cancelled prompt.
@@ -10046,7 +10064,7 @@ export function App({
       ensureSessionForPrompt,
       finishPromptPreparation,
       getComposerWorkspaceCwd,
-      pushToast,
+      reportError,
       sessionCatalogController,
       sessionActions,
       sessionOwnerGuard,
@@ -10306,21 +10324,6 @@ export function App({
     ]),
   );
 
-  const reportError = useCallback(
-    (error: unknown, fallback: string) => {
-      if (isAbortError(error)) return;
-      if (isDaemonTurnError(error)) {
-        return;
-      }
-      if (isAlreadyDispatched(error)) {
-        return;
-      }
-      const message = formatError(error, fallback);
-      console.error('[web-shell]', message, error);
-      pushToast('error', message);
-    },
-    [pushToast],
-  );
   const handleFailedPromptRetry = useCallback(() => {
     if (
       sessionWriteBlockedRef.current ||
@@ -10629,22 +10632,17 @@ export function App({
               sourceWorkspaceCwd,
             );
           } catch (err) {
-            console.warn(
-              '[web-shell] queued prompt preflight rejected, cancelled',
-              err,
-            );
             // A rejected preflight cancels the submission, so it has to say so.
             // Hosts put user-facing text in these errors — the VS Code
-            // companion's rewind failures are localized strings — and a console
-            // warning leaves the user in front of a composer that silently did
-            // nothing (#9911). Stay quiet only when this submission is no
-            // longer the current one, where the toast would belong to a session
-            // the user has already left.
+            // companion's rewind failures are localized strings — and a silent
+            // cancel leaves the user in front of a composer that did nothing
+            // (#9911). Stay quiet only when this submission is no longer the
+            // current one, where the toast would belong to a session the user
+            // has already left. reportError suppresses aborts and logs the
+            // error itself, so this catch no longer warns (that would
+            // double-log a real failure).
             if (submissionSessionIsCurrent()) {
-              pushToast(
-                'error',
-                formatError(err, 'Message could not be submitted'),
-              );
+              reportError(err, 'Message could not be submitted');
             }
           }
         })();
@@ -10661,7 +10659,7 @@ export function App({
     },
     [
       getComposerWorkspaceCwd,
-      pushToast,
+      reportError,
       rawEnqueuePrompt,
       sessionCatalogController,
       sessionOwnerGuard,


### PR DESCRIPTION
## What this PR does

Completes the web-shell half of #11432 by routing the two preflight-failure toast sites in `packages/web-shell/client/App.tsx` through the file's existing `reportError` helper instead of hand-rolling `pushToast('error', formatError(err, ...))`. `reportError` suppresses `AbortError`, daemon-turn errors and already-dispatched notices before surfacing anything, so a daemon teardown that rejects a submission with an `AbortError` now stays silent instead of showing a "failed" toast for a submission the user cancelled.

To do this, `reportError` is hoisted above `sendPrompt`/`enqueuePrompt` — its declaration previously sat below both, which would be a TDZ error once their dependency arrays referenced it. The now-redundant `console.warn` in each preflight catch is dropped, because `reportError` already logs the error via `console.error` and keeping the warn would double-log every real failure (this is the "reportError double-logging" item the CI triage on #11432 asked to fold into scope). The `prepareSubmit`/`onSubmitBefore` prop contract now states that a rejection's `Error.message` is shown to the user, so hosts must localize it.

## Why it's needed

#11432 was deferred from #11171's review thread as two halves. Half 1 (localizing rewind preflight errors in the VS Code companion) landed in #11628. This PR is the remaining half: suppressing the abort toast, so a cancelled submission doesn't surface a spurious "failed" toast.

## Reviewer Test Plan

### How to verify

A witness test asserts `onToast` is not called when `prepareSubmit` rejects with an `AbortError` (both direct and queued paths). On `main` this fails — the toast fires with the raw `Error.message` — and passes after the fix.

```bash
cd packages/web-shell
npx vitest run client/App.test.tsx -t "AbortError"
```

Red (before fix): 2 failed — `onToast` called with `["error", "cancelled"]`.
Green (after fix): 2 passed.

### Evidence (Before & After)

N/A — the change is a toast being suppressed, pinned by unit tests rather than a screenshot.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment

Local: `cd packages/web-shell && npx vitest run client/App.test.tsx` (911 passed) and `npx tsc -p tsconfig.json --noEmit` (0 errors), plus `eslint` and `prettier --check` on the two changed files.

## Risk & Scope

- Main risk or tradeoff: an `AbortError` preflight rejection now logs nothing to the console (`reportError` returns early on abort). That is the intended "suppress abort" behavior; real failures still log via `reportError`'s `console.error`.
- Not validated / out of scope: the VS Code companion localization (half 1) — already landed in #11628.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11432

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

完成 #11432 的 web-shell 半边：把 `packages/web-shell/client/App.tsx` 里两处 preflight 失败 toast 从手写的 `pushToast('error', formatError(err, ...))` 改为复用文件内已有的 `reportError`。`reportError` 会先抑制 `AbortError`、daemon-turn 错误和已派发通知，所以 daemon 关闭时用 `AbortError` 拒绝提交的场景现在会静默，而不再为一个「用户已取消」的提交弹出「failed」toast。

为此把 `reportError` 上提到 `sendPrompt`/`enqueuePrompt` 之前——它原来声明在两者之后，一旦这两个回调的依赖数组引用它就会触发 TDZ 错误。两处 preflight catch 里原本的 `console.warn` 被移除，因为 `reportError` 自己会通过 `console.error` 记录错误，保留 warn 会让每次真实失败都重复打两条日志（这正是 #11432 的 CI triage 要求并入 scope 的「reportError 重复日志」项）。`prepareSubmit`/`onSubmitBefore` 的 prop 契约也补充说明：rejection 的 `Error.message` 会展示给用户，宿主必须本地化它。

## 为什么需要

#11432 从 #11171 的 review 线程延后为两件套。半边 1（VS Code companion 里本地化 rewind preflight 错误）已在 #11628 落地。本 PR 是剩下的半边：抑制 abort toast，让被取消的提交不再弹出一个误导性的「failed」toast。

## Reviewer 测试方案

### 如何验证

新增 witness 测试断言：当 `prepareSubmit` 用 `AbortError` reject 时，`onToast` 不被调用（直发与排队两条路径都覆盖）。在 `main` 上该断言失败——toast 会带着原始 `Error.message` 弹出——修复后通过。

```bash
cd packages/web-shell
npx vitest run client/App.test.tsx -t "AbortError"
```

修复前（红态）：2 条失败——`onToast` 被调用且参数为 `["error", "cancelled"]`。
修复后（绿态）：2 条通过。

### 证据（Before & After）

N/A——这是一处被抑制的 toast，用单元测试钉住行为，不涉及截图。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### 环境

本机：`cd packages/web-shell && npx vitest run client/App.test.tsx`（911 条全部通过）与 `npx tsc -p tsconfig.json --noEmit`（0 错误），另对两个改动文件跑了 `eslint` 与 `prettier --check`。

## 风险与范围

- 主要风险/取舍：`AbortError` 的 preflight 拒绝现在不会再往控制台打日志（`reportError` 在 abort 时提前返回）。这是「抑制 abort」的预期行为；真实失败仍会通过 `reportError` 的 `console.error` 记录。
- 未验证/超出范围：VS Code companion 的本地化（半边 1）——已在 #11628 落地。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #11432

</details>
