### PR TITLE
feat(workflows): add effort and disallowedTools to agent() options

### DIFF
--- a/packages/cli/src/acp-integration/model-configuration.test.ts
+++ b/packages/cli/src/acp-integration/model-configuration.test.ts
@@ -8,6 +8,7 @@ import type { Config, ContentGeneratorConfig } from '@qwen-code/qwen-code-core';
 import {
   buildInstallPlan,
   findProviderById,
+  REASONING_EFFORT_TIERS,
   resolveBaseUrl,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../config/settings.js';
@@ -21,6 +22,7 @@ import {
   getDefaultReasoningConfig,
   getModelConfiguration,
   getGptReasoningOverrideState,
+  getReasoningEffortsForConfig,
   type ModelReasoningConfiguration,
   isReasoningSelectionSupported,
   resolvePersistedReasoningConfigState,
@@ -718,5 +720,51 @@ describe('GPT raw reasoning reporting', () => {
         } as ModelReasoningConfiguration,
       ),
     ).toBeUndefined();
+  });
+});
+
+// `/effort` and a workflow agent's per-call effort share one tier rule (core's
+// reasoningEffortsForCapability); these pin it at the `/effort` read site.
+describe('getReasoningEffortsForConfig', () => {
+  const configWith = (reasoning: unknown) =>
+    ({
+      getModel: () => 'custom-model',
+      getAuthType: () => 'openai',
+      getContentGeneratorConfig: () => ({
+        model: 'custom-model',
+        authType: 'openai',
+        baseUrl: 'https://example.com',
+      }),
+      getResolvedModelConfig: () => ({ capabilities: { reasoning } }),
+    }) as unknown as Config;
+
+  it('offers nothing for a toggle-only model', () => {
+    expect(
+      getReasoningEffortsForConfig(
+        configWith({
+          thinking: true,
+          toggleOnly: true,
+          disableField: 'enable_thinking',
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('offers exactly the declared tiers', () => {
+    expect(
+      getReasoningEffortsForConfig(
+        configWith({
+          thinking: true,
+          disableField: 'reasoning_effort',
+          efforts: ['low', 'high'],
+        }),
+      ),
+    ).toEqual(['low', 'high']);
+  });
+
+  it('offers every tier for a model that declares none', () => {
+    expect(getReasoningEffortsForConfig(configWith(undefined))).toEqual(
+      REASONING_EFFORT_TIERS,
+    );
   });
 });

--- a/packages/cli/src/acp-integration/model-configuration.ts
+++ b/packages/cli/src/acp-integration/model-configuration.ts
@@ -11,6 +11,7 @@ import {
   isReasoningEffortPlaceholder,
   isOpenRouterHostname,
   clampReasoningEffort,
+  reasoningEffortsForCapability,
   type Config,
   type ContentGeneratorConfig,
   type ReasoningEffort,
@@ -323,9 +324,11 @@ export function getReasoningEffortsForConfig(
   config: Config,
 ): readonly ReasoningEffort[] {
   const modelId = config.getModel?.();
-  const reasoning = getConfiguredModelReasoning(config, modelId, false);
-  if (reasoning) return reasoning.toggleOnly ? [] : reasoning.efforts;
-  return REASONING_EFFORT_TIERS;
+  // One tier rule for `/effort` and a workflow agent's per-call effort: this
+  // site keeps its own capability lookup and delegates only the rule.
+  return reasoningEffortsForCapability(
+    getConfiguredModelReasoning(config, modelId, false),
+  );
 }
 
 export function parseReasoningSelection(

--- a/packages/cli/src/commands/review/workflow-script.test.ts
+++ b/packages/cli/src/commands/review/workflow-script.test.ts
@@ -42,10 +42,12 @@ const KNOWN_AGENT_OPTS = [
   'phase',
   'schema',
   'model',
+  'effort',
   'isolation',
   'agentType',
   'stallMs',
   'workingDir',
+  'disallowedTools',
 ];
 
 async function runScript(
@@ -358,5 +360,25 @@ describe('the generated review batch script', () => {
     const generated = script.slice(0, script.length - FAN_OUT_BODY.length);
     expect(generated).not.toContain('parallel(');
     expect(generated).not.toContain('agent(');
+  });
+});
+
+// The harness mirrors the runtime allowlist, so it has to accept what the
+// runtime accepts: otherwise the first generated script to use one of these
+// options fails here while production runs it.
+describe('the review harness option mirror', () => {
+  it('accepts the effort and disallowedTools options the runtime accepts', async () => {
+    const script = [
+      'export const meta = {',
+      "  name: 'probe',",
+      '};',
+      "await agent('p', { effort: 'low', disallowedTools: ['write_file'] });",
+      "return 'ok';",
+    ].join('\n');
+    const { result, dispatched } = await runScript(script, async () => 'done');
+    expect(result).toBe('ok');
+    expect(dispatched).toEqual([
+      { prompt: 'p', opts: { effort: 'low', disallowedTools: ['write_file'] } },
+    ]);
   });
 });

--- a/packages/core/src/agents/runtime/agent-types.ts
+++ b/packages/core/src/agents/runtime/agent-types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Content, FunctionDeclaration } from '@google/genai';
+import type { ReasoningEffort } from '../../core/reasoning-effort.js';
 
 // ─── Agent Configuration ─────────────────────────────────────
 
@@ -52,6 +53,13 @@ export interface ModelConfig {
    * TODO: In the future, this needs to support 'auto' or some other string to support routing use cases.
    */
   model?: string;
+
+  /**
+   * Reasoning effort for this agent alone. Written onto the agent's own
+   * content-generator config — never the session's — and limited to the tiers
+   * `/effort` offers for the agent's model.
+   */
+  reasoningEffort?: ReasoningEffort;
 }
 
 /**

--- a/packages/core/src/agents/runtime/agent-types.ts
+++ b/packages/core/src/agents/runtime/agent-types.ts
@@ -55,9 +55,12 @@ export interface ModelConfig {
   model?: string;
 
   /**
-   * Reasoning effort for this agent alone. Written onto the agent's own
+   * Reasoning effort for this agent alone, honored by
+   * `SubagentManager.createAgentHeadless`: written onto the agent's own
    * content-generator config — never the session's — and limited to the tiers
-   * `/effort` offers for the agent's model.
+   * `/effort` offers for the agent's model. Spawn paths that build their own
+   * generator view (the in-process backend behind teammates and arena agents)
+   * do not read it.
    */
   reasoningEffort?: ReasoningEffort;
 }

--- a/packages/core/src/agents/runtime/workflow-journal.test.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.test.ts
@@ -305,3 +305,38 @@ describe('deriveArgsSeed', () => {
     expect(k1).not.toBe(k2); // same prompt+opts, different args → different key
   });
 });
+
+// A resume that changed how hard an agent thinks, or what it may call, has to
+// run that agent live. The sandbox normalizes spellings before the key is
+// derived; that half is pinned end to end in workflow-orchestrator.test.ts.
+describe('resume key for effort and disallowedTools', () => {
+  it('projects both into the canonical opts', () => {
+    expect(
+      canonicalizeAgentOpts({
+        label: 'ignored',
+        effort: 'high',
+        disallowedTools: ['run_shell_command', 'write_file'],
+      }),
+    ).toBe(
+      JSON.stringify({
+        disallowedTools: ['run_shell_command', 'write_file'],
+        effort: 'high',
+      }),
+    );
+  });
+
+  it('gives a different effort a different key', () => {
+    const low = deriveAgentKey('', 'review it', { effort: 'low' });
+    expect(low).not.toBe(deriveAgentKey('', 'review it', { effort: 'high' }));
+    expect(low).not.toBe(deriveAgentKey('', 'review it', {}));
+    expect(low).toBe(deriveAgentKey('', 'review it', { effort: 'low' }));
+  });
+
+  it('gives a different deny set a different key', () => {
+    expect(
+      deriveAgentKey('', 'scan', { disallowedTools: ['write_file'] }),
+    ).not.toBe(
+      deriveAgentKey('', 'scan', { disallowedTools: ['edit', 'write_file'] }),
+    );
+  });
+});

--- a/packages/core/src/agents/runtime/workflow-journal.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.ts
@@ -98,6 +98,23 @@ export interface JournalReplay {
 }
 
 /**
+ * The `agent()` options that change what a dispatch does, as one list: the
+ * resume key projects exactly these, and the orchestrator's fast path, which
+ * hands the session config to the agent untouched, is taken only when every
+ * one of them is absent. `label` / `phase` / `stallMs` are deliberately not
+ * here: they are cosmetic or operational.
+ */
+export const DISPATCH_AFFECTING_AGENT_OPTS = [
+  'schema',
+  'model',
+  'effort',
+  'isolation',
+  'agentType',
+  'workingDir',
+  'disallowedTools',
+] as const;
+
+/**
  * Project the dispatch-affecting opts into a stable canonical string. Only
  * `schema` / `model` / `effort` / `isolation` / `agentType` / `workingDir` /
  * `disallowedTools` change what the dispatch does; `label` / `phase` /
@@ -108,8 +125,9 @@ export interface JournalReplay {
  * `effort` and `disallowedTools` change how hard the agent thinks and what it
  * may do, so a resume that changed either has to run live. The sandbox
  * normalizes both before they get here — an effort alias to its tier, a deny
- * list to a sorted, de-duplicated array — so `'med'` and `'medium'`, or the
- * same tools listed in another order, are one key.
+ * list to a sorted, de-duplicated array of tool names — so `'med'` and
+ * `'medium'`, `Edit` and `edit`, or the same tools in another order, are one
+ * key.
  *
  * `workingDir` is dispatch-affecting for the same reason it exists: the same
  * prompt run against two different worktrees is two different questions. Were
@@ -118,15 +136,7 @@ export interface JournalReplay {
  */
 export function canonicalizeAgentOpts(opts: WorkflowAgentOpts): string {
   const projected: Record<string, unknown> = {};
-  for (const k of [
-    'schema',
-    'model',
-    'effort',
-    'isolation',
-    'agentType',
-    'workingDir',
-    'disallowedTools',
-  ] as const) {
+  for (const k of DISPATCH_AFFECTING_AGENT_OPTS) {
     const v = opts[k];
     if (v === undefined || typeof v === 'function') continue;
     projected[k] = v;

--- a/packages/core/src/agents/runtime/workflow-journal.ts
+++ b/packages/core/src/agents/runtime/workflow-journal.ts
@@ -30,9 +30,9 @@
  * key, and so on — so the cache naturally invalidates from the edit point.
  *
  * The `canonicalOpts` projection keeps only the dispatch-affecting opts
- * (`schema`, `model`, `isolation`, `agentType`, `workingDir`) with object keys
- * sorted, so cosmetic opt differences (a re-ordered schema, a `label` change)
- * don't bust the cache.
+ * (`schema`, `model`, `effort`, `isolation`, `agentType`, `workingDir`,
+ * `disallowedTools`) with object keys sorted, so cosmetic opt differences (a
+ * re-ordered schema, a `label` change) don't bust the cache.
  *
  * Determinism requirement: workflow scripts are deterministic (`Date.now`
  * / `Math.random` throw in the sandbox), so the sequence of `agent()`
@@ -99,10 +99,17 @@ export interface JournalReplay {
 
 /**
  * Project the dispatch-affecting opts into a stable canonical string. Only
- * `schema` / `model` / `isolation` / `agentType` / `workingDir` change what
- * the dispatch does; `label` / `phase` / `stallMs` are cosmetic or
- * operational and must NOT bust the cache. Object keys are sorted recursively
- * so a re-serialized schema with reordered keys hashes the same.
+ * `schema` / `model` / `effort` / `isolation` / `agentType` / `workingDir` /
+ * `disallowedTools` change what the dispatch does; `label` / `phase` /
+ * `stallMs` are cosmetic or operational and must NOT bust the cache. Object
+ * keys are sorted recursively so a re-serialized schema with reordered keys
+ * hashes the same.
+ *
+ * `effort` and `disallowedTools` change how hard the agent thinks and what it
+ * may do, so a resume that changed either has to run live. The sandbox
+ * normalizes both before they get here — an effort alias to its tier, a deny
+ * list to a sorted, de-duplicated array — so `'med'` and `'medium'`, or the
+ * same tools listed in another order, are one key.
  *
  * `workingDir` is dispatch-affecting for the same reason it exists: the same
  * prompt run against two different worktrees is two different questions. Were
@@ -114,9 +121,11 @@ export function canonicalizeAgentOpts(opts: WorkflowAgentOpts): string {
   for (const k of [
     'schema',
     'model',
+    'effort',
     'isolation',
     'agentType',
     'workingDir',
+    'disallowedTools',
   ] as const) {
     const v = opts[k];
     if (v === undefined || typeof v === 'function') continue;

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -1579,6 +1579,39 @@ describe('WorkflowOrchestrator', () => {
     return { journal, entries };
   }
 
+  // The sandbox normalizes effort and disallowedTools before the resume key is
+  // derived: spelling the same request differently must replay, and a
+  // genuinely different request must not.
+  it('derives one resume key for equivalent effort and disallowedTools spellings', async () => {
+    const keyFor = async (opts: string): Promise<string> => {
+      const { journal, entries } = memoryJournal();
+      await new WorkflowOrchestrator(async () => 'ok').run({
+        script: `return await agent('scan', ${opts});`,
+        args: undefined,
+        journal,
+      });
+      const started = entries.find((e) => e.type === 'started');
+      return (started as { key: string }).key;
+    };
+
+    const medium = await keyFor(
+      `{ effort: 'medium', disallowedTools: ['write_file', 'edit'] }`,
+    );
+    expect(
+      await keyFor(
+        `{ effort: 'MED', disallowedTools: ['edit', 'write_file', 'edit'] }`,
+      ),
+    ).toBe(medium);
+    expect(
+      await keyFor(
+        `{ effort: 'high', disallowedTools: ['edit', 'write_file'] }`,
+      ),
+    ).not.toBe(medium);
+    expect(
+      await keyFor(`{ effort: 'medium', disallowedTools: ['edit'] }`),
+    ).not.toBe(medium);
+  });
+
   it('settles a sequential agent() to null when the agent itself failed', async () => {
     const { journal, entries } = memoryJournal();
     const orchestrator = new WorkflowOrchestrator(async () => {
@@ -3427,6 +3460,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     runtimeIgnoreFiles?: string;
     options?: {
       runConfigOverrides?: unknown;
+      modelConfigOverrides?: unknown;
       taskName?: string;
       subagentId?: string;
     };
@@ -3521,6 +3555,12 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       getWorktreeSymlinkDirectories: () => [],
       getSubagentManager: () => ({
         findSubagentByName: opts.findSubagentByName ?? (async () => null),
+        // The real manager resolves display names against the tool registry;
+        // the stub knows the one display name the schema-deny refusal needs.
+        resolveToolNames: async (names: string[]) =>
+          names.map((name) =>
+            name === 'StructuredOutput' ? 'structured_output' : name,
+          ),
         createAgentHeadless: async (
           subagentConfig: {
             name?: string;
@@ -3531,6 +3571,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
           options?: {
             eventEmitter?: unknown;
             runConfigOverrides?: unknown;
+            modelConfigOverrides?: unknown;
             taskName?: string;
             subagentId?: string;
           },
@@ -3545,6 +3586,7 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
               .getQwenIgnoreFileNamesDisplay(),
             options: {
               runConfigOverrides: options?.runConfigOverrides,
+              modelConfigOverrides: options?.modelConfigOverrides,
               taskName: options?.taskName,
               subagentId: options?.subagentId,
             },
@@ -4204,6 +4246,125 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       ]),
     );
   });
+
+  // effort needs the agent's own content-generator config, which only the
+  // override path builds: it has to leave the fast path and reach the manager
+  // as a per-agent model-config override, never as a session change.
+  it('routes effort through the override path as a per-agent model override', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+
+    const result = await createProductionDispatch(config)('hi', {
+      effort: 'low',
+    });
+
+    expect(result).toBe('done');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.options?.modelConfigOverrides).toEqual({
+      reasoningEffort: 'low',
+    });
+    expect(calls[0]!.config.model).toBeUndefined();
+  });
+
+  it('sends no model-config override when effort is omitted', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+
+    await createProductionDispatch(config)('hi', { model: 'qwen3-max' });
+
+    expect(calls[0]!.options?.modelConfigOverrides).toBeUndefined();
+  });
+
+  // The sandbox normalizes effort before it crosses; a host caller that
+  // dispatches directly gets the same normalization and the same refusal.
+  it('normalizes a host-supplied effort alias and refuses an unknown tier', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'done', terminateMode: 'GOAL' }),
+    });
+    const dispatch = createProductionDispatch(config);
+
+    await dispatch('hi', { effort: 'X-High' as unknown as 'xhigh' });
+    expect(calls[0]!.options?.modelConfigOverrides).toEqual({
+      reasoningEffort: 'xhigh',
+    });
+
+    await expect(
+      dispatch('hi', { effort: 'turbo' as unknown as 'low' }),
+    ).rejects.toThrow(/agent\(\{effort\}\): unknown effort tier "turbo"/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('unions per-call disallowedTools with the agentType denies and the floor', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Scanner',
+        description: 'read-only scan',
+        systemPrompt: 'scan prompt',
+        level: 'project',
+        disallowedTools: ['Foo'],
+      }),
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+
+    await createProductionDispatch(config)('scan', {
+      agentType: 'Scanner',
+      disallowedTools: ['Shell', 'write_file'],
+    });
+
+    const disallowed = calls[0]!.config.disallowedTools ?? [];
+    expect(disallowed).toEqual(
+      expect.arrayContaining([
+        'Foo',
+        'Shell',
+        'write_file',
+        'ask_user_question',
+        'send_message',
+        'monitor',
+        'enter_plan_mode',
+        'exit_plan_mode',
+        'agent',
+      ]),
+    );
+    expect(new Set(disallowed).size).toBe(disallowed.length);
+  });
+
+  it('routes disallowedTools alone through the override path', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+
+    await createProductionDispatch(config)('scan', {
+      disallowedTools: ['edit'],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.config.disallowedTools).toEqual(
+      expect.arrayContaining(['edit', 'agent', 'ask_user_question']),
+    );
+  });
+
+  // A schema agent answers only through structured_output. Denying it must be
+  // refused before anything spawns, by display name as well as by tool name.
+  it.each([['structured_output'], ['StructuredOutput']])(
+    'refuses a schema agent that denies %s before spawning',
+    async (name) => {
+      const { config, calls } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+      });
+
+      await expect(
+        createProductionDispatch(config)('extract', {
+          schema: { type: 'object' },
+          disallowedTools: [name],
+        }),
+      ).rejects.toThrow(
+        /schema mode needs the structured_output tool, but disallowedTools deny it/,
+      );
+      expect(calls).toHaveLength(0);
+    },
+  );
 
   it('schema-mode: subagent calls structured_output successfully → returns validated args', async () => {
     const { config } = fakeConfigWithMgr({

--- a/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.test.ts
@@ -37,6 +37,8 @@ import {
   WorkflowAgentCapExceededError,
   WorkflowAgentFailedError,
 } from './workflow-agent-failure.js';
+import { DISPATCH_AFFECTING_AGENT_OPTS } from './workflow-journal.js';
+import { resolveBuiltinToolName } from '../../tools/tool-names.js';
 
 // FIX-C3 (TST-2-C1): use vi.hoisted so `created` is initialised before the
 // vi.mock factory runs AND remains accessible inside tests for assertion +
@@ -1610,6 +1612,12 @@ describe('WorkflowOrchestrator', () => {
     expect(
       await keyFor(`{ effort: 'medium', disallowedTools: ['edit'] }`),
     ).not.toBe(medium);
+    // A built-in tool named by its display name is the same deny.
+    expect(
+      await keyFor(
+        `{ effort: 'medium', disallowedTools: ['WriteFile', 'Edit'] }`,
+      ),
+    ).toBe(medium);
   });
 
   it('settles a sequential agent() to null when the agent itself failed', async () => {
@@ -3555,11 +3563,14 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
       getWorktreeSymlinkDirectories: () => [],
       getSubagentManager: () => ({
         findSubagentByName: opts.findSubagentByName ?? (async () => null),
-        // The real manager resolves display names against the tool registry;
-        // the stub knows the one display name the schema-deny refusal needs.
-        resolveToolNames: async (names: string[]) =>
-          names.map((name) =>
-            name === 'StructuredOutput' ? 'structured_output' : name,
+        // Mirrors the real manager for everything a unit test can know: MCP
+        // patterns and built-in tools match, anything else is unmatched. The
+        // schema-deny refusal resolves names itself and does not use this.
+        findUnmatchedToolNames: async (names: string[]) =>
+          names.filter(
+            (name) =>
+              !name.startsWith('mcp__') &&
+              resolveBuiltinToolName(name) === undefined,
           ),
         createAgentHeadless: async (
           subagentConfig: {
@@ -4314,10 +4325,11 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
     });
 
     const disallowed = calls[0]!.config.disallowedTools ?? [];
+    // The built-in display name arrives as its tool name.
     expect(disallowed).toEqual(
       expect.arrayContaining([
         'Foo',
-        'Shell',
+        'run_shell_command',
         'write_file',
         'ask_user_question',
         'send_message',
@@ -4346,7 +4358,8 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
   });
 
   // A schema agent answers only through structured_output. Denying it must be
-  // refused before anything spawns, by display name as well as by tool name.
+  // refused before anything spawns, by display name as well as by tool name,
+  // with no help from the tool registry (the stub above does not resolve it).
   it.each([['structured_output'], ['StructuredOutput']])(
     'refuses a schema agent that denies %s before spawning',
     async (name) => {
@@ -4363,6 +4376,114 @@ describe('WorkflowOrchestrator P3 — agentType / model / isolation / schema', (
         /schema mode needs the structured_output tool, but disallowedTools deny it/,
       );
       expect(calls).toHaveLength(0);
+    },
+  );
+
+  it('refuses a schema agent whose agent type denies structured_output', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      findSubagentByName: async () => ({
+        name: 'Scanner',
+        description: 'scan',
+        systemPrompt: 'scan prompt',
+        level: 'project',
+        disallowedTools: ['StructuredOutput'],
+      }),
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+
+    await expect(
+      createProductionDispatch(config)('extract', {
+        agentType: 'Scanner',
+        schema: { type: 'object' },
+      }),
+    ).rejects.toThrow(/schema mode needs the structured_output tool/);
+    expect(calls).toHaveLength(0);
+  });
+
+  // A deny that matches no tool would leave the agent that very tool while
+  // the script believes it narrowed it.
+  it('refuses a deny entry that matches no tool before spawning', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+
+    await expect(
+      createProductionDispatch(config)('scan', {
+        disallowedTools: ['Bash', 'edit'],
+      }),
+    ).rejects.toThrow(/"Bash" matches no tool/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('accepts MCP deny patterns', async () => {
+    const { config, calls } = fakeConfigWithMgr({
+      onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+    });
+
+    await createProductionDispatch(config)('scan', {
+      disallowedTools: ['mcp__github', 'mcp__slack__*'],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.config.disallowedTools).toEqual(
+      expect.arrayContaining(['mcp__github', 'mcp__slack__*']),
+    );
+  });
+
+  // The host re-checks the deny list's shape for callers that bypass the
+  // sandbox: a bare string would otherwise spread into single characters and a
+  // padded name would deny nothing.
+  it.each([
+    ['a bare string', 'write_file'],
+    ['a padded name', [' edit']],
+  ])(
+    'refuses a host-supplied deny list that is %s before spawning',
+    async (_label, disallowedTools) => {
+      const { config, calls } = fakeConfigWithMgr({
+        onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+      });
+
+      await expect(
+        createProductionDispatch(config)('scan', {
+          disallowedTools: disallowedTools as unknown as string[],
+        }),
+      ).rejects.toThrow(/must be an array of non-empty tool-name strings/);
+      expect(calls).toHaveLength(0);
+    },
+  );
+
+  // Every option the resume key projects must also keep a dispatch off the
+  // fast path. The guard is driven by the same list, so an option added there
+  // cannot be silently dropped by a fast path that ignores it.
+  it.each(DISPATCH_AFFECTING_AGENT_OPTS.map((key) => [key]))(
+    'keeps a dispatch that sets only %s off the fast path',
+    async (key) => {
+      const samples: Record<string, unknown> = {
+        schema: { type: 'object' },
+        model: 'qwen3-max',
+        effort: 'low',
+        isolation: 'worktree',
+        agentType: 'Scanner',
+        workingDir: '/nonexistent/worktree',
+        disallowedTools: ['edit'],
+      };
+      expect(samples).toHaveProperty(key);
+      const { config } = fakeConfigWithMgr({
+        findSubagentByName: async () => ({
+          name: 'Scanner',
+          description: 'scan',
+          systemPrompt: 'scan prompt',
+          level: 'project',
+        }),
+        onCreate: async () => ({ finalText: 'ok', terminateMode: 'GOAL' }),
+      });
+      const fastPathAgentsBefore = created.length;
+
+      await createProductionDispatch(config)('probe', {
+        [key]: samples[key],
+      }).catch(() => undefined);
+
+      expect(created.length).toBe(fastPathAgentsBefore);
     },
   );
 

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -52,6 +52,11 @@ import type {
   AgentToolResultEvent,
 } from './agent-events.js';
 import { ToolNames } from '../../tools/tool-names.js';
+import {
+  normalizeReasoningEffort,
+  REASONING_EFFORT_TIERS,
+  type ReasoningEffort,
+} from '../../core/reasoning-effort.js';
 import { parsePositiveIntegerEnv } from '../../utils/env.js';
 import { stripAnsiAndControl } from '../../utils/textUtils.js';
 import type { SubagentConfig } from '../../subagents/types.js';
@@ -271,6 +276,9 @@ export function resolveSubagentMaxTimeMinutes(
  * and MonitorTool depends on AgentTool-owned notification callbacks that
  * workflow subagents do not register. Defense-in-depth alongside the workflow
  * system prompt's return-value contract.
+ *
+ * A per-call `agent({ disallowedTools })` is unioned on top of this floor and
+ * can only narrow the set further; nothing a script passes removes an entry.
  */
 export const WORKFLOW_SUBAGENT_DISALLOWED_TOOLS: string[] = [
   ToolNames.ASK_USER_QUESTION,
@@ -745,13 +753,17 @@ async function runSingleDispatch(
   // The fast path hands `config` to AgentHeadless untouched, so it has no
   // way to honour a directory rebind — `workingDir` MUST route through the
   // override path or it would be silently dropped and the agent would run in
-  // the parent working tree.
+  // the parent working tree. The same holds for `effort`, which needs the
+  // agent's own content-generator config, and for `disallowedTools`, whose
+  // display names are resolved only on the override path.
   if (
     opts.agentType === undefined &&
     opts.model === undefined &&
     opts.isolation === undefined &&
     opts.schema === undefined &&
-    opts.workingDir === undefined
+    opts.workingDir === undefined &&
+    opts.effort === undefined &&
+    opts.disallowedTools === undefined
   ) {
     const subagent = await AgentHeadless.create(
       agentIdentity.name,
@@ -852,7 +864,47 @@ function reportTokens(
 }
 
 /**
- * Override path for `agent({ agentType, model, isolation })`. Resolves the
+ * `opts.effort` as its canonical tier, or `undefined` when omitted. The sandbox
+ * already normalizes it; this re-check covers a host caller that dispatches
+ * without going through the sandbox.
+ */
+function resolveDispatchEffort(raw: unknown): ReasoningEffort | undefined {
+  if (raw === undefined) return undefined;
+  const tier =
+    typeof raw === 'string' ? normalizeReasoningEffort(raw) : undefined;
+  if (tier === undefined) {
+    throw new Error(
+      `agent({effort}): unknown effort tier ${sanitizeForErrorMessage(
+        JSON.stringify(raw) ?? String(raw),
+      )}. Known tiers are: ${REASONING_EFFORT_TIERS.join(', ')}.`,
+    );
+  }
+  return tier;
+}
+
+/**
+ * `opts.disallowedTools` as a list (`[]` when omitted). Same host-side
+ * re-check as {@link resolveDispatchEffort}.
+ */
+function resolveDispatchDenies(raw: unknown): string[] {
+  if (raw === undefined) return [];
+  if (
+    !Array.isArray(raw) ||
+    raw.some(
+      (name) =>
+        typeof name !== 'string' || name.length === 0 || name !== name.trim(),
+    )
+  ) {
+    throw new Error(
+      "agent({disallowedTools}): must be an array of non-empty tool-name strings without surrounding whitespace, e.g. ['run_shell_command', 'write_file'].",
+    );
+  }
+  return raw as string[];
+}
+
+/**
+ * Override path for `agent({ agentType, model, effort, isolation,
+ * disallowedTools })`. Resolves the
  * requested agentType against `SubagentManager`, applies the workflow
  * disallowed-tool floor, threads `opts.model` into `SubagentConfig.model`
  * so provider routing in `buildRuntimeContentGeneratorView` sees the
@@ -872,7 +924,13 @@ function reportTokens(
  * (not via `toolConfigOverride`): augmenting before `convertToRuntimeConfig`
  * lets the manager's `transformToToolNames` normalize all entries together
  * (display name → tool name + MCP pattern preservation). A toolConfigOverride
- * would bypass that normalization and require us to duplicate it here.
+ * would bypass that normalization and require us to duplicate it here. A
+ * per-call `disallowedTools` joins the same union for the same reason.
+ *
+ * Why `effort` goes into `modelConfigOverrides.reasoningEffort`: the manager
+ * builds this agent its own content generator from a copy of the session
+ * config and writes the tier onto that copy, limited to the tiers `/effort`
+ * offers for the agent's model, so the session's own tier is never touched.
  *
  * Why the worktree-rebound Config is passed as `runtimeContext` (not
  * `toolConfigOverride`): `SubagentManager` derives its subagent context from
@@ -916,6 +974,9 @@ async function runOverridePath(
       "agent({isolation:'remote'}) is not available in this build.",
     );
   }
+
+  const effort = resolveDispatchEffort(opts.effort);
+  const requestedDenies = resolveDispatchDenies(opts.disallowedTools);
 
   const subagentMgr = config.getSubagentManager();
   let baseConfig: SubagentConfig;
@@ -1006,9 +1067,24 @@ async function runOverridePath(
       new Set([
         ...(baseConfig.disallowedTools ?? []),
         ...WORKFLOW_SUBAGENT_DISALLOWED_TOOLS,
+        ...requestedDenies,
       ]),
     ),
   };
+
+  // A schema agent answers only through structured_output. Denying that tool
+  // leaves it no way to deliver the one result the script accepts, and the
+  // run would spend the agent's turns before failing as if it had ignored the
+  // contract. Refuse before anything is provisioned. Names are resolved by the
+  // normalizer the spawn itself applies, so the display name is caught too.
+  if (opts.schema !== undefined && requestedDenies.length > 0) {
+    const resolvedDenies = await subagentMgr.resolveToolNames(requestedDenies);
+    if (resolvedDenies.includes(ToolNames.STRUCTURED_OUTPUT)) {
+      throw new Error(
+        'agent({schema, disallowedTools}): schema mode needs the structured_output tool, but disallowedTools deny it.',
+      );
+    }
+  }
 
   // Provision worktree BEFORE createAgentHeadless so the derived Config
   // is in place when convertToRuntimeConfig and buildSubagentContextOverride
@@ -1160,6 +1236,9 @@ async function runOverridePath(
           max_turns: resolveSubagentMaxTurns(),
           max_time_minutes: resolveSubagentMaxTimeMinutes(),
         },
+        ...(effort !== undefined
+          ? { modelConfigOverrides: { reasoningEffort: effort } }
+          : {}),
         eventEmitter,
         taskName: String(ctx.get('task_prompt')),
         subagentId: workflowAgentId,

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -34,7 +34,11 @@ import {
   WorkflowAgentFailedError,
 } from './workflow-agent-failure.js';
 import { resolveStallMs, runStallResilient } from './workflow-stall.js';
-import { deriveAgentKey, deriveArgsSeed } from './workflow-journal.js';
+import {
+  DISPATCH_AFFECTING_AGENT_OPTS,
+  deriveAgentKey,
+  deriveArgsSeed,
+} from './workflow-journal.js';
 import type { WorkflowJournal, JournalReplay } from './workflow-journal.js';
 import {
   WORKFLOW_SUBAGENT_SYSTEM_PROMPT,
@@ -51,7 +55,7 @@ import type {
   AgentToolCallEvent,
   AgentToolResultEvent,
 } from './agent-events.js';
-import { ToolNames } from '../../tools/tool-names.js';
+import { resolveBuiltinToolName, ToolNames } from '../../tools/tool-names.js';
 import {
   normalizeReasoningEffort,
   REASONING_EFFORT_TIERS,
@@ -753,18 +757,12 @@ async function runSingleDispatch(
   // The fast path hands `config` to AgentHeadless untouched, so it has no
   // way to honour a directory rebind — `workingDir` MUST route through the
   // override path or it would be silently dropped and the agent would run in
-  // the parent working tree. The same holds for `effort`, which needs the
-  // agent's own content-generator config, and for `disallowedTools`, whose
-  // display names are resolved only on the override path.
-  if (
-    opts.agentType === undefined &&
-    opts.model === undefined &&
-    opts.isolation === undefined &&
-    opts.schema === undefined &&
-    opts.workingDir === undefined &&
-    opts.effort === undefined &&
-    opts.disallowedTools === undefined
-  ) {
+  // the parent working tree. The same holds for every option that changes
+  // what a dispatch does (`effort` needs the agent's own content-generator
+  // config, `disallowedTools` the override path's deny union), so the guard is
+  // driven by the one list the resume key also projects: an option added there
+  // cannot silently take this path.
+  if (DISPATCH_AFFECTING_AGENT_OPTS.every((key) => opts[key] === undefined)) {
     const subagent = await AgentHeadless.create(
       agentIdentity.name,
       config,
@@ -883,8 +881,9 @@ function resolveDispatchEffort(raw: unknown): ReasoningEffort | undefined {
 }
 
 /**
- * `opts.disallowedTools` as a list (`[]` when omitted). Same host-side
- * re-check as {@link resolveDispatchEffort}.
+ * `opts.disallowedTools` as a list (`[]` when omitted), with built-in display
+ * names mapped to tool names as the sandbox maps them. Same host-side re-check
+ * as {@link resolveDispatchEffort}.
  */
 function resolveDispatchDenies(raw: unknown): string[] {
   if (raw === undefined) return [];
@@ -899,7 +898,7 @@ function resolveDispatchDenies(raw: unknown): string[] {
       "agent({disallowedTools}): must be an array of non-empty tool-name strings without surrounding whitespace, e.g. ['run_shell_command', 'write_file'].",
     );
   }
-  return raw as string[];
+  return (raw as string[]).map((name) => resolveBuiltinToolName(name) ?? name);
 }
 
 /**
@@ -1072,18 +1071,37 @@ async function runOverridePath(
     ),
   };
 
-  // A schema agent answers only through structured_output. Denying that tool
-  // leaves it no way to deliver the one result the script accepts, and the
-  // run would spend the agent's turns before failing as if it had ignored the
-  // contract. Refuse before anything is provisioned. Names are resolved by the
-  // normalizer the spawn itself applies, so the display name is caught too.
-  if (opts.schema !== undefined && requestedDenies.length > 0) {
-    const resolvedDenies = await subagentMgr.resolveToolNames(requestedDenies);
-    if (resolvedDenies.includes(ToolNames.STRUCTURED_OUTPUT)) {
+  // A deny that matches no tool denies nothing: the agent would keep the tool
+  // the script meant to take away while the script believes it narrowed it.
+  // Refuse such entries before anything is provisioned. MCP patterns, built-in
+  // tools not registered in this session and registered tools all pass.
+  if (requestedDenies.length > 0) {
+    const unmatched = await subagentMgr.findUnmatchedToolNames(requestedDenies);
+    if (unmatched.length > 0) {
       throw new Error(
-        'agent({schema, disallowedTools}): schema mode needs the structured_output tool, but disallowedTools deny it.',
+        `agent({disallowedTools}): ${sanitizeForErrorMessage(
+          unmatched.map((name) => JSON.stringify(name)).join(', '),
+        )} ${unmatched.length === 1 ? 'matches' : 'match'} no tool. Use a tool name (run_shell_command, write_file, edit), a display name (Shell, WriteFile, Edit), or an MCP pattern (mcp__<server>, mcp__<server>__*, mcp__<server>__<tool>).`,
       );
     }
+  }
+
+  // A schema agent answers only through structured_output. Denying that tool,
+  // from this call or from the agent type's own definition, leaves it no way
+  // to deliver the one result the script accepts, and the run would spend the
+  // dispatch before failing as if the agent had ignored the contract. Refuse
+  // before anything is provisioned. Built-in names resolve statically, so the
+  // display name is caught whether or not the tool is registered here.
+  if (
+    opts.schema !== undefined &&
+    [...(baseConfig.disallowedTools ?? []), ...requestedDenies].some(
+      (name) =>
+        (resolveBuiltinToolName(name) ?? name) === ToolNames.STRUCTURED_OUTPUT,
+    )
+  ) {
+    throw new Error(
+      'agent({schema, disallowedTools}): schema mode needs the structured_output tool, but disallowedTools deny it (from this call or from the agent type).',
+    );
   }
 
   // Provision worktree BEFORE createAgentHeadless so the derived Config

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -782,6 +782,55 @@ describe('createWorkflowSandbox security', () => {
     ).rejects.toThrow(/Known options are: .*effort.*disallowedTools/);
   });
 
+  // A rejected call must leave no phase behind: the phase is recorded only
+  // after every option gate has passed.
+  it.each([
+    ['effort: "turbo"', /unknown effort tier/],
+    ['disallowedTools: "edit"', /must be an array/],
+  ])(
+    'records no phase for a call rejected over %s',
+    async (option, message) => {
+      const dispatch = vi.fn(async () => 'ignored');
+      const sandbox = createWorkflowSandbox({ args: undefined, dispatch });
+      await expect(
+        sandbox.run(`return agent("x", { phase: "Verify", ${option} });`),
+      ).rejects.toThrow(message);
+      expect(sandbox.getPhases()).toEqual([]);
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  // The rejected value is script-controlled, and JSON.stringify leaves DEL and
+  // C1 (incl. NEL) in place, so the echo is sanitized before the message.
+  it('strips control characters from an echoed effort value', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    const error = (await sandbox
+      .run(`return agent("x", { effort: "turbo\u0085inject\u007f" });`)
+      .catch((e: unknown) => e)) as Error;
+    expect(error.message).toMatch(/unknown effort tier "turboinject"/);
+    expect(error.message).not.toMatch(/[\u007f-\u009f]/);
+  });
+
+  // Built-in display names become tool names before the resume key is
+  // derived, so renaming Edit to edit keeps the cache; MCP patterns pass as is.
+  it('hands the host built-in deny names as tool names', async () => {
+    const seen: unknown[] = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (_p, opts) => {
+        seen.push(opts.disallowedTools);
+        return 'ok';
+      },
+    });
+    await sandbox.run(
+      `return agent("a", { disallowedTools: ["Edit", "edit", "WriteFile", "mcp__github"] });`,
+    );
+    expect(seen).toEqual([['edit', 'mcp__github', 'write_file']]);
+  });
+
   // SEC-I2: log() must cap at MAX_LOG_LINES and add a truncation marker.
   it('log() caps at MAX_LOG_LINES with a truncation marker', async () => {
     const emitted: string[] = [];

--- a/packages/core/src/agents/runtime/workflow-sandbox.test.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.test.ts
@@ -704,6 +704,84 @@ describe('createWorkflowSandbox security', () => {
     expect(sandbox.getPhases()).toEqual(['Search']);
   });
 
+  // effort is validated and normalized on the revived copy, so the host (and
+  // the resume key) sees one canonical tier for every alias /effort accepts.
+  it('agent({effort}) hands the host the canonical tier', async () => {
+    const seen: unknown[] = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (_p, opts) => {
+        seen.push(opts.effort);
+        return 'ok';
+      },
+    });
+    await sandbox.run(`
+      await agent("a", { effort: "high" });
+      await agent("b", { effort: "X-High" });
+      await agent("c", { effort: "med" });
+      await agent("d", {});
+      return "done";
+    `);
+    expect(seen).toEqual(['high', 'xhigh', 'medium', undefined]);
+  });
+
+  it.each([['"turbo"'], ['3'], ['{}']])(
+    'agent({effort: %s}) is rejected before dispatch',
+    async (literal) => {
+      const dispatch = vi.fn(async () => 'ignored');
+      const sandbox = createWorkflowSandbox({ args: undefined, dispatch });
+      await expect(
+        sandbox.run(`return agent("hi", { effort: ${literal} });`),
+      ).rejects.toThrow(
+        /agent\(\{effort\}\): unknown effort tier .*Known tiers are: low, medium, high, xhigh, max\./,
+      );
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  // Order and duplicates are not part of what the list means, so they must
+  // not reach the resume key; an empty list denies nothing and is dropped.
+  it('agent({disallowedTools}) hands the host a sorted, de-duplicated list', async () => {
+    const seen: unknown[] = [];
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async (_p, opts) => {
+        seen.push(opts.disallowedTools);
+        return 'ok';
+      },
+    });
+    await sandbox.run(`
+      await agent("a", { disallowedTools: ["write_file", "run_shell_command", "write_file"] });
+      await agent("b", { disallowedTools: [] });
+      return "done";
+    `);
+    expect(seen).toEqual([['run_shell_command', 'write_file'], undefined]);
+  });
+
+  it.each([['"run_shell_command"'], ['[""]'], ['[" edit"]'], ['[42]']])(
+    'agent({disallowedTools: %s}) is rejected before dispatch',
+    async (literal) => {
+      const dispatch = vi.fn(async () => 'ignored');
+      const sandbox = createWorkflowSandbox({ args: undefined, dispatch });
+      await expect(
+        sandbox.run(`return agent("hi", { disallowedTools: ${literal} });`),
+      ).rejects.toThrow(
+        /agent\(\{disallowedTools\}\): must be an array of non-empty tool-name strings/,
+      );
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('names effort and disallowedTools among the known options', async () => {
+    const sandbox = createWorkflowSandbox({
+      args: undefined,
+      dispatch: async () => 'ignored',
+    });
+    await expect(
+      sandbox.run(`return agent("hi", { efort: "low" });`),
+    ).rejects.toThrow(/Known options are: .*effort.*disallowedTools/);
+  });
+
   // SEC-I2: log() must cap at MAX_LOG_LINES and add a truncation marker.
   it('log() caps at MAX_LOG_LINES with a truncation marker', async () => {
     const emitted: string[] = [];

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -445,6 +445,7 @@ import {
   REASONING_EFFORT_TIERS,
   type ReasoningEffort,
 } from '../../core/reasoning-effort.js';
+import { resolveBuiltinToolName } from '../../tools/tool-names.js';
 import { stripAnsiAndControl } from '../../utils/textUtils.js';
 import { parseWorkflowMetaLiteral } from './workflow-meta-literal.js';
 import type { WorkflowDispatchScheduler } from './workflow-dispatch-scheduler.js';
@@ -514,8 +515,10 @@ export interface WorkflowAgentOpts {
   /**
    * Tools this agent may not call, on top of the workflow floor. It only
    * narrows: the dispatch unions it with the floor and the agentType's own
-   * denies. The sandbox hands the host a sorted, de-duplicated list (and drops
-   * an empty one), so order and duplicates never change the resume key.
+   * denies, and refuses an entry that matches no tool. The sandbox hands the
+   * host a sorted, de-duplicated list with built-in display names mapped to
+   * tool names (and drops an empty one), so order, duplicates and the choice
+   * of name never change the resume key.
    */
   disallowedTools?: string[];
   // The index signature exists so TypeScript accepts forward-compat opt names
@@ -1009,6 +1012,15 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
     normalizeEffort: (raw: unknown): string | null =>
       typeof raw === 'string' ? (normalizeReasoningEffort(raw) ?? null) : null,
     effortTiers: REASONING_EFFORT_TIERS.join(', '),
+    // A built-in tool named by its display name or a legacy alias becomes its
+    // tool name, so both spellings share one resume key; any other entry comes
+    // back as given for the host to judge. Primitives only.
+    canonicalDenyName: (raw: unknown): string | null =>
+      typeof raw === 'string' ? (resolveBuiltinToolName(raw) ?? raw) : null,
+    // JSON.stringify escapes only C0: strip DEL / C1 (incl. NEL) from a
+    // script-controlled echo so it cannot fragment a rejection message.
+    sanitizeForMessage: (raw: unknown): string =>
+      typeof raw === 'string' ? stripAnsiAndControl(raw) : '',
     // PR #4947 R2 T7 (qwen-code-ci-bot): host-side log hook for reviveInRealm's
     // catch path. Mirrors the rejection-logging in settleToNullArray so an
     // operator running with debug logging can distinguish "thunk rejected"
@@ -1567,11 +1579,6 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
             );
           }
         }
-        if (typeof agentOpts.phase === 'string' && agentOpts.phase.length > 0) {
-          if (__b.lastPhase() !== agentOpts.phase) {
-            __b.pushPhase(agentOpts.phase);
-          }
-        }
         // SECURITY (P3 R2 self-review): user-script-controlled agentOpts
         // cross the vm/host boundary verbatim via vmAsync's hostFn.apply.
         // A Proxy / inherited-getter / non-plain object in agentOpts.schema
@@ -1593,14 +1600,14 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
         // effort and disallowedTools are validated on the REVIVED copy: that
         // is the object the host dispatch and the resume key see, so a getter
         // cannot show one value here and hand another to the dispatch. Both
-        // are normalized in place (an effort alias becomes its tier, a deny
-        // list becomes sorted and de-duplicated) so equivalent spellings share
-        // one resume key.
+        // are normalized in place (an effort alias becomes its tier; a deny
+        // list has built-in display names mapped to tool names and is sorted
+        // and de-duplicated) so equivalent spellings share one resume key.
         if (safeOpts.effort !== undefined) {
           var tier = __b.normalizeEffort(safeOpts.effort);
           if (tier === null) {
             throw new Error(
-              "agent({effort}): unknown effort tier " + JSON.stringify(safeOpts.effort) + ". " +
+              "agent({effort}): unknown effort tier " + __b.sanitizeForMessage(JSON.stringify(safeOpts.effort)) + ". " +
               "Known tiers are: " + __b.effortTiers + "."
             );
           }
@@ -1621,13 +1628,22 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
           }
           var uniqueDenied = [];
           for (var d = 0; d < denied.length; d++) {
-            if (uniqueDenied.indexOf(denied[d]) === -1) uniqueDenied.push(denied[d]);
+            var deniedName = __b.canonicalDenyName(denied[d]);
+            if (uniqueDenied.indexOf(deniedName) === -1) uniqueDenied.push(deniedName);
           }
           uniqueDenied.sort();
           if (uniqueDenied.length === 0) {
             delete safeOpts.disallowedTools;
           } else {
             safeOpts.disallowedTools = uniqueDenied;
+          }
+        }
+        // The phase is recorded only once every option gate above has passed,
+        // so a call its options rejected leaves no phase that dispatched
+        // nothing.
+        if (typeof agentOpts.phase === 'string' && agentOpts.phase.length > 0) {
+          if (__b.lastPhase() !== agentOpts.phase) {
+            __b.pushPhase(agentOpts.phase);
           }
         }
         // SECURITY (PR #4947 R1 wenshao, extended for P3): vmAsync's resolve

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -440,6 +440,11 @@ function isRegexContext(source: string, i: number): boolean {
 
 import * as vm from 'node:vm';
 import { createDebugLogger } from '../../utils/debugLogger.js';
+import {
+  normalizeReasoningEffort,
+  REASONING_EFFORT_TIERS,
+  type ReasoningEffort,
+} from '../../core/reasoning-effort.js';
 import { stripAnsiAndControl } from '../../utils/textUtils.js';
 import { parseWorkflowMetaLiteral } from './workflow-meta-literal.js';
 import type { WorkflowDispatchScheduler } from './workflow-dispatch-scheduler.js';
@@ -499,6 +504,20 @@ export interface WorkflowAgentOpts {
    * for this call.
    */
   stallMs?: number;
+  /**
+   * Reasoning effort for this one agent (`low` … `max`). The sandbox accepts
+   * the aliases `/effort` accepts and hands the host the canonical tier; the
+   * dispatch writes it onto the agent's own content-generator config, never
+   * the session's. Part of the resume key.
+   */
+  effort?: ReasoningEffort;
+  /**
+   * Tools this agent may not call, on top of the workflow floor. It only
+   * narrows: the dispatch unions it with the floor and the agentType's own
+   * denies. The sandbox hands the host a sorted, de-duplicated list (and drops
+   * an empty one), so order and duplicates never change the resume key.
+   */
+  disallowedTools?: string[];
   // The index signature exists so TypeScript accepts forward-compat opt names
   // at compile time; the runtime allowlist still rejects unknown names.
   [key: string]: unknown;
@@ -984,6 +1003,12 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
     pushLog: safeLog,
     lastPhase: () => phases[phases.length - 1],
     hostAgent: opts.dispatch,
+    // Effort tiers are resolved host-side so the sandbox accepts exactly the
+    // aliases `/effort` does without a second copy of the alias table. Takes
+    // and returns primitives only.
+    normalizeEffort: (raw: unknown): string | null =>
+      typeof raw === 'string' ? (normalizeReasoningEffort(raw) ?? null) : null,
+    effortTiers: REASONING_EFFORT_TIERS.join(', '),
     // PR #4947 R2 T7 (qwen-code-ci-bot): host-side log hook for reviveInRealm's
     // catch path. Mirrors the rejection-logging in settleToNullArray so an
     // operator running with debug logging can distinguish "thunk rejected"
@@ -1484,7 +1509,7 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
       // FIX-Round1-T13: throw on any opts key not in the allowlist — catches
       // typos like { scema: ... } that previously slipped through the
       // [key:string]: unknown index signature.
-      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'isolation', 'agentType', 'stallMs', 'workingDir'];
+      const KNOWN_AGENT_OPTS = ['label', 'phase', 'schema', 'model', 'effort', 'isolation', 'agentType', 'stallMs', 'workingDir', 'disallowedTools'];
       globalThis.agent = vmAsync(function (prompt, agentOpts) {
         agentOpts = agentOpts || {};
         const keys = Object.keys(agentOpts);
@@ -1564,6 +1589,46 @@ export function createWorkflowSandbox(opts: SandboxOptions): WorkflowSandbox {
             "agent() opts contain a non-JSON-serializable value: " +
             String(e && e.message != null ? e.message : e)
           );
+        }
+        // effort and disallowedTools are validated on the REVIVED copy: that
+        // is the object the host dispatch and the resume key see, so a getter
+        // cannot show one value here and hand another to the dispatch. Both
+        // are normalized in place (an effort alias becomes its tier, a deny
+        // list becomes sorted and de-duplicated) so equivalent spellings share
+        // one resume key.
+        if (safeOpts.effort !== undefined) {
+          var tier = __b.normalizeEffort(safeOpts.effort);
+          if (tier === null) {
+            throw new Error(
+              "agent({effort}): unknown effort tier " + JSON.stringify(safeOpts.effort) + ". " +
+              "Known tiers are: " + __b.effortTiers + "."
+            );
+          }
+          safeOpts.effort = tier;
+        }
+        if (safeOpts.disallowedTools !== undefined) {
+          var denied = safeOpts.disallowedTools;
+          if (
+            !Array.isArray(denied) ||
+            denied.some(function (name) {
+              return typeof name !== 'string' || name.length === 0 || name !== name.trim();
+            })
+          ) {
+            throw new Error(
+              "agent({disallowedTools}): must be an array of non-empty tool-name strings " +
+              "without surrounding whitespace, e.g. ['run_shell_command', 'write_file']."
+            );
+          }
+          var uniqueDenied = [];
+          for (var d = 0; d < denied.length; d++) {
+            if (uniqueDenied.indexOf(denied[d]) === -1) uniqueDenied.push(denied[d]);
+          }
+          uniqueDenied.sort();
+          if (uniqueDenied.length === 0) {
+            delete safeOpts.disallowedTools;
+          } else {
+            safeOpts.disallowedTools = uniqueDenied;
+          }
         }
         // SECURITY (PR #4947 R1 wenshao, extended for P3): vmAsync's resolve
         // path is verbatim (no re-wrap of resolved values). Host-realm

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -20,7 +20,10 @@ import type {
   InputModalities,
 } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfigSources } from '../core/contentGenerator.js';
-import type { ReasoningEffort } from '../core/reasoning-effort.js';
+import {
+  setGeneratorReasoningEffort,
+  type ReasoningEffort,
+} from '../core/reasoning-effort.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
 import type { ShellExecutionConfig } from '../services/shellExecutionService.js';
 import type { VisionBridgeModelSelection } from '../services/visionBridge/vision-bridge-service.js';
@@ -5848,26 +5851,12 @@ export class Config {
    * cannot silently re-enable it.
    */
   setReasoningEffort(effort: ReasoningEffort | undefined): void {
+    // One rule for every config that carries the tier; a workflow agent's own
+    // config goes through the same helper (see setGeneratorReasoningEffort).
     const applyEffort = (
       cfg: { reasoning?: ContentGeneratorConfig['reasoning'] } | undefined,
     ): void => {
-      if (!cfg || cfg.reasoning === false) {
-        return;
-      }
-      const next: { effort?: ReasoningEffort; budget_tokens?: number } = {
-        ...(cfg.reasoning ?? {}),
-      };
-      if (effort) {
-        next.effort = effort;
-      } else {
-        delete next.effort;
-      }
-      // Clearing the last key (e.g. setReasoningEffort(undefined) with no
-      // sibling budget_tokens) collapses `reasoning` back to undefined rather
-      // than leaving an empty `{}` — an empty object is truthy, so downstream
-      // `if (cfg.reasoning)` checks would treat reasoning as active and the
-      // pipeline would emit `reasoning: {}` as wire noise.
-      cfg.reasoning = Object.keys(next).length > 0 ? next : undefined;
+      setGeneratorReasoningEffort(cfg, effort);
     };
     // The main session and a runtime (sub-agent) content generator may hold
     // distinct config objects; update whichever the request path reads.

--- a/packages/core/src/core/reasoning-effort.test.ts
+++ b/packages/core/src/core/reasoning-effort.test.ts
@@ -9,6 +9,8 @@ import type { Config } from '../config/config.js';
 import {
   REASONING_EFFORT_TIERS,
   applyReasoningEffort,
+  setGeneratorReasoningEffort,
+  reasoningEffortsForCapability,
   clampReasoningEffort,
   getGptReasoningCapabilities,
   isReasoningEffortPlaceholder,
@@ -16,6 +18,7 @@ import {
   parseModelReasoningCapabilities,
   type ReasoningEffort,
 } from './reasoning-effort.js';
+import type { ContentGeneratorConfig } from './contentGenerator.js';
 
 describe('getGptReasoningCapabilities', () => {
   it.each([
@@ -295,6 +298,72 @@ describe('applyReasoningEffort', () => {
 
     const disabled = makeConfig(true);
     expect(applyReasoningEffort(disabled, undefined)).toBe(true);
+  });
+});
+
+// The one rule `/effort` and a workflow `agent({ effort })` share for putting a
+// tier on a config. A per-agent config is spread from the session's, so the
+// block must be replaced rather than mutated or the session would change too.
+describe('setGeneratorReasoningEffort', () => {
+  type ReasoningHolder = { reasoning?: ContentGeneratorConfig['reasoning'] };
+
+  it('writes the tier onto a config with no reasoning block', () => {
+    const cfg: ReasoningHolder = {};
+    expect(setGeneratorReasoningEffort(cfg, 'low')).toBe(true);
+    expect(cfg.reasoning).toEqual({ effort: 'low' });
+  });
+
+  it('keeps sibling fields and replaces the block instead of mutating it', () => {
+    const shared = { effort: 'high' as const, budget_tokens: 2048 };
+    const cfg: ReasoningHolder = { reasoning: shared };
+    expect(setGeneratorReasoningEffort(cfg, 'max')).toBe(true);
+    expect(cfg.reasoning).toEqual({ effort: 'max', budget_tokens: 2048 });
+    expect(shared).toEqual({ effort: 'high', budget_tokens: 2048 });
+  });
+
+  it('leaves a config with thinking turned off alone', () => {
+    const cfg: ReasoningHolder = { reasoning: false };
+    expect(setGeneratorReasoningEffort(cfg, 'high')).toBe(false);
+    expect(cfg.reasoning).toBe(false);
+  });
+
+  it('collapses reasoning to undefined when clearing the last key', () => {
+    const cfg: ReasoningHolder = { reasoning: { effort: 'medium' } };
+    expect(setGeneratorReasoningEffort(cfg, undefined)).toBe(true);
+    expect(cfg.reasoning).toBeUndefined();
+  });
+
+  it('reports false for a missing config', () => {
+    expect(setGeneratorReasoningEffort(undefined, 'low')).toBe(false);
+  });
+});
+
+// The tier set `/effort` offers a model, shared with the per-agent path.
+describe('reasoningEffortsForCapability', () => {
+  it('offers every tier when the model declares nothing', () => {
+    expect(reasoningEffortsForCapability(undefined)).toEqual(
+      REASONING_EFFORT_TIERS,
+    );
+  });
+
+  it('offers nothing for a toggle-only model', () => {
+    const toggleOnly = parseModelReasoningCapabilities({
+      thinking: true,
+      disableField: 'enable_thinking',
+      toggleOnly: true,
+    });
+    expect(toggleOnly).toBeDefined();
+    expect(reasoningEffortsForCapability(toggleOnly)).toEqual([]);
+  });
+
+  it('offers exactly the declared tiers', () => {
+    const declared = parseModelReasoningCapabilities({
+      thinking: true,
+      disableField: 'reasoning_effort',
+      efforts: ['low', 'high'],
+    });
+    expect(declared).toBeDefined();
+    expect(reasoningEffortsForCapability(declared)).toEqual(['low', 'high']);
   });
 });
 

--- a/packages/core/src/core/reasoning-effort.ts
+++ b/packages/core/src/core/reasoning-effort.ts
@@ -275,9 +275,17 @@ export function setGeneratorReasoningEffort(
  * The tiers `/effort` offers for a model with this parsed reasoning
  * capability: none for a toggle-only model, the declared list otherwise, and
  * the whole ladder when the model declares nothing (the provider clamps then).
+ * The one tier rule shared by `/effort` (the CLI's picker and command) and a
+ * workflow agent's per-call effort; each site keeps its own capability lookup.
  */
 export function reasoningEffortsForCapability(
-  reasoning: ModelReasoningCapabilities | undefined,
+  reasoning:
+    | { readonly toggleOnly: true }
+    | {
+        readonly toggleOnly?: false;
+        readonly efforts: readonly ReasoningEffort[];
+      }
+    | undefined,
 ): readonly ReasoningEffort[] {
   if (!reasoning) return REASONING_EFFORT_TIERS;
   return reasoning.toggleOnly ? [] : reasoning.efforts;

--- a/packages/core/src/core/reasoning-effort.ts
+++ b/packages/core/src/core/reasoning-effort.ts
@@ -7,6 +7,7 @@
 import type { Config } from '../config/config.js';
 import { normalize } from './tokenLimits.js';
 import type { ModelReasoningCapabilities } from '../models/types.js';
+import type { ContentGeneratorConfig } from './contentGenerator.js';
 
 /**
  * Unified reasoning-effort ladder exposed to users (e.g. via `/effort`).
@@ -229,6 +230,57 @@ export function applyReasoningEffort(
 ): boolean {
   config.setReasoningEffort(effort);
   return config.getReasoningEffort() === effort;
+}
+
+/**
+ * Write `effort` onto a content-generator config's `reasoning` block. This is
+ * the one rule for putting a tier on a config: `/effort` applies it to the
+ * session (`Config.setReasoningEffort`) and a workflow `agent({ effort })`
+ * applies it to that agent's own copy of the config.
+ *
+ * A config with thinking explicitly turned off (`reasoning: false`) is left
+ * alone and `false` is returned. Otherwise the tier replaces `reasoning.effort`
+ * while sibling fields such as `budget_tokens` survive, and `undefined`
+ * removes the tier. Removing the last key collapses `reasoning` back to
+ * `undefined` rather than leaving an empty `{}`: an empty object is truthy, so
+ * downstream `if (cfg.reasoning)` checks would treat reasoning as active and
+ * the pipeline would emit `reasoning: {}` as wire noise.
+ *
+ * The block is replaced, never mutated, so a config that shares its
+ * `reasoning` object with another — a per-agent config spread from the
+ * session's — never changes the other one. No clamping happens here: each
+ * provider maps the tier onto what the target model accepts when it builds a
+ * request.
+ */
+export function setGeneratorReasoningEffort(
+  cfg: { reasoning?: ContentGeneratorConfig['reasoning'] } | undefined,
+  effort: ReasoningEffort | undefined,
+): boolean {
+  if (!cfg || cfg.reasoning === false) {
+    return false;
+  }
+  const next: { effort?: ReasoningEffort; budget_tokens?: number } = {
+    ...(cfg.reasoning ?? {}),
+  };
+  if (effort) {
+    next.effort = effort;
+  } else {
+    delete next.effort;
+  }
+  cfg.reasoning = Object.keys(next).length > 0 ? next : undefined;
+  return true;
+}
+
+/**
+ * The tiers `/effort` offers for a model with this parsed reasoning
+ * capability: none for a toggle-only model, the declared list otherwise, and
+ * the whole ladder when the model declares nothing (the provider clamps then).
+ */
+export function reasoningEffortsForCapability(
+  reasoning: ModelReasoningCapabilities | undefined,
+): readonly ReasoningEffort[] {
+  if (!reasoning) return REASONING_EFFORT_TIERS;
+  return reasoning.toggleOnly ? [] : reasoning.efforts;
 }
 
 /**

--- a/packages/core/src/models/content-generator-config.test.ts
+++ b/packages/core/src/models/content-generator-config.test.ts
@@ -301,7 +301,9 @@ describe('buildAgentContentGeneratorConfig', () => {
   // to land on the agent's copy by the rule `/effort` uses, and never on the
   // session config that copy was spread from.
   describe('per-agent reasoning effort', () => {
-    it('writes the tier onto an inherited copy without touching the parent', () => {
+    // An explicit tier is authoritative on the copy: an inherited budget would
+    // outrank it on the wire, so the copy drops it. The parent keeps both.
+    it('writes the tier onto an inherited copy, drops the inherited budget, and leaves the parent alone', () => {
       const parent: ContentGeneratorConfig = {
         ...parentConfig,
         reasoning: { effort: 'high', budget_tokens: 4096 },
@@ -317,7 +319,7 @@ describe('buildAgentContentGeneratorConfig', () => {
 
       expect(result.model).toBe('parent-model');
       expect(result.apiKey).toBe('parent-key');
-      expect(result.reasoning).toEqual({ effort: 'low', budget_tokens: 4096 });
+      expect(result.reasoning).toEqual({ effort: 'low' });
       expect(parent.reasoning).toEqual({ effort: 'high', budget_tokens: 4096 });
     });
 
@@ -411,6 +413,147 @@ describe('buildAgentContentGeneratorConfig', () => {
       );
 
       expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it('drops a thinking budget the agent model registry provides', () => {
+      const registryModel = {
+        id: 'registry-model',
+        authType: 'openai',
+        name: 'registry-model',
+        baseUrl: 'https://registry.example.com',
+        generationConfig: { reasoning: { budget_tokens: 32000 } },
+        capabilities: {},
+      } as unknown as ResolvedModelConfig;
+      const config = createMockConfig(parentConfig, registryModel);
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        'registry-model',
+        { authType: 'openai' },
+        { reasoningEffort: 'low' },
+      );
+
+      expect(result.model).toBe('registry-model');
+      expect(result.reasoning).toEqual({ effort: 'low' });
+    });
+
+    // A provider switch clears the session's `reasoning: false` from the copy;
+    // the tier must still not switch thinking back on.
+    it('never re-enables thinking the session turned off, even across providers', () => {
+      const config = createMockConfig({ ...parentConfig, reasoning: false });
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        'claude-sonnet',
+        { authType: 'anthropic' },
+        { reasoningEffort: 'max' },
+      );
+
+      expect(result.reasoning).toBeUndefined();
+    });
+
+    // Registry stubs that answer only for the arguments they are given, so a
+    // lookup keyed on the wrong model or an exact-only base URL shows up.
+    const DECLARED_TIERS = {
+      thinking: true,
+      disableField: 'reasoning_effort',
+      efforts: ['low', 'medium', 'high'],
+    };
+    function configWithRegistry(
+      parent: ContentGeneratorConfig,
+      entry: { authType: string; model: string; baseUrl: string },
+    ): Config {
+      const getResolvedModel = vi.fn(
+        (authType: string, model: string, baseUrl?: string) =>
+          authType === entry.authType &&
+          model === entry.model &&
+          (baseUrl === undefined || baseUrl === entry.baseUrl)
+            ? ({
+                id: entry.model,
+                authType: entry.authType,
+                name: entry.model,
+                baseUrl: entry.baseUrl,
+                generationConfig: {},
+                capabilities: { reasoning: DECLARED_TIERS },
+              } as unknown as ResolvedModelConfig)
+            : undefined,
+      );
+      return {
+        getContentGeneratorConfig: () => parent,
+        getModelsConfig: () => ({ getResolvedModel }),
+      } as unknown as Config;
+    }
+
+    it("clamps against the agent's own model, not the session's", () => {
+      const config = configWithRegistry(parentConfig, {
+        authType: 'openai',
+        model: 'agent-model',
+        baseUrl: 'https://agent.example.com',
+      });
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        'agent-model',
+        { authType: 'openai' },
+        { reasoningEffort: 'max' },
+      );
+
+      expect(result.model).toBe('agent-model');
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it('finds the declared tiers behind a gateway base URL', () => {
+      const config = configWithRegistry(
+        { ...parentConfig, baseUrl: 'https://gw.internal/v1' },
+        {
+          authType: 'openai',
+          model: 'parent-model',
+          baseUrl: 'https://api.openai.com/v1',
+        },
+      );
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'max' },
+      );
+
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it("falls back to the provider's built-in tiers when the registry declares none", () => {
+      const config = createMockConfig({ ...parentConfig, model: 'gpt-5' });
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'max' },
+      );
+
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it('refuses an interactive login when asked to', async () => {
+      const config = createMockConfig(parentConfig);
+      vi.mocked(createContentGenerator).mockResolvedValue(
+        {} as Awaited<ReturnType<typeof createContentGenerator>>,
+      );
+
+      await createRuntimeContentGeneratorView(
+        config,
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'low', requireCachedCredentials: true },
+      );
+
+      expect(createContentGenerator).toHaveBeenCalledWith(
+        expect.objectContaining({ reasoning: { effort: 'low' } }),
+        config,
+        true,
+      );
     });
 
     it('carries the effort through createRuntimeContentGeneratorView', async () => {

--- a/packages/core/src/models/content-generator-config.test.ts
+++ b/packages/core/src/models/content-generator-config.test.ts
@@ -297,6 +297,146 @@ describe('buildAgentContentGeneratorConfig', () => {
     });
   });
 
+  // A workflow `agent({ effort })` gets its tier through this builder. It has
+  // to land on the agent's copy by the rule `/effort` uses, and never on the
+  // session config that copy was spread from.
+  describe('per-agent reasoning effort', () => {
+    it('writes the tier onto an inherited copy without touching the parent', () => {
+      const parent: ContentGeneratorConfig = {
+        ...parentConfig,
+        reasoning: { effort: 'high', budget_tokens: 4096 },
+      };
+      const config = createMockConfig(parent);
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'low' },
+      );
+
+      expect(result.model).toBe('parent-model');
+      expect(result.apiKey).toBe('parent-key');
+      expect(result.reasoning).toEqual({ effort: 'low', budget_tokens: 4096 });
+      expect(parent.reasoning).toEqual({ effort: 'high', budget_tokens: 4096 });
+    });
+
+    it('leaves thinking off when the parent turned it off', () => {
+      const config = createMockConfig({ ...parentConfig, reasoning: false });
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'max' },
+      );
+
+      expect(result.reasoning).toBe(false);
+    });
+
+    it('applies after a cross-provider switch cleared the generation config', () => {
+      const config = createMockConfig(parentConfig);
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        'claude-sonnet',
+        { authType: 'anthropic' },
+        { reasoningEffort: 'xhigh' },
+      );
+
+      expect(result.samplingParams).toBeUndefined();
+      expect(result.reasoning).toEqual({ effort: 'xhigh' });
+    });
+
+    it('changes nothing when no effort is requested', () => {
+      const config = createMockConfig(parentConfig);
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        {},
+      );
+
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    // Limited to what `/effort` offers the agent's model: an unoffered tier
+    // becomes the next stronger offered one (else the strongest), and a model
+    // that offers none keeps the tier the agent inherited.
+    it('clamps to the tiers the model declares', () => {
+      const config = createMockConfig(parentConfig, {
+        capabilities: {
+          reasoning: {
+            thinking: true,
+            disableField: 'reasoning_effort',
+            efforts: ['low', 'medium', 'high'],
+          },
+        },
+      } as unknown as ResolvedModelConfig);
+
+      const above = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'max' },
+      );
+      const offered = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'low' },
+      );
+
+      expect(above.reasoning).toEqual({ effort: 'high' });
+      expect(offered.reasoning).toEqual({ effort: 'low' });
+    });
+
+    it('keeps the inherited tier for a model that offers none', () => {
+      const config = createMockConfig(parentConfig, {
+        capabilities: {
+          reasoning: {
+            thinking: true,
+            disableField: 'enable_thinking',
+            toggleOnly: true,
+          },
+        },
+      } as unknown as ResolvedModelConfig);
+
+      const result = buildAgentContentGeneratorConfig(
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'low' },
+      );
+
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it('carries the effort through createRuntimeContentGeneratorView', async () => {
+      const config = createMockConfig(parentConfig);
+      vi.mocked(createContentGenerator).mockResolvedValue(
+        {} as Awaited<ReturnType<typeof createContentGenerator>>,
+      );
+
+      const view = await createRuntimeContentGeneratorView(
+        config,
+        config,
+        undefined,
+        { authType: 'openai' },
+        { reasoningEffort: 'medium' },
+      );
+
+      expect(view.contentGeneratorConfig.reasoning).toEqual({
+        effort: 'medium',
+      });
+      expect(createContentGenerator).toHaveBeenCalledWith(
+        expect.objectContaining({ reasoning: { effort: 'medium' } }),
+        config,
+      );
+    });
+  });
+
   describe('edge cases', () => {
     it('should fall back to parent model when modelId is undefined', () => {
       const config = createMockConfig(parentConfig);

--- a/packages/core/src/models/content-generator-config.ts
+++ b/packages/core/src/models/content-generator-config.ts
@@ -26,7 +26,9 @@ import {
 import type { ResolvedModelConfig } from './types.js';
 import {
   clampReasoningEffort,
+  getGptReasoningCapabilities,
   parseModelReasoningCapabilities,
+  REASONING_EFFORT_TIERS,
   reasoningEffortsForCapability,
   setGeneratorReasoningEffort,
   type ReasoningEffort,
@@ -44,10 +46,21 @@ export interface AuthOverrides {
 export interface AgentContentGeneratorOptions {
   /**
    * Reasoning effort for this agent alone, written onto the agent's own copy of
-   * the config and never onto the session's. Limited to the tiers `/effort`
-   * offers for the agent's model; see {@link applyAgentReasoningEffort}.
+   * the config and never onto the session's; {@link resolveAgentReasoningTier}
+   * decides which tier lands. An explicit tier also drops a thinking budget the
+   * copy inherited, because Anthropic honours an explicit budget before the
+   * tier. A thinking knob fixed in the provider settings (`extra_body`,
+   * `samplingParams`) is left alone and still outranks the tier on the wire,
+   * exactly as it outranks the session tier set by `/effort`.
    */
   reasoningEffort?: ReasoningEffort;
+  /**
+   * Refuse to start an interactive login while building this generator. A
+   * derived per-agent generator runs headless, so missing credentials must
+   * fail fast instead of opening a device-authorization flow; a refresh of
+   * cached credentials still happens.
+   */
+  requireCachedCredentials?: boolean;
 }
 
 /**
@@ -78,45 +91,98 @@ export function buildAgentContentGeneratorConfig(
 }
 
 /**
- * Put a per-agent tier on `target`, limited to the tiers `/effort` offers for
- * the agent's model. `/effort` refuses a tier outside that set; an agent gets
- * the closest tier the model does offer instead (the next stronger one, else
- * the strongest), so a script written for one model still runs on another. A
- * model that offers no tiers, or has thinking turned off, keeps the tier the
- * agent inherited. The tier is then written with the rule the session setter
- * uses, and each provider clamps it per request as it does the session tier.
+ * The tier a per-agent `reasoningEffort` request lands as on a config shaped
+ * like `target`, or `undefined` when it cannot land and the agent keeps the
+ * effort it would otherwise have.
+ *
+ * The tier is limited to the tiers `/effort` offers for the target model
+ * ({@link reasoningEffortsForCapability}). A model whose settings declare no
+ * tiers falls back to its provider's built-in table, because the Responses
+ * wire forwards a tier verbatim with no provider-side clamp. `/effort` refuses a
+ * tier outside the set; an agent gets the closest tier the model does offer
+ * instead (the next stronger one, else the strongest), so a script written for
+ * one model still runs on another. Nothing lands when the model offers no
+ * tiers, or when thinking is turned off for the session or on the target
+ * config: a per-agent tier never re-enables thinking that was switched off,
+ * including across a provider switch that cleared the session's
+ * `reasoning: false` from the copy.
+ */
+export function resolveAgentReasoningTier(
+  base: Config,
+  target: Pick<
+    ContentGeneratorConfig,
+    'authType' | 'model' | 'baseUrl' | 'reasoning'
+  >,
+  requested: ReasoningEffort,
+): ReasoningEffort | undefined {
+  if (
+    target.reasoning === false ||
+    base.getContentGeneratorConfig().reasoning === false
+  ) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' ignored: thinking is turned off.`,
+    );
+    return undefined;
+  }
+  const offered = offeredReasoningEfforts(base, target);
+  if (offered.length === 0) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' ignored: model '${target.model}' offers no reasoning effort tiers.`,
+    );
+    return undefined;
+  }
+  const tier = clampReasoningEffort(requested, offered);
+  if (tier !== requested) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' is not offered by model '${target.model}'; using '${tier}'.`,
+    );
+  }
+  return tier;
+}
+
+function offeredReasoningEfforts(
+  base: Config,
+  target: Pick<ContentGeneratorConfig, 'authType' | 'model' | 'baseUrl'>,
+): readonly ReasoningEffort[] {
+  if (target.authType && target.model) {
+    const models = base.getModelsConfig();
+    // Exact id + baseUrl first, then any entry with the same id: a gateway or
+    // proxy base URL must not hide the tiers the registry declares (the same
+    // fallback modelsConfig applies to this miss).
+    const resolved =
+      (target.baseUrl !== undefined
+        ? models.getResolvedModel(target.authType, target.model, target.baseUrl)
+        : undefined) ?? models.getResolvedModel(target.authType, target.model);
+    const declared = parseModelReasoningCapabilities(
+      resolved?.capabilities?.reasoning,
+    );
+    if (declared) return reasoningEffortsForCapability(declared);
+  }
+  return (
+    getGptReasoningCapabilities(target.model)?.efforts ?? REASONING_EFFORT_TIERS
+  );
+}
+
+/**
+ * Put the landed tier on `target` with the session setter's rule, then make it
+ * authoritative on this copy: an inherited `budget_tokens` would otherwise
+ * outrank it, because Anthropic honours an explicit budget before the tier, so
+ * the copy drops it. The session's own block is never touched.
  */
 function applyAgentReasoningEffort(
   base: Config,
   target: ContentGeneratorConfig,
   requested: ReasoningEffort,
 ): void {
-  const capability =
-    target.authType && target.model
-      ? base
-          .getModelsConfig()
-          .getResolvedModel(target.authType, target.model, target.baseUrl)
-          ?.capabilities?.reasoning
-      : undefined;
-  const offered = reasoningEffortsForCapability(
-    parseModelReasoningCapabilities(capability),
-  );
-  if (offered.length === 0) {
-    debugLogger.debug(
-      `Per-agent reasoning effort '${requested}' ignored: model '${target.model}' offers no reasoning effort tiers.`,
-    );
+  const tier = resolveAgentReasoningTier(base, target, requested);
+  if (tier === undefined || !setGeneratorReasoningEffort(target, tier)) {
     return;
   }
-  const tier = clampReasoningEffort(requested, offered);
-  if (!setGeneratorReasoningEffort(target, tier)) {
+  if (target.reasoning && target.reasoning.budget_tokens !== undefined) {
+    const { budget_tokens: inheritedBudget, ...rest } = target.reasoning;
+    target.reasoning = rest;
     debugLogger.debug(
-      `Per-agent reasoning effort '${requested}' ignored: thinking is disabled for model '${target.model}'.`,
-    );
-    return;
-  }
-  if (tier !== requested) {
-    debugLogger.debug(
-      `Per-agent reasoning effort '${requested}' is not offered by model '${target.model}'; using '${tier}'.`,
+      `Per-agent reasoning effort '${tier}' replaces an inherited thinking budget of ${inheritedBudget} tokens.`,
     );
   }
 }
@@ -215,10 +281,17 @@ export async function createRuntimeContentGeneratorView(
     authOverrides,
     options,
   );
-  const contentGenerator = await createContentGenerator(
-    contentGeneratorConfig,
-    contentGeneratorOwner,
-  );
+  const contentGenerator = options.requireCachedCredentials
+    ? await createContentGenerator(
+        contentGeneratorConfig,
+        contentGeneratorOwner,
+        // isInitialAuth: refuse an interactive login for a derived generator.
+        true,
+      )
+    : await createContentGenerator(
+        contentGeneratorConfig,
+        contentGeneratorOwner,
+      );
   return { contentGenerator, contentGeneratorConfig };
 }
 

--- a/packages/core/src/models/content-generator-config.ts
+++ b/packages/core/src/models/content-generator-config.ts
@@ -24,11 +24,30 @@ import {
   MODEL_GENERATION_CONFIG_FIELDS,
 } from './constants.js';
 import type { ResolvedModelConfig } from './types.js';
+import {
+  clampReasoningEffort,
+  parseModelReasoningCapabilities,
+  reasoningEffortsForCapability,
+  setGeneratorReasoningEffort,
+  type ReasoningEffort,
+} from '../core/reasoning-effort.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('AGENT_CONTENT_GENERATOR');
 
 export interface AuthOverrides {
   authType: string;
   apiKey?: string;
   baseUrl?: string;
+}
+
+export interface AgentContentGeneratorOptions {
+  /**
+   * Reasoning effort for this agent alone, written onto the agent's own copy of
+   * the config and never onto the session's. Limited to the tiers `/effort`
+   * offers for the agent's model; see {@link applyAgentReasoningEffort}.
+   */
+  reasoningEffort?: ReasoningEffort;
 }
 
 /**
@@ -42,6 +61,67 @@ export interface AuthOverrides {
  * what a PTY subprocess does during its own initialization.
  */
 export function buildAgentContentGeneratorConfig(
+  base: Config,
+  modelId: string | undefined,
+  authOverrides: AuthOverrides,
+  options: AgentContentGeneratorOptions = {},
+): ContentGeneratorConfig {
+  const nextConfig = buildInheritedAgentContentGeneratorConfig(
+    base,
+    modelId,
+    authOverrides,
+  );
+  if (options.reasoningEffort !== undefined) {
+    applyAgentReasoningEffort(base, nextConfig, options.reasoningEffort);
+  }
+  return nextConfig;
+}
+
+/**
+ * Put a per-agent tier on `target`, limited to the tiers `/effort` offers for
+ * the agent's model. `/effort` refuses a tier outside that set; an agent gets
+ * the closest tier the model does offer instead (the next stronger one, else
+ * the strongest), so a script written for one model still runs on another. A
+ * model that offers no tiers, or has thinking turned off, keeps the tier the
+ * agent inherited. The tier is then written with the rule the session setter
+ * uses, and each provider clamps it per request as it does the session tier.
+ */
+function applyAgentReasoningEffort(
+  base: Config,
+  target: ContentGeneratorConfig,
+  requested: ReasoningEffort,
+): void {
+  const capability =
+    target.authType && target.model
+      ? base
+          .getModelsConfig()
+          .getResolvedModel(target.authType, target.model, target.baseUrl)
+          ?.capabilities?.reasoning
+      : undefined;
+  const offered = reasoningEffortsForCapability(
+    parseModelReasoningCapabilities(capability),
+  );
+  if (offered.length === 0) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' ignored: model '${target.model}' offers no reasoning effort tiers.`,
+    );
+    return;
+  }
+  const tier = clampReasoningEffort(requested, offered);
+  if (!setGeneratorReasoningEffort(target, tier)) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' ignored: thinking is disabled for model '${target.model}'.`,
+    );
+    return;
+  }
+  if (tier !== requested) {
+    debugLogger.debug(
+      `Per-agent reasoning effort '${requested}' is not offered by model '${target.model}'; using '${tier}'.`,
+    );
+  }
+}
+
+function buildInheritedAgentContentGeneratorConfig(
   base: Config,
   modelId: string | undefined,
   authOverrides: AuthOverrides,
@@ -127,11 +207,13 @@ export async function createRuntimeContentGeneratorView(
   contentGeneratorOwner: Config,
   modelId: string | undefined,
   authOverrides: AuthOverrides,
+  options: AgentContentGeneratorOptions = {},
 ): Promise<RuntimeContentGeneratorView> {
   const contentGeneratorConfig = buildAgentContentGeneratorConfig(
     base,
     modelId,
     authOverrides,
+    options,
   );
   const contentGenerator = await createContentGenerator(
     contentGeneratorConfig,

--- a/packages/core/src/skills/bundled/workflow-authoring/SKILL.md
+++ b/packages/core/src/skills/bundled/workflow-authoring/SKILL.md
@@ -105,15 +105,23 @@ say explicitly what each one should read and whether it may edit files.
 - `model` (string) — per-call model override; routes provider correctly via the
   subagent runtime view.
 - `effort` (`'low'` | `'medium'` | `'high'` | `'xhigh'` | `'max'`) — the
-  reasoning effort for this one agent; omit it to inherit the session's effort.
-  It is limited to the tiers `/effort` offers for the agent's model: a tier the
-  model does not offer becomes the next stronger tier it does offer, or its
-  strongest tier when none is stronger, and a model that offers no tiers, or has
-  thinking turned off, keeps the effort it inherited. The session's own effort
-  is never changed. Aliases such as `'med'` and `'x-high'` are accepted; any
-  other value rejects the call. Use `'low'` for cheap mechanical stages and the
-  higher tiers only for the hardest verify or judge stages. A different effort
-  is a different resume cache key.
+  reasoning effort for this one agent. It is limited to the tiers `/effort`
+  offers for the agent's model or, for a model whose settings declare none, to
+  the tiers its provider's built-in table accepts: a tier the model does not
+  offer becomes the next stronger tier it does offer, or its strongest tier
+  when none is stronger. A model that offers no tiers, or thinking turned off
+  for the session or the model, leaves the agent with the effort it would have
+  had without the option. The session's own effort is never changed, and an
+  explicit tier replaces any thinking budget the agent would otherwise inherit;
+  a thinking setting fixed in the provider settings (such as `extra_body` or
+  `samplingParams`) still takes precedence over the tier, as it does over
+  `/effort`. Omitting `effort` inherits the session's effort only while the
+  agent stays on the session's provider: a `model` override that switches
+  provider starts from that model's own reasoning settings, so pass `effort`
+  there. Aliases such as `'med'` and `'x-high'` are accepted; any other value
+  rejects the call. Use `'low'` for cheap mechanical stages and the higher tiers
+  only for the hardest verify or judge stages. A different effort is a
+  different resume cache key.
 - `isolation` — `'worktree'` provisions a fresh git worktree under
   `<projectRoot>/.qwen/worktrees/agent-<7hex>`; the worktree is auto-removed if
   no changes, otherwise the path and branch are returned alongside the result.
@@ -142,14 +150,19 @@ say explicitly what each one should read and whether it may edit files.
   `QWEN_CODE_WORKFLOW_STALL_SECONDS`, whole seconds); `0` disables the
   watchdog. Wall time per attempt is bounded separately.
 - `disallowedTools` (string[]) — tools this agent may not call, on top of the
-  floor below; it can only narrow the agent's tools, never re-enable one. Use
-  tool names (`run_shell_command`, `write_file`, `edit`) or display names
-  (`Shell`, `WriteFile`, `Edit`); a name that matches no tool denies nothing.
-  Entries must be non-empty strings without surrounding whitespace, or the call
-  is rejected. A `schema` agent that denies `structured_output` resolves to null
-  with the reason recorded, because it would have no way to return its result.
-  The resume cache key depends on which tools are denied, not on their order or
-  duplicates.
+  floor below; it can only narrow the agent's tools, never re-enable one. Name a
+  tool by its tool name (`run_shell_command`, `write_file`, `edit`) or its
+  display name (`Shell`, `WriteFile`, `Edit`), or deny MCP tools with
+  `mcp__<server>` (every tool of that server), `mcp__<server>__*`, or
+  `mcp__<server>__<tool>`. An entry that names no built-in or registered tool
+  and is not an `mcp__` pattern, such as `'Bash'`, resolves the call to null
+  with the reason recorded rather than silently denying nothing. Entries must
+  be non-empty strings without surrounding whitespace, or the call is rejected.
+  A `schema` agent whose denies, from this call or from its `agentType`,
+  include `structured_output` resolves to null with the reason recorded,
+  because it would have no way to return its result. The resume cache key
+  depends on which tools are denied, not on their order or duplicates, and not
+  on whether a built-in tool is named by its tool name or its display name.
 
 Workflow subagents can never use AskUserQuestion, SendMessage, Monitor,
 EnterPlanMode, ExitPlanMode, or the Agent tool, whatever their `agentType`. A

--- a/packages/core/src/skills/bundled/workflow-authoring/SKILL.md
+++ b/packages/core/src/skills/bundled/workflow-authoring/SKILL.md
@@ -83,7 +83,7 @@ say explicitly what each one should read and whether it may edit files.
 
 ## agent() options
 
-`agent(prompt, { label?, phase?, schema?, model?, agentType?, isolation?, workingDir?, stallMs? })`
+`agent(prompt, { label?, phase?, schema?, model?, effort?, agentType?, isolation?, workingDir?, stallMs?, disallowedTools? })`
 
 - `label` (string) — the name shown in the run views and the failures list.
   Make it unique per dispatch: a failure line carries only the label and the
@@ -104,6 +104,16 @@ say explicitly what each one should read and whether it may edit files.
   agent type 'X' not found"; check for null.
 - `model` (string) — per-call model override; routes provider correctly via the
   subagent runtime view.
+- `effort` (`'low'` | `'medium'` | `'high'` | `'xhigh'` | `'max'`) — the
+  reasoning effort for this one agent; omit it to inherit the session's effort.
+  It is limited to the tiers `/effort` offers for the agent's model: a tier the
+  model does not offer becomes the next stronger tier it does offer, or its
+  strongest tier when none is stronger, and a model that offers no tiers, or has
+  thinking turned off, keeps the effort it inherited. The session's own effort
+  is never changed. Aliases such as `'med'` and `'x-high'` are accepted; any
+  other value rejects the call. Use `'low'` for cheap mechanical stages and the
+  higher tiers only for the hardest verify or judge stages. A different effort
+  is a different resume cache key.
 - `isolation` — `'worktree'` provisions a fresh git worktree under
   `<projectRoot>/.qwen/worktrees/agent-<7hex>`; the worktree is auto-removed if
   no changes, otherwise the path and branch are returned alongside the result.
@@ -131,6 +141,15 @@ say explicitly what each one should read and whether it may edit files.
   a legitimately slow tool is not a stall. Default 180000 (override via
   `QWEN_CODE_WORKFLOW_STALL_SECONDS`, whole seconds); `0` disables the
   watchdog. Wall time per attempt is bounded separately.
+- `disallowedTools` (string[]) — tools this agent may not call, on top of the
+  floor below; it can only narrow the agent's tools, never re-enable one. Use
+  tool names (`run_shell_command`, `write_file`, `edit`) or display names
+  (`Shell`, `WriteFile`, `Edit`); a name that matches no tool denies nothing.
+  Entries must be non-empty strings without surrounding whitespace, or the call
+  is rejected. A `schema` agent that denies `structured_output` resolves to null
+  with the reason recorded, because it would have no way to return its result.
+  The resume cache key depends on which tools are denied, not on their order or
+  duplicates.
 
 Workflow subagents can never use AskUserQuestion, SendMessage, Monitor,
 EnterPlanMode, ExitPlanMode, or the Agent tool, whatever their `agentType`. A

--- a/packages/core/src/skills/bundled/workflow-authoring/SKILL.test.ts
+++ b/packages/core/src/skills/bundled/workflow-authoring/SKILL.test.ts
@@ -176,18 +176,29 @@ describe('bundled workflow-authoring skill', () => {
     // The phase option is ambient, not per call.
     ['every dispatch issued after it'],
     ['It is not scoped to the one call'],
-    // effort: the rule it shares with /effort, and what changes the key.
+    // effort: the rule it shares with /effort, where it does not reach, and
+    // what changes the key.
     ['model?, effort?, agentType?'],
     ["limited to the tiers `/effort` offers for the agent's model"],
+    ["the tiers its provider's built-in table accepts"],
     ['becomes the next stronger tier it does offer'],
-    ['keeps the effort it inherited'],
+    ['leaves the agent with the effort it would have had without the option'],
     ["The session's own effort is never changed"],
+    ['replaces any thinking budget the agent would otherwise inherit'],
+    ['still takes precedence over the tier'],
+    [
+      "a `model` override that switches provider starts from that model's own reasoning settings",
+    ],
     ['A different effort is a different resume cache key'],
-    // disallowedTools only narrows, and a schema agent cannot deny its answer.
+    // disallowedTools only narrows, names what it accepts, and a schema agent
+    // cannot deny its answer.
     ['stallMs?, disallowedTools? })'],
     ['never re-enable one'],
-    ['denies `structured_output` resolves to null'],
+    ['`mcp__<server>__*`'],
+    ["such as `'Bash'`, resolves the call to null"],
+    ['include `structured_output` resolves to null'],
     ['not on their order or duplicates'],
+    ['named by its tool name or its display name'],
     // What the disallowed-tool floor means for a script. The tools themselves
     // are checked against the orchestrator's own list below.
     ['cannot fan out further'],

--- a/packages/core/src/skills/bundled/workflow-authoring/SKILL.test.ts
+++ b/packages/core/src/skills/bundled/workflow-authoring/SKILL.test.ts
@@ -176,6 +176,18 @@ describe('bundled workflow-authoring skill', () => {
     // The phase option is ambient, not per call.
     ['every dispatch issued after it'],
     ['It is not scoped to the one call'],
+    // effort: the rule it shares with /effort, and what changes the key.
+    ['model?, effort?, agentType?'],
+    ["limited to the tiers `/effort` offers for the agent's model"],
+    ['becomes the next stronger tier it does offer'],
+    ['keeps the effort it inherited'],
+    ["The session's own effort is never changed"],
+    ['A different effort is a different resume cache key'],
+    // disallowedTools only narrows, and a schema agent cannot deny its answer.
+    ['stallMs?, disallowedTools? })'],
+    ['never re-enable one'],
+    ['denies `structured_output` resolves to null'],
+    ['not on their order or duplicates'],
     // What the disallowed-tool floor means for a script. The tools themselves
     // are checked against the orchestrator's own list below.
     ['cannot fan out further'],

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -3229,12 +3229,62 @@ bad`);
             reasoning: { effort: 'low' },
           }),
           mockConfig,
+          true,
         );
         const { runtimeView } = destructureAgentHeadlessCall(
           mockAgentHeadlessCreate.mock.calls[0],
         );
         expect(runtimeView).toBeDefined();
         expect(parent.reasoning).toBeUndefined();
+      });
+
+      // A tier the session's model cannot take changes nothing, so it must not
+      // cost the agent a ContentGenerator of its own.
+      it('should NOT create a ContentGenerator for a tier the model cannot take', async () => {
+        vi.spyOn(mockConfig, 'getModelsConfig').mockReturnValue({
+          getResolvedModel: vi.fn().mockReturnValue({
+            capabilities: {
+              reasoning: {
+                thinking: true,
+                toggleOnly: true,
+                disableField: 'enable_thinking',
+              },
+            },
+          }),
+          getGenerationConfig: vi.fn().mockReturnValue({}),
+        } as unknown as ReturnType<Config['getModelsConfig']>);
+
+        await manager.createAgentHeadless(agentConfig, mockConfig, {
+          modelConfigOverrides: { reasoningEffort: 'low' },
+        });
+
+        expect(mockCreateContentGenerator).not.toHaveBeenCalled();
+        const { runtimeView } = destructureAgentHeadlessCall(
+          mockAgentHeadlessCreate.mock.calls[0],
+        );
+        expect(runtimeView).toBeUndefined();
+      });
+
+      // A tier alone is no reason to log in, and no reason to fail the
+      // dispatch: a failed build leaves the agent on the session's generator.
+      it('should run an effort-only agent on the session generator when its own cannot be built', async () => {
+        mockCreateContentGenerator.mockRejectedValueOnce(
+          new Error('Qwen OAuth credentials expired.'),
+        );
+
+        await manager.createAgentHeadless(agentConfig, mockConfig, {
+          modelConfigOverrides: { reasoningEffort: 'low' },
+        });
+
+        expect(mockCreateContentGenerator).toHaveBeenCalledWith(
+          expect.anything(),
+          mockConfig,
+          true,
+        );
+        const { runtimeView } = destructureAgentHeadlessCall(
+          mockAgentHeadlessCreate.mock.calls[0],
+        );
+        expect(runtimeView).toBeUndefined();
       });
 
       it('should carry a reasoning effort alongside a model override', async () => {
@@ -3253,10 +3303,22 @@ bad`);
         );
       });
 
-      it('resolves display names to tool names and keeps unknown names as given', async () => {
+      // A deny that matches nothing silently leaves the agent the tool. Only an
+      // entry that is neither an MCP pattern, a built-in tool (registered here
+      // or not), nor a registered tool's name or display name comes back.
+      it('finds the deny entries that match no tool', async () => {
         await expect(
-          manager.resolveToolNames(['Write File', 'grep', 'not_a_tool']),
-        ).resolves.toEqual(['write_file', 'grep', 'not_a_tool']);
+          manager.findUnmatchedToolNames([
+            'Write File',
+            'grep',
+            'edit',
+            'Shell',
+            'mcp__github',
+            'mcp__github__*',
+            'Bash',
+            'run_shell',
+          ]),
+        ).resolves.toEqual(['Bash', 'run_shell']);
       });
 
       it('should pass the agent runtimeView to AgentHeadless.create', async () => {

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -3212,6 +3212,53 @@ bad`);
         expect(mockCreateContentGenerator).not.toHaveBeenCalled();
       });
 
+      // A per-agent reasoning effort needs its own content generator even on
+      // the parent's model: the tier goes onto the agent's copy of the
+      // config, and the session config the agent would otherwise share must
+      // never receive it.
+      it('should create a ContentGenerator on the parent model for a reasoning effort alone', async () => {
+        const parent = mockConfig.getContentGeneratorConfig();
+
+        await manager.createAgentHeadless(agentConfig, mockConfig, {
+          modelConfigOverrides: { reasoningEffort: 'low' },
+        });
+
+        expect(mockCreateContentGenerator).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model: 'parent-model',
+            reasoning: { effort: 'low' },
+          }),
+          mockConfig,
+        );
+        const { runtimeView } = destructureAgentHeadlessCall(
+          mockAgentHeadlessCreate.mock.calls[0],
+        );
+        expect(runtimeView).toBeDefined();
+        expect(parent.reasoning).toBeUndefined();
+      });
+
+      it('should carry a reasoning effort alongside a model override', async () => {
+        await manager.createAgentHeadless(
+          { ...agentConfig, model: 'custom-model' },
+          mockConfig,
+          { modelConfigOverrides: { reasoningEffort: 'max' } },
+        );
+
+        expect(mockCreateContentGenerator).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model: 'custom-model',
+            reasoning: { effort: 'max' },
+          }),
+          mockConfig,
+        );
+      });
+
+      it('resolves display names to tool names and keeps unknown names as given', async () => {
+        await expect(
+          manager.resolveToolNames(['Write File', 'grep', 'not_a_tool']),
+        ).resolves.toEqual(['write_file', 'grep', 'not_a_tool']);
+      });
+
       it('should pass the agent runtimeView to AgentHeadless.create', async () => {
         const config = { ...agentConfig, model: 'custom-model' };
         const fakeGenerator = { generateContentStream: vi.fn() };

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -46,6 +46,7 @@ import type { RuntimeContentGeneratorView } from '../agents/runtime/agent-contex
 import type { ReasoningEffort } from '../core/reasoning-effort.js';
 import {
   createRuntimeContentGeneratorView,
+  resolveAgentReasoningTier,
   type AuthOverrides,
 } from '../models/content-generator-config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -67,7 +68,11 @@ import {
   parseMaxTurns,
   claudePermissionModeToApprovalMode,
 } from './agent-frontmatter-schema.js';
-import { ToolDisplayNamesMigration, ToolNames } from '../tools/tool-names.js';
+import {
+  resolveBuiltinToolName,
+  ToolDisplayNamesMigration,
+  ToolNames,
+} from '../tools/tool-names.js';
 import { QWEN_DIR, Storage } from '../config/storage.js';
 import {
   hasRebuiltToolRegistry,
@@ -1336,6 +1341,21 @@ export class SubagentManager {
     if (!modelId && reasoningEffort === undefined) {
       return undefined;
     }
+    // An effort-only request would otherwise share the session's generator.
+    // Give the agent its own only when the tier can land on the session's
+    // model: a tier it cannot take (toggle-only, thinking off) changes nothing,
+    // and a generator per dispatch would be pure cost.
+    if (
+      !modelId &&
+      reasoningEffort !== undefined &&
+      resolveAgentReasoningTier(
+        base,
+        base.getContentGeneratorConfig(),
+        reasoningEffort,
+      ) === undefined
+    ) {
+      return undefined;
+    }
 
     const authType =
       route?.authType ??
@@ -1348,18 +1368,35 @@ export class SubagentManager {
           authType: authType as string,
         };
 
-    const view = await createRuntimeContentGeneratorView(
-      base,
-      base,
-      modelId,
-      authOverrides,
-      { reasoningEffort },
-    );
+    let view: RuntimeContentGeneratorView;
+    try {
+      view = await createRuntimeContentGeneratorView(
+        base,
+        base,
+        modelId,
+        authOverrides,
+        {
+          reasoningEffort,
+          // A tier alone is no reason to log in: a headless dispatch must
+          // never open an interactive device flow for it.
+          ...(modelId ? {} : { requireCachedCredentials: true }),
+        },
+      );
+    } catch (error) {
+      if (modelId) throw error;
+      // Effort-only: the agent still runs, on the session's generator and
+      // effort, rather than failing the dispatch over a cosmetic option.
+      debugLogger.warn(
+        `Subagent "${config.name}" could not get its own ContentGenerator for reasoningEffort=${reasoningEffort} (${error instanceof Error ? error.message : String(error)}); it runs on the session's generator and effort.`,
+      );
+      return undefined;
+    }
 
+    const landed = view.contentGeneratorConfig.reasoning;
     debugLogger.info(
       `Created per-agent ContentGenerator for subagent "${config.name}": authType=${authType}, model=${view.contentGeneratorConfig.model}` +
         (reasoningEffort !== undefined
-          ? `, reasoningEffort=${reasoningEffort}`
+          ? `, reasoningEffort=${landed ? (landed.effort ?? 'none') : 'none'} (requested ${reasoningEffort})`
           : ''),
     );
 
@@ -1511,13 +1548,28 @@ export class SubagentManager {
   }
 
   /**
-   * Resolve tool names or display names to tool names with the rules a spawn
-   * applies to `tools` / `disallowedTools`. A name that matches no registered
-   * tool is kept as given. Lets a caller reason about a deny list before the
-   * spawn without keeping a second copy of the matching rules.
+   * The entries of a deny list that can deny nothing: not an `mcp__` pattern
+   * (those match by pattern at run time), not a built-in tool by tool name,
+   * display name or legacy alias (registered in this session or not), and not
+   * the name or display name of any registered tool. A deny that matches
+   * nothing silently leaves the agent the tool the caller meant to take away,
+   * so callers refuse these instead of forwarding them.
    */
-  async resolveToolNames(tools: string[]): Promise<string[]> {
-    return this.transformToToolNames(tools);
+  async findUnmatchedToolNames(tools: string[]): Promise<string[]> {
+    const candidates = tools.filter(
+      (name) =>
+        !name.startsWith('mcp__') && resolveBuiltinToolName(name) === undefined,
+    );
+    if (candidates.length === 0) return [];
+    const toolRegistry = this.config.getToolRegistry();
+    if (!toolRegistry) return candidates;
+    await toolRegistry.warmAll();
+    const registered = new Set<string>();
+    for (const tool of toolRegistry.getAllTools()) {
+      registered.add(tool.name);
+      if (tool.displayName) registered.add(tool.displayName);
+    }
+    return candidates.filter((name) => !registered.has(name));
   }
 
   /**

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -43,6 +43,7 @@ import type { Config, MCPServerConfig } from '../config/config.js';
 import { APPROVAL_MODES, deriveConfig } from '../config/config.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
 import type { RuntimeContentGeneratorView } from '../agents/runtime/agent-context.js';
+import type { ReasoningEffort } from '../core/reasoning-effort.js';
 import {
   createRuntimeContentGeneratorView,
   type AuthOverrides,
@@ -1074,15 +1075,17 @@ export class SubagentManager {
         ),
       };
 
-      // When the model selector specifies a different provider, build a
-      // dedicated ContentGenerator + view so the subagent talks to the
-      // right API without affecting the parent process. The view is
+      // When the model selector specifies a different provider, or the
+      // caller asked for a per-agent reasoning effort, build a dedicated
+      // ContentGenerator + view so the subagent talks to the right API with
+      // its own settings without affecting the parent process. The view is
       // applied via AsyncLocalStorage when the agent runs.
       const runtimeView = await this.buildRuntimeContentGeneratorView(
         config,
         runtimeContext,
         modelConfig.model,
         options?.runtimeAuthOverrides,
+        modelConfig.reasoningEffort,
       );
 
       const { context: subagentContext, cleanup } =
@@ -1308,6 +1311,10 @@ export class SubagentManager {
    * override is needed — including `inherit`, an unset `fast` selector, or
    * any selector that fails to resolve to a configured model.
    *
+   * A `reasoningEffort` always needs its own view, even on the parent's model:
+   * the tier is written onto the agent's copy of the config, and the session
+   * config the agent would otherwise share must never receive it.
+   *
    * FileReadCache isolation and tool-registry rebuilding are handled
    * separately in {@link buildSubagentContextOverride} — every subagent
    * (inherit or explicit) gets that, regardless of whether a runtime
@@ -1318,6 +1325,7 @@ export class SubagentManager {
     base: Config,
     fallbackModelId?: string,
     runtimeAuthOverrides?: AuthOverrides,
+    reasoningEffort?: ReasoningEffort,
   ): Promise<RuntimeContentGeneratorView | undefined> {
     const route = this.resolveModelRoute(
       config,
@@ -1325,7 +1333,7 @@ export class SubagentManager {
       runtimeAuthOverrides?.authType,
     );
     const modelId = route?.modelId ?? fallbackModelId;
-    if (!modelId) {
+    if (!modelId && reasoningEffort === undefined) {
       return undefined;
     }
 
@@ -1345,10 +1353,14 @@ export class SubagentManager {
       base,
       modelId,
       authOverrides,
+      { reasoningEffort },
     );
 
     debugLogger.info(
-      `Created per-agent ContentGenerator for subagent "${config.name}": authType=${authType}, model=${view.contentGeneratorConfig.model}`,
+      `Created per-agent ContentGenerator for subagent "${config.name}": authType=${authType}, model=${view.contentGeneratorConfig.model}` +
+        (reasoningEffort !== undefined
+          ? `, reasoningEffort=${reasoningEffort}`
+          : ''),
     );
 
     return view;
@@ -1496,6 +1508,16 @@ export class SubagentManager {
       runConfig,
       toolConfig,
     };
+  }
+
+  /**
+   * Resolve tool names or display names to tool names with the rules a spawn
+   * applies to `tools` / `disallowedTools`. A name that matches no registered
+   * tool is kept as given. Lets a caller reason about a deny list before the
+   * spawn without keeping a second copy of the matching rules.
+   */
+  async resolveToolNames(tools: string[]): Promise<string[]> {
+    return this.transformToToolNames(tools);
   }
 
   /**

--- a/packages/core/src/tools/tool-names.test.ts
+++ b/packages/core/src/tools/tool-names.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  resolveBuiltinToolName,
+  ToolDisplayNames,
+  ToolNames,
+} from './tool-names.js';
+
+describe('resolveBuiltinToolName', () => {
+  it('maps a tool name, its display name and legacy aliases to the tool name', () => {
+    expect(resolveBuiltinToolName(ToolNames.SHELL)).toBe(ToolNames.SHELL);
+    expect(resolveBuiltinToolName(ToolDisplayNames.SHELL)).toBe(
+      ToolNames.SHELL,
+    );
+    expect(resolveBuiltinToolName('replace')).toBe(ToolNames.EDIT);
+    expect(resolveBuiltinToolName('SearchFiles')).toBe(ToolNames.GREP);
+  });
+
+  it('knows every built-in tool by both of its names', () => {
+    const displayNames = ToolDisplayNames as Record<string, string>;
+    for (const [key, name] of Object.entries(ToolNames)) {
+      expect(resolveBuiltinToolName(name)).toBe(name);
+      if (displayNames[key] !== undefined) {
+        expect(resolveBuiltinToolName(displayNames[key])).toBeDefined();
+      }
+    }
+  });
+
+  it('does not recognise MCP tools, other spellings or typos', () => {
+    for (const name of ['Bash', 'run_shell', 'mcp__github', 'EDIT']) {
+      expect(resolveBuiltinToolName(name)).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -160,3 +160,44 @@ export const ToolDisplayNamesMigration = {
   Task: ToolDisplayNames.AGENT, // Old display name for Agent (renamed from Task)
   TodoWrite: ToolDisplayNames.TODO_WRITE, // Old display name for TodoList (renamed from TodoWrite)
 } as const;
+
+/**
+ * Every spelling of a built-in tool, mapped to the name it is registered
+ * under: the tool name itself, its display name, and the legacy aliases of
+ * either. Built at module end so every table above is initialised.
+ */
+const BUILTIN_TOOL_NAMES: ReadonlyMap<string, string> = (() => {
+  const lookup = new Map<string, string>();
+  const displayNames = ToolDisplayNames as Record<string, string>;
+  for (const name of Object.values(ToolNames)) {
+    lookup.set(name, name);
+  }
+  for (const [key, name] of Object.entries(ToolNames)) {
+    const display = displayNames[key];
+    if (display !== undefined && !lookup.has(display)) {
+      lookup.set(display, name);
+    }
+  }
+  for (const [legacy, name] of Object.entries(ToolNamesMigration)) {
+    if (!lookup.has(legacy)) lookup.set(legacy, name);
+  }
+  for (const [legacyDisplay, display] of Object.entries(
+    ToolDisplayNamesMigration,
+  )) {
+    const name = lookup.get(display);
+    if (name !== undefined && !lookup.has(legacyDisplay)) {
+      lookup.set(legacyDisplay, name);
+    }
+  }
+  return lookup;
+})();
+
+/**
+ * The tool name a built-in tool is registered under, given its tool name, its
+ * display name, or a legacy alias of either; `undefined` for anything that is
+ * not a built-in tool (an MCP tool, a discovered tool, a typo). Static, so the
+ * answer does not depend on whether the tool is registered in this session.
+ */
+export function resolveBuiltinToolName(name: string): string | undefined {
+  return BUILTIN_TOOL_NAMES.get(name);
+}


### PR DESCRIPTION
## What this PR does

A workflow script can now tell each agent how hard to think and what it may not use.

`agent(prompt, { effort })` sets the reasoning effort for that one agent: `low`, `medium`, `high`, `xhigh` or `max`, with the same aliases `/effort` accepts. The tier is written onto the agent's own copy of the model settings, never the session's, and it is limited to the tiers `/effort` offers for that agent's model or, when the model's settings declare none, to the tiers its provider's built-in table accepts. Where `/effort` would refuse a tier the model does not offer, an agent gets the next stronger tier the model does offer (or its strongest), so a script written for one model still runs on another. A model that offers no tiers, or thinking turned off for the session or the model, leaves the agent with the effort it would have had without the option: a per-agent tier never switches thinking back on. An explicit tier replaces any thinking budget the agent's copy would otherwise inherit, because Anthropic honours an explicit budget before the tier. An effort-only dispatch gets its own content generator only when the tier can land, never opens an interactive login to build one, and runs on the session's generator if that build fails. The tier is written by the same code the session setter uses, and the CLI's `/effort` tier rule now calls the same core helper the agent path uses.

`agent(prompt, { disallowedTools })` takes tools away from that agent on top of the workflow's fixed floor. It can only narrow: the list is unioned with the floor and with whatever the agent type already denies, so nothing a script passes re-enables a tool. Built-in tools can be named by tool name or display name, and MCP tools by `mcp__<server>`, `mcp__<server>__*` or `mcp__<server>__<tool>`. An entry that names no built-in or registered tool and is not an MCP pattern, such as `'Bash'`, is refused instead of silently denying nothing. A schema agent whose denies, from the call or from its agent type, include `structured_output` is refused before it spawns, because it would have no way to return its result. Both refusals settle the call to null with the reason recorded.

Both options are part of the resume key. The sandbox normalizes them on the copy that crosses to the host, before the key is derived: an effort alias becomes its tier, and a deny list is sorted, de-duplicated and has built-in display names mapped to tool names. So `'med'` and `'medium'`, `Edit` and `edit`, or the same tools in a different order replay from the journal, while a genuinely different effort or deny set runs live. Invalid values reject the call with a message naming the accepted tiers or the expected shape, and a rejected call records no phase. The fast path that skips the subagent manager is driven by the same option list the resume key projects, so a future option cannot be dropped by it. The `workflow-authoring` skill documents both options, including where effort does not reach.

## Why it's needed

A fan-out usually mixes stages of very different difficulty, such as mechanical extraction next to adversarial verification. Every agent ran at the session's effort, so a script either paid high-effort cost on its cheap stages or ran its judges at low effort. Every agent also had the full tool set minus a fixed floor: a read-only survey stage could still edit files or run shell commands, and the only guard was prose in its prompt. Claude Code's workflow runtime accepts both options per call; this brings qwen-code's `agent()` to parity. It is item 2 of #11013.

## Reviewer Test Plan

### How to verify

Run a workflow that dispatches `agent('summarize this file', { effort: 'low' })` and `agent('find the bug', { effort: 'high' })` with debug logging on. The subagent manager logs a per-agent content generator for each with the tier that actually landed, and the session's `/effort` is unchanged afterwards. On a toggle-only model the same dispatch creates no per-agent generator. Dispatch `agent('x', { effort: 'turbo' })` and confirm the call rejects with the list of known tiers.

Run `agent('survey the repo and try to run ls', { disallowedTools: ['Shell', 'write_file', 'edit'] })` and confirm the agent has no shell, write or edit tool. Run `agent('x', { disallowedTools: ['Bash'] })` and confirm it resolves to null with `"Bash" matches no tool` in the failures list, while `['mcp__github']` is accepted. Run `agent('extract', { schema: { type: 'object' }, disallowedTools: ['StructuredOutput'] })` and confirm it resolves to null with the refusal named.

For the resume key, run a workflow with `{ effort: 'med', disallowedTools: ['Edit'] }` and resume it with `{ effort: 'medium', disallowedTools: ['edit'] }`: the agent replays from the journal. Resume again with `{ effort: 'high' }`: it runs live.

Unit tests for the touched areas:

```
cd packages/core && npx vitest run src/tools/tool-names.test.ts src/core/reasoning-effort.test.ts src/models/content-generator-config.test.ts src/subagents/subagent-manager.test.ts src/agents/runtime/workflow-journal.test.ts src/agents/runtime/workflow-sandbox.test.ts src/agents/runtime/workflow-orchestrator.test.ts src/skills/bundled/workflow-authoring/SKILL.test.ts src/agents/runtime/workflow-runner.test.ts src/tools/workflow/workflow.test.ts
cd packages/cli && npx vitest run src/acp-integration/model-configuration.test.ts src/commands/review/workflow-script.test.ts
```

All tests in those files pass locally, and core type-checking and ESLint are clean. To check that the tests guard what they claim, targeted mutations were applied one at a time and the matching tests re-run: twelve against the first version and fifteen against the review fixes, and every one turned tests red. The fixes' mutations were: not dropping an inherited thinking budget, not honouring the session's thinking-off switch, no gateway base URL fallback, no built-in tier fallback, keying the tier lookup on the session's model, no effort-only pre-check, not refusing an interactive login, not inheriting the session generator on a failed build, not refusing an unmatched deny, ignoring the agent type's denies in the schema check, resolving display names only through the registry, a fast path that ignores `effort`, recording the phase before the option gates, not sanitizing the echoed effort, and not canonicalizing deny names.

### Evidence (Before & After)

N/A — no TUI change. The affected surfaces are the `agent()` options a workflow script can pass, the model settings and tools the dispatched agent receives, and the resume key.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: an agent that sets `effort` without a model override now gets its own content generator built from a copy of the session config whenever the tier can land on the session's model, where it previously shared the session's. The copy inherits every setting except the reasoning block. A deny entry that matches no tool is now refused, so a script naming a tool this session does not recognise resolves that call to null instead of running with the deny silently ignored.
- Not validated / out of scope: Claude Code's per-call `bashCommandClamp` (a shell command allowlist) is not added; it is a permission-layer feature with no equivalent layer here and is deferred to item 11 of #11013. A thinking setting fixed in provider settings (`extra_body` or `samplingParams`) still outranks the per-agent tier on the wire, as it outranks the session tier, and the agent path does not report that shadowing yet; that follow-up stays under #11013. Spawn paths that build their own generator view (the in-process backend behind teammates and arena agents) do not read the per-agent tier. No live run against a provider: the tests pin the config each provider receives, not the wire request. The main Agent tool gains no per-call effort.
- Breaking changes / migration notes: none. A script that passes neither option dispatches exactly as before and keeps its resume keys, because the canonical options only gain a key when the option is present.

## Linked Issues

Part of #11013

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

workflow 脚本现在可以给每个 agent 分别指定推理强度，以及它不能使用的工具。

`agent(prompt, { effort })` 为这一个 agent 设置推理强度：`low`、`medium`、`high`、`xhigh` 或 `max`，并接受与 `/effort` 相同的别名。这个档位写到该 agent 自己那份模型设置副本上，绝不写到会话上；它限定在 `/effort` 为该 agent 的模型提供的档位之内，若模型设置没有声明档位，则限定在该 provider 内置表接受的档位之内。对模型不提供的档位，`/effort` 会拒绝，而 agent 会得到模型提供的下一个更强档位（没有更强的就取最强的），这样为一个模型写的脚本换到另一个模型上仍能运行。模型不提供任何档位、或会话或模型关闭了思考时，agent 保留不传该选项时本来会有的推理强度：per-agent 档位绝不会重新打开思考。显式档位会替换 agent 副本本来会继承的思考预算，因为 Anthropic 会先采用显式预算、再看档位。只传 effort 的派发只有在档位能落地时才获得自己的 content generator，构建时绝不打开交互式登录，构建失败则继续用会话的 generator 运行。写入档位用的是会话设置函数的同一段代码，CLI 的 `/effort` 档位规则现在也调用 agent 路径所用的同一个 core 辅助函数。

`agent(prompt, { disallowedTools })` 在 workflow 固定的禁用工具下限之上，再为这个 agent 去掉一些工具。它只能收窄：这份列表与下限、以及 agent 类型自身已禁用的工具取并集，脚本传入的任何内容都无法重新启用某个工具。内置工具可以用工具名或显示名，MCP 工具可以用 `mcp__<server>`、`mcp__<server>__*` 或 `mcp__<server>__<tool>`。既不是内置或已注册工具、也不是 MCP 模式的条目（例如 `'Bash'`）会被拒绝，而不是静默地什么都不禁用。schema agent 的禁用项（无论来自本次调用还是来自它的 agent 类型）若包含 `structured_output`，会在启动前被拒绝，因为它将无法返回结果。这两种拒绝都会让调用结算为 null，并记录原因。

两个选项都参与 resume 的缓存键。sandbox 在键生成之前、对跨到宿主的那份副本做规范化：effort 别名变成对应档位，禁用列表去重、排序，并把内置工具的显示名映射成工具名。所以 `'med'` 与 `'medium'`、`Edit` 与 `edit`、或者顺序不同的同一组工具，都会从 journal 回放；而真正不同的 effort 或禁用集合会实跑。非法取值会拒绝这次调用，错误信息会列出可接受的档位或期望的形状，被拒绝的调用不会记录 phase。跳过 subagent manager 的快速路径改由 resume 缓存键所投影的同一份选项清单驱动，将来新增的选项不会被它丢掉。`workflow-authoring` skill 记录了这两个选项，包括 effort 管不到的地方。

## 为什么需要

一次扇出通常混合了难度差别很大的阶段，比如机械的提取与对抗式验证并存。原来每个 agent 都以会话的推理强度运行，于是脚本要么在便宜的阶段付出高强度的开销，要么让评判阶段以低强度运行。每个 agent 也都拥有全套工具减去一个固定下限：只读的调研阶段仍然可以改文件或执行 shell 命令，唯一的防护是提示词里的文字。Claude Code 的 workflow 运行时支持按调用传这两个选项；本 PR 让 qwen-code 的 `agent()` 与之对齐，是 #11013 的第 2 项。

## 验证方式

在开启 debug 日志的情况下运行一个 workflow，派发 `agent('summarize this file', { effort: 'low' })` 和 `agent('find the bug', { effort: 'high' })`。subagent manager 会为每个 agent 记录一个 per-agent content generator，并写明实际落地的档位，之后会话的 `/effort` 保持不变。在 toggle-only 模型上同样的派发不会创建 per-agent generator。派发 `agent('x', { effort: 'turbo' })`，确认调用被拒绝，且错误中列出了已知档位。

运行 `agent('survey the repo and try to run ls', { disallowedTools: ['Shell', 'write_file', 'edit'] })`，确认该 agent 没有 shell、写文件或编辑工具。运行 `agent('x', { disallowedTools: ['Bash'] })`，确认它结算为 null，失败清单里有 `"Bash" matches no tool`；而 `['mcp__github']` 会被接受。运行 `agent('extract', { schema: { type: 'object' }, disallowedTools: ['StructuredOutput'] })`，确认它结算为 null 并写明拒绝原因。

关于 resume 缓存键：用 `{ effort: 'med', disallowedTools: ['Edit'] }` 运行一次 workflow，再用 `{ effort: 'medium', disallowedTools: ['edit'] }` resume，agent 会从 journal 回放。再用 `{ effort: 'high' }` resume，它会实跑。

受影响部分的单元测试：

```
cd packages/core && npx vitest run src/tools/tool-names.test.ts src/core/reasoning-effort.test.ts src/models/content-generator-config.test.ts src/subagents/subagent-manager.test.ts src/agents/runtime/workflow-journal.test.ts src/agents/runtime/workflow-sandbox.test.ts src/agents/runtime/workflow-orchestrator.test.ts src/skills/bundled/workflow-authoring/SKILL.test.ts src/agents/runtime/workflow-runner.test.ts src/tools/workflow/workflow.test.ts
cd packages/cli && npx vitest run src/acp-integration/model-configuration.test.ts src/commands/review/workflow-script.test.ts
```

本地这些文件的测试全部通过，core 类型检查与 ESLint 干净。为确认测试确实守住了它们声称的行为，逐一施加了定向变异并重跑对应测试：针对第一版十二个、针对评审修复十五个，全部让测试变红。修复部分的变异是：不删掉继承的思考预算、不遵守会话的关闭思考开关、没有网关 base URL 回退、没有内置档位回退、按会话模型查档位、只传 effort 时不做预检、不拒绝交互式登录、构建失败时不继承会话 generator、不拒绝匹配不到的禁用项、schema 检查忽略 agent 类型的禁用项、只通过注册表解析显示名、快速路径忽略 `effort`、在选项校验之前记录 phase、回显的 effort 不做净化、禁用名不做规范化。

## 证据（前后对比）

N/A —— 没有 TUI 变化。受影响的是 workflow 脚本可传的 `agent()` 选项、被派发的 agent 实际拿到的模型设置与工具，以及 resume 缓存键。

## 风险与范围

- 主要风险/取舍：只设置 `effort`、没有覆盖模型的 agent，只要档位能在会话模型上落地，现在就会基于会话配置的副本获得自己的 content generator，而以前它与会话共用。副本继承除 reasoning 块之外的全部设置。匹配不到任何工具的禁用条目现在会被拒绝，因此脚本若写了本会话识别不了的工具名，这次调用会结算为 null，而不是在禁用项被静默忽略的情况下继续运行。
- 未验证/不在范围：没有加入 Claude Code 的按调用 `bashCommandClamp`（shell 命令白名单）；那是权限层的功能，这里没有对应的层，留到 #11013 的第 11 项。provider 设置里固定的思考开关（`extra_body` 或 `samplingParams`）在线上仍会压过 per-agent 档位，正如它压过会话档位一样，而 agent 路径还不会上报这种遮蔽，这项跟进留在 #11013 下。自行构建 generator view 的 spawn 路径（teammate 与 arena 背后的 in-process backend）不读取 per-agent 档位。没有针对真实 provider 的实跑：测试钉住的是每个 provider 收到的配置，而不是线上请求。主循环的 Agent 工具没有增加按调用的 effort。
- 破坏性变更/迁移说明：无。两个选项都不传的脚本派发方式与以前完全相同，resume 缓存键也不变，因为规范化后的选项只在该选项存在时才多出一个键。

## 关联 issue

Part of #11013

</details>
