### PR TITLE
fix(goal): remove backtracking fence unwrap from judge replies

### DIFF
--- a/packages/core/src/goals/goal-checkpoint-verifier.ts
+++ b/packages/core/src/goals/goal-checkpoint-verifier.ts
@@ -274,7 +274,7 @@ function verifierContents(
  * model output of unbounded length, and a backtracking pattern over it runs
  * synchronously, past the verifier's own timeout.
  */
-function stripMarkdownFence(text: string): string {
+export function stripMarkdownFence(text: string): string {
   const body = text.trim();
   const fenceChar = body[0];
   if (fenceChar !== '`' && fenceChar !== '~') return text;

--- a/packages/core/src/goals/goal-checkpoint-verifier.ts
+++ b/packages/core/src/goals/goal-checkpoint-verifier.ts
@@ -274,7 +274,7 @@ function verifierContents(
  * model output of unbounded length, and a backtracking pattern over it runs
  * synchronously, past the verifier's own timeout.
  */
-export function stripMarkdownFence(text: string): string {
+function stripMarkdownFence(text: string): string {
   const body = text.trim();
   const fenceChar = body[0];
   if (fenceChar !== '`' && fenceChar !== '~') return text;

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -718,15 +718,45 @@ describe('judgeGoal', () => {
     expect(verdict.kind).toBe('met');
   });
 
-  it('returns an error for an opening fence that never closes', async () => {
+  it('parses a reply whose payload is glued to the opening fence line', async () => {
+    const client = makeMockClient({
+      reply:
+        '```json {"ok":true,"reason":"met","evidence":["output is ready"]}\n```',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'output is ready',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.kind).toBe('met');
+  });
+
+  it('parses a pretty-printed reply whose payload starts on the opening fence line', async () => {
+    const client = makeMockClient({
+      reply:
+        '```json {\n  "ok": true,\n  "reason": "met",\n  "evidence": ["output is ready"]\n}\n```',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'output is ready',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.kind).toBe('met');
+  });
+
+  it('returns an error for an opening fence that never closes', { timeout: 5_000 }, async () => {
     // A degenerate reply — an opening fence followed by a long whitespace run
     // and no closing fence. The old fence regex backtracked super-linearly on
     // this shape (~49 s for 5 000 spaces, measured locally); the index-scan
     // unwrap must return it unchanged so the judge fails fast instead of
     // freezing the event loop. The trailing `{` keeps the whitespace run
     // internal, so `extractText`'s `.trim()` cannot collapse it away before
-    // `parseJudgeReply` sees it. The assertion is on the value, not the
-    // elapsed time.
+    // `parseJudgeReply` sees it. The per-test timeout pins the guard
+    // independently of the runner's global testTimeout; the stage assertion
+    // confirms the reply actually reached `parseJudgeReply` (the `parse`
+    // failure path) rather than failing on an earlier stage.
     const client = makeMockClient({
       reply: '```json\n' + ' '.repeat(5_000) + '{',
     });
@@ -737,6 +767,7 @@ describe('judgeGoal', () => {
       signal: new AbortController().signal,
     });
     expect(verdict.kind).toBe('error');
+    expect(reportErrorMock.mock.calls[0][2]).toMatchObject({ stage: 'parse' });
   });
 
   it('returns an error when reply is not JSON', async () => {

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -746,29 +746,35 @@ describe('judgeGoal', () => {
     expect(verdict.kind).toBe('met');
   });
 
-  it('returns an error for an opening fence that never closes', { timeout: 5_000 }, async () => {
-    // A degenerate reply — an opening fence followed by a long whitespace run
-    // and no closing fence. The old fence regex backtracked super-linearly on
-    // this shape (~49 s for 5 000 spaces, measured locally); the index-scan
-    // unwrap must return it unchanged so the judge fails fast instead of
-    // freezing the event loop. The trailing `{` keeps the whitespace run
-    // internal, so `extractText`'s `.trim()` cannot collapse it away before
-    // `parseJudgeReply` sees it. The per-test timeout pins the guard
-    // independently of the runner's global testTimeout; the stage assertion
-    // confirms the reply actually reached `parseJudgeReply` (the `parse`
-    // failure path) rather than failing on an earlier stage.
-    const client = makeMockClient({
-      reply: '```json\n' + ' '.repeat(5_000) + '{',
-    });
-    const config = makeConfig({ client });
-    const verdict = await judgeGoal(config, {
-      condition: 'x',
-      lastAssistantText: 'y',
-      signal: new AbortController().signal,
-    });
-    expect(verdict.kind).toBe('error');
-    expect(reportErrorMock.mock.calls[0][2]).toMatchObject({ stage: 'parse' });
-  });
+  it(
+    'returns an error for an opening fence that never closes',
+    { timeout: 5_000 },
+    async () => {
+      // A degenerate reply — an opening fence followed by a long whitespace run
+      // and no closing fence. The old fence regex backtracked super-linearly on
+      // this shape (~49 s for 5 000 spaces, measured locally); the index-scan
+      // unwrap must return it unchanged so the judge fails fast instead of
+      // freezing the event loop. The trailing `{` keeps the whitespace run
+      // internal, so `extractText`'s `.trim()` cannot collapse it away before
+      // `parseJudgeReply` sees it. The per-test timeout pins the guard
+      // independently of the runner's global testTimeout; the stage assertion
+      // confirms the reply actually reached `parseJudgeReply` (the `parse`
+      // failure path) rather than failing on an earlier stage.
+      const client = makeMockClient({
+        reply: '```json\n' + ' '.repeat(5_000) + '{',
+      });
+      const config = makeConfig({ client });
+      const verdict = await judgeGoal(config, {
+        condition: 'x',
+        lastAssistantText: 'y',
+        signal: new AbortController().signal,
+      });
+      expect(verdict.kind).toBe('error');
+      expect(reportErrorMock.mock.calls[0][2]).toMatchObject({
+        stage: 'parse',
+      });
+    },
+  );
 
   it('returns an error when reply is not JSON', async () => {
     const client = makeMockClient({ reply: 'I have no idea sorry' });

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -718,6 +718,27 @@ describe('judgeGoal', () => {
     expect(verdict.kind).toBe('met');
   });
 
+  it('returns an error for an opening fence that never closes', async () => {
+    // A degenerate reply — an opening fence followed by a long whitespace run
+    // and no closing fence. The old fence regex backtracked super-linearly on
+    // this shape (~49 s for 5 000 spaces, measured locally); the index-scan
+    // unwrap must return it unchanged so the judge fails fast instead of
+    // freezing the event loop. The trailing `{` keeps the whitespace run
+    // internal, so `extractText`'s `.trim()` cannot collapse it away before
+    // `parseJudgeReply` sees it. The assertion is on the value, not the
+    // elapsed time.
+    const client = makeMockClient({
+      reply: '```json\n' + ' '.repeat(5_000) + '{',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.kind).toBe('error');
+  });
+
   it('returns an error when reply is not JSON', async () => {
     const client = makeMockClient({ reply: 'I have no idea sorry' });
     const config = makeConfig({ client });

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -746,6 +746,20 @@ describe('judgeGoal', () => {
     expect(verdict.kind).toBe('met');
   });
 
+  it('parses a glued pretty-printed reply quoting a braced excerpt', async () => {
+    const client = makeMockClient({
+      reply:
+        '```json {\n  "ok": true,\n  "reason": "met",\n  "evidence": ["function foo() { return 1; }"]\n}\n```',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'function foo() { return 1; }',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.kind).toBe('met');
+  });
+
   it(
     'returns an error for an opening fence that never closes',
     { timeout: 5_000 },

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -8,7 +8,6 @@ import type { Content, Part, Schema } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { reportError } from '../utils/errorReporting.js';
-import { stripMarkdownFence } from './goal-checkpoint-verifier.js';
 
 const debugLogger = createDebugLogger('GOAL_JUDGE');
 
@@ -436,15 +435,12 @@ function extractText(response: unknown): string {
 }
 
 function parseJudgeReply(text: string): JudgeWireResult | null {
-  const stripped = stripMarkdownFence(text);
-  // The fence helper's multi-line branch discards the opening fence line, so a
-  // reply whose payload is glued to that line (` ```json {"ok":true}` with the
-  // closing fence on the next line) unwraps to brace-less text. Fall back to
-  // the raw reply when the unwrap produced no `{`, keeping the tolerant scan
-  // below able to find the payload.
-  const cleaned = (stripped.includes('{') ? stripped : text).trim();
   // Accept the JSON anywhere in the reply: tolerant to chatty preambles when
-  // the model ignores structured-output mode.
+  // the model ignores structured-output mode. A markdown fence (backticks or
+  // tildes) and its info string carry no braces, so the index scan finds the
+  // payload without unwrapping first, and stays linear (no backtracking) on
+  // unbounded model output.
+  const cleaned = text.trim();
   const start = cleaned.indexOf('{');
   const end = cleaned.lastIndexOf('}');
   if (start === -1 || end === -1 || end < start) return null;

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -436,7 +436,13 @@ function extractText(response: unknown): string {
 }
 
 function parseJudgeReply(text: string): JudgeWireResult | null {
-  const cleaned = stripMarkdownFence(text).trim();
+  const stripped = stripMarkdownFence(text);
+  // The fence helper's multi-line branch discards the opening fence line, so a
+  // reply whose payload is glued to that line (` ```json {"ok":true}` with the
+  // closing fence on the next line) unwraps to brace-less text. Fall back to
+  // the raw reply when the unwrap produced no `{`, keeping the tolerant scan
+  // below able to find the payload.
+  const cleaned = (stripped.includes('{') ? stripped : text).trim();
   // Accept the JSON anywhere in the reply: tolerant to chatty preambles when
   // the model ignores structured-output mode.
   const start = cleaned.indexOf('{');

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -8,6 +8,7 @@ import type { Content, Part, Schema } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { reportError } from '../utils/errorReporting.js';
+import { stripMarkdownFence } from './goal-checkpoint-verifier.js';
 
 const debugLogger = createDebugLogger('GOAL_JUDGE');
 
@@ -435,7 +436,7 @@ function extractText(response: unknown): string {
 }
 
 function parseJudgeReply(text: string): JudgeWireResult | null {
-  const cleaned = stripCodeFence(text).trim();
+  const cleaned = stripMarkdownFence(text).trim();
   // Accept the JSON anywhere in the reply: tolerant to chatty preambles when
   // the model ignores structured-output mode.
   const start = cleaned.indexOf('{');
@@ -556,9 +557,4 @@ function toJudgeResult(
     };
   }
   return { kind: 'not_met', ok: false, reason: result.reason };
-}
-
-function stripCodeFence(s: string): string {
-  const m = s.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-  return m ? m[1] : s;
 }


### PR DESCRIPTION
## What this PR does

Removes the goal judge's redundant fence-unwrapping step and its backtracking regex. The existing first/last-brace JSON scan already handles bare JSON, fenced JSON, and a chatty preamble, so no shared parser or new export is needed. The checkpoint verifier remains unchanged.

## Why it's needed

`stripCodeFence` used `/^```(?:json)?\s*([\s\S]*?)\s*```$/i`, whose three overlapping quantifiers backtrack super-linearly on a reply that opens a fence and then degenerates without closing it. Measured locally: an opening fence followed by 5 000 spaces and no closing fence took ~49 s in one synchronous `exec`, blocking the event loop — past the judge's 25 s `setTimeout` guard, which cannot fire while the loop is blocked. A degenerate model reply can freeze the whole process. This is the same shape #11578 already removed from the checkpoint verifier.

## Reviewer Test Plan

### How to verify

- Red (before this change): the new test in `goalJudge.test.ts` — "returns an error for an opening fence that never closes" — times out (`Test timed out in 15000ms`, ~49 s of synchronous regex).
- Green (after): the same test passes instantly, and the full goals suite passes.

```
cd packages/core
npx vitest run src/goals/goalJudge.test.ts src/goals/goal-checkpoint-verifier.test.ts
```

- The existing fenced case ("extracts JSON from a chatty preamble") still parses.

### Evidence (Before & After)

N/A (non–user-visible core logic). A regression test is added; the committed test asserts the returned value, not elapsed time.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ |

<!-- ✅ tested · ⚠️ not tested · N/A -->

## Risk & Scope

- Main risk or tradeoff: the judge retains its existing tolerant JSON extraction, including malformed or glued fences. This change removes preprocessing; it does not make reply validation stricter.
- Not validated / out of scope: item 2 of #11689 (the terminal verifier's strict `JSON.parse`) is deliberately untouched, per the issue.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11689

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

删除 goal judge 多余的去围栏步骤及其回溯正则。现有的首尾花括号扫描已经能够提取裸 JSON、围栏内 JSON 和带前言的 JSON，因此无需共享解析器或新增导出。checkpoint 校验器保持不变。

## 为什么需要

`stripCodeFence` 用的正则 `/^```(?:json)?\s*([\s\S]*?)\s*```$/i` 三个量词重叠，在"开围栏后退化且不闭合"的回复上超线性回溯。本地实测：开围栏 + 5000 空格不闭合，单次同步 `exec` 约 49 秒，阻塞事件循环——而且 judge 的 25 秒 `setTimeout` 兜底在事件循环被卡住时无法触发。退化的模型回复会让整个进程冻结。这与 #11578 从 checkpoint 校验器移除的形状相同。

## 评审验证计划

### 如何验证

- 红（改动前）：`goalJudge.test.ts` 新增用例 "returns an error for an opening fence that never closes" 会超时（`Test timed out in 15000ms`，约 49 秒同步正则）。
- 绿（改动后）：同一用例立即通过，整个 goals 套件通过。

```
cd packages/core
npx vitest run src/goals/goalJudge.test.ts src/goals/goal-checkpoint-verifier.test.ts
```

- 既有围栏用例（"extracts JSON from a chatty preamble"）仍能解析。

### 证据（前后对比）

N/A（非用户可见的核心逻辑）。已加回归测试；提交的测试断言返回值，不做墙钟计时断言。

### 实测环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ |

## 风险与范围

- 主要风险/权衡：保留 judge 现有的宽松 JSON 提取，包括格式不完整或紧贴 JSON 的围栏。本改动只删除预处理，不收紧回复校验规则。
- 未验证/不在范围内：按 issue 要求，第 2 项（终态校验器的严格 `JSON.parse`）有意不改。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #11689

</details>
