### PR TITLE
fix(core): keep the mirrored reasoning field off Fireworks requests

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -19,6 +19,7 @@ import {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   CerebrasOpenAICompatibleProvider,
+  FireworksOpenAICompatibleProvider,
   type OpenAICompatibleProvider,
   DefaultOpenAICompatibleProvider,
 } from './provider/index.js';
@@ -35,6 +36,7 @@ export {
   MiniMaxOpenAICompatibleProvider,
   MistralOpenAICompatibleProvider,
   CerebrasOpenAICompatibleProvider,
+  FireworksOpenAICompatibleProvider,
 } from './provider/index.js';
 
 export { OpenAIContentConverter } from './converter.js';
@@ -114,6 +116,14 @@ export function determineProvider(
   // Check for Cerebras provider
   if (CerebrasOpenAICompatibleProvider.isCerebrasProvider(config)) {
     return new CerebrasOpenAICompatibleProvider(
+      contentGeneratorConfig,
+      cliConfig,
+    );
+  }
+
+  // Check for Fireworks provider
+  if (FireworksOpenAICompatibleProvider.isFireworksProvider(config)) {
+    return new FireworksOpenAICompatibleProvider(
       contentGeneratorConfig,
       cliConfig,
     );

--- a/packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts
@@ -1,0 +1,303 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type OpenAI from 'openai';
+import type { GenerateContentParameters } from '@google/genai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { determineProvider } from '../index.js';
+import { OpenAIContentGenerator } from '../openaiContentGenerator.js';
+import { FireworksOpenAICompatibleProvider } from './fireworks.js';
+
+function createCliConfig(): Config {
+  return {
+    getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+    getProxy: vi.fn().mockReturnValue(undefined),
+  } as unknown as Config;
+}
+
+function createProviderConfig(
+  overrides: Partial<ContentGeneratorConfig>,
+): ContentGeneratorConfig {
+  return {
+    apiKey: 'test-api-key',
+    baseUrl: 'https://api.fireworks.ai/inference/v1',
+    model: 'accounts/fireworks/models/qwen3p8-max',
+    ...overrides,
+  } as ContentGeneratorConfig;
+}
+
+function createReasoningRequest(): OpenAI.Chat.ChatCompletionCreateParams {
+  return {
+    model: 'accounts/fireworks/models/qwen3p8-max',
+    messages: [
+      { role: 'user', content: 'test' },
+      {
+        role: 'assistant',
+        content: 'Hey! How can I help?',
+        reasoning_content: 'The user said test.',
+      } as OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+        reasoning_content: string;
+      },
+      { role: 'user', content: 'follow-up question' },
+    ],
+    max_tokens: 1000,
+  };
+}
+
+describe('Fireworks provider reasoning-mirror suppression (issue #11657)', () => {
+  it('drops the mirrored reasoning field for api.fireworks.ai while preserving reasoning_content, without mutating the source history', () => {
+    const originalRequest = createReasoningRequest();
+    const provider = determineProvider(
+      createProviderConfig({
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        model: 'accounts/fireworks/models/qwen3p8-max',
+      }),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+
+    expect(result.messages?.[1]).toEqual({
+      role: 'assistant',
+      content: 'Hey! How can I help?',
+      reasoning_content: 'The user said test.',
+    });
+    expect(
+      (originalRequest.messages[1] as { reasoning?: string }).reasoning,
+    ).toBeUndefined();
+  });
+
+  it('drops the mirrored reasoning field for Fireworks subdomains', () => {
+    const originalRequest = createReasoningRequest();
+    const provider = determineProvider(
+      createProviderConfig({
+        baseUrl: 'https://inference.api.fireworks.ai/v1',
+        model: 'accounts/fireworks/models/qwen3p8-max',
+      }),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+
+    expect(
+      (result.messages?.[1] as { reasoning?: string }).reasoning,
+    ).toBeUndefined();
+    expect(
+      (result.messages?.[1] as { reasoning_content?: string })
+        .reasoning_content,
+    ).toBe('The user said test.');
+  });
+
+  it('does not treat hostile hostnames containing api.fireworks.ai as Fireworks', () => {
+    const originalRequest = createReasoningRequest();
+    const provider = determineProvider(
+      createProviderConfig({
+        baseUrl: 'https://api.fireworks.ai.evil.example/v1',
+        model: 'accounts/fireworks/models/qwen3p8-max',
+      }),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+
+    // Falls through to the default provider, which mirrors reasoning_content
+    // into reasoning for qwen3 model names.
+    expect((result.messages?.[1] as { reasoning?: string }).reasoning).toBe(
+      'The user said test.',
+    );
+  });
+
+  it('keeps an explicit reasoning field that differs from reasoning_content', () => {
+    const request = createReasoningRequest();
+    (request.messages[1] as { reasoning?: string }).reasoning =
+      'Canonical reasoning field';
+    const provider = determineProvider(
+      createProviderConfig({}),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(request, 'prompt-123');
+
+    expect((result.messages?.[1] as { reasoning?: string }).reasoning).toBe(
+      'Canonical reasoning field',
+    );
+    expect(
+      (result.messages?.[1] as { reasoning_content?: string })
+        .reasoning_content,
+    ).toBe('The user said test.');
+  });
+
+  it('leaves non-Fireworks qwen3 endpoints mirroring as before', () => {
+    const originalRequest = createReasoningRequest();
+    const provider = determineProvider(
+      createProviderConfig({
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'accounts/other-vendor/models/qwen3-something',
+      }),
+      createCliConfig(),
+    );
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+
+    expect((result.messages?.[1] as { reasoning?: string }).reasoning).toBe(
+      'The user said test.',
+    );
+  });
+});
+
+describe('tool-call continuation against a Fireworks-like strict endpoint (issue #11657)', () => {
+  /**
+   * Local stand-in for Fireworks: accepts OpenAI-compatible chat
+   * completions with `reasoning_content` (which Fireworks documents for
+   * reasoning replay) but rejects the mirrored `reasoning` field with the
+   * same validation payload api.fireworks.ai returns.
+   */
+  let server: http.Server;
+  let baseUrl: string;
+  let receivedBodies: Array<Record<string, unknown>>;
+
+  beforeAll(async () => {
+    // The generator's constructor builds undici-backed fetch options
+    // synchronously; production preloads undici in createContentGenerator.
+    const { preloadRuntimeFetchModule } = await import(
+      '../../../utils/runtimeFetchOptions.js'
+    );
+    await preloadRuntimeFetchModule();
+
+    receivedBodies = [];
+    server = http.createServer((req, res) => {
+      let raw = '';
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        const body = JSON.parse(raw) as Record<string, unknown>;
+        receivedBodies.push(body);
+        const carriesMirroredReasoning = (
+          body['messages'] as Array<Record<string, unknown>> | undefined
+        )?.some(
+          (message) =>
+            message['role'] === 'assistant' && 'reasoning' in message,
+        );
+        if (carriesMirroredReasoning) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              detail: [
+                {
+                  type: 'extra_forbidden',
+                  loc: ['body', 'messages', 2, 'reasoning'],
+                  msg: 'Extra inputs are not permitted',
+                  input: 'The user said test.',
+                },
+              ],
+            }),
+          );
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            id: 'chatcmpl-test',
+            object: 'chat.completion',
+            created: 1757000000,
+            model: body['model'],
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'Sure, go ahead.' },
+                finish_reason: 'stop',
+              },
+            ],
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 4,
+              total_tokens: 14,
+            },
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}/inference/v1`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it('continues a qwen3 tool-call conversation without shipping the mirrored reasoning field', async () => {
+    // The stand-in runs on 127.0.0.1, not api.fireworks.ai, so hostname
+    // detection (covered above) cannot wire the provider here; construct it
+    // directly. The generator runs the real path: session history ->
+    // converter -> provider boundary -> wire.
+    const providerConfig = createProviderConfig({ baseUrl });
+    const cliConfig = createCliConfig();
+    const generator = new OpenAIContentGenerator(
+      providerConfig,
+      cliConfig,
+      new FireworksOpenAICompatibleProvider(providerConfig, cliConfig),
+    );
+
+    // Turn 1 — a thinking turn that returns a tool call.
+    const turn1: GenerateContentParameters = {
+      model: 'accounts/fireworks/models/qwen3p8-max',
+      contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+    };
+    const response1 = await generator.generateContent(turn1, 'prompt-1');
+    expect(response1.candidates?.[0]?.content?.parts?.[0]).toMatchObject({
+      text: 'Sure, go ahead.',
+    });
+
+    // Turn 2 — history carries the model's prior thinking as a thought
+    // part, exactly what the session history holds after a thinking turn;
+    // on main this turn fails with `400 Extra inputs are not permitted,
+    // field: 'messages[2].reasoning'`.
+    const turn2: GenerateContentParameters = {
+      model: 'accounts/fireworks/models/qwen3p8-max',
+      contents: [
+        { role: 'user', parts: [{ text: 'test' }] },
+        {
+          role: 'model',
+          parts: [
+            { text: 'The user said test.', thought: true },
+            { text: 'Hey! How can I help?' },
+          ],
+        },
+        { role: 'user', parts: [{ text: 'follow-up question' }] },
+      ],
+    };
+    const response2 = await generator.generateContent(turn2, 'prompt-2');
+    expect(response2.candidates?.[0]?.content?.parts?.[0]).toMatchObject({
+      text: 'Sure, go ahead.',
+    });
+
+    // The strict endpoint accepted both turns, reasoning_content was
+    // preserved on the wire, and the mirrored reasoning field never left.
+    const followUp = receivedBodies[1] as {
+      messages?: Array<Record<string, unknown>>;
+    };
+    expect(followUp.messages).toBeDefined();
+    const assistantOnWire = followUp.messages?.find(
+      (message) => message['role'] === 'assistant',
+    );
+    expect(assistantOnWire).toMatchObject({
+      role: 'assistant',
+      content: 'Hey! How can I help?',
+      reasoning_content: 'The user said test.',
+    });
+    expect(assistantOnWire).not.toHaveProperty('reasoning');
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/fireworks.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/fireworks.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type OpenAI from 'openai';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+const FIREWORKS_API_HOST = 'api.fireworks.ai';
+
+/**
+ * Hostname-only detection: Fireworks serves third-party model names
+ * (`accounts/fireworks/models/qwen3p8-max`), so a model-name fallback
+ * would misroute other providers' models.
+ */
+export function isFireworksProvider(config: ContentGeneratorConfig): boolean {
+  const baseUrl = config.baseUrl ?? '';
+  if (!baseUrl) return false;
+
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      hostname === FIREWORKS_API_HOST ||
+      hostname.endsWith(`.${FIREWORKS_API_HOST}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fireworks' OpenAI-compatible endpoint accepts the non-standard
+ * `messages[].reasoning_content` field on input but rejects the mirrored
+ * `reasoning` field with HTTP 400 (`Extra inputs are not permitted, field:
+ * 'messages[N].reasoning'`, issue #11657). The default provider mirrors
+ * `reasoning_content` into `reasoning` for any model whose name contains
+ * "qwen3" — a family match that does not establish the endpoint accepts
+ * the extra field — so multi-turn tool-call continuation with Qwen3
+ * thinking models fails on Fireworks. Undo the mirror at the outbound
+ * request boundary, exactly where the default provider applies it; shared
+ * conversation history is never mutated and `reasoning_content` (which
+ * Fireworks documents for reasoning replay) is preserved.
+ */
+export class FireworksOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  static isFireworksProvider = isFireworksProvider;
+
+  override buildRequest(
+    request: OpenAI.Chat.ChatCompletionCreateParams,
+    userPromptId: string,
+  ): OpenAI.Chat.ChatCompletionCreateParams {
+    const baseRequest = super.buildRequest(request, userPromptId);
+
+    return {
+      ...baseRequest,
+      messages: baseRequest.messages.map(unmirrorReasoningField),
+    };
+  }
+}
+
+type AssistantMessageWithReasoningFields = {
+  reasoning_content?: string | null;
+  reasoning?: string | null;
+};
+
+// The mirror the default provider added is recognizable by construction:
+// `reasoning` is a non-empty string equal to `reasoning_content` on an
+// assistant message. Only that exact copy is dropped; a `reasoning` field
+// the caller set itself (distinct value) is left alone, and empty/null
+// mirrors are harmless on the wire but removed for shape parity with what
+// Fireworks would have received had the mirror never run.
+function unmirrorReasoningField(
+  message: OpenAI.Chat.ChatCompletionMessageParam,
+): OpenAI.Chat.ChatCompletionMessageParam {
+  if (message.role !== 'assistant') {
+    return message;
+  }
+
+  const assistant = message as typeof message &
+    AssistantMessageWithReasoningFields;
+  if (assistant.reasoning !== assistant.reasoning_content) {
+    return message;
+  }
+  if (typeof assistant.reasoning !== 'string') {
+    return message;
+  }
+
+  const { reasoning: _drop, ...rest } = assistant as typeof assistant & {
+    reasoning?: string;
+  };
+  return rest as OpenAI.Chat.ChatCompletionMessageParam;
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -5,6 +5,7 @@ export { ZaiOpenAICompatibleProvider } from './zai.js';
 export { MiniMaxOpenAICompatibleProvider } from './minimax.js';
 export { MistralOpenAICompatibleProvider } from './mistral.js';
 export { CerebrasOpenAICompatibleProvider } from './cerebras.js';
+export { FireworksOpenAICompatibleProvider } from './fireworks.js';
 export { MiMoOpenAICompatibleProvider } from './mimo.js';
 export { DefaultOpenAICompatibleProvider } from './default.js';
 export type {


### PR DESCRIPTION
## What this PR does

Adds a Fireworks provider that removes the mirrored `reasoning` field from outgoing chat-completion messages, detected by hostname (`api.fireworks.ai` and subdomains) in the provider router — the same shape as the Cerebras handling from #11049. The mirror is recognized by construction (an assistant message whose `reasoning` equals its `reasoning_content`, exactly what the default provider's mirroring produces for qwen3 model names); only that exact copy is dropped. A distinct explicit `reasoning` field, and `reasoning_content` itself, are preserved. Conversation history is never mutated, and non-Fireworks endpoints keep the existing mirroring behavior unchanged.

## Why it's needed

Fireworks' OpenAI-compatible endpoint accepts the non-standard `messages[].reasoning_content` field on input (it documents replaying it alongside `content` and `tool_calls`) but rejects the additional `reasoning` field with HTTP 400 (`Extra inputs are not permitted, field: 'messages[N].reasoning'`). The default provider mirrors `reasoning_content` into `reasoning` for any model whose name contains `qwen3` — a model-family match that does not establish that the endpoint accepts the extra field. Result: with a Qwen3 thinking model on Fireworks, the first response (which may include reasoning and a tool call) succeeds, and every subsequent request that replays the assistant's thinking — including tool-call continuation — fails with the 400 above, exactly as reported in #11657. The unmirror stays at the outbound request boundary, so qwen3 endpoints that require the mirrored field are untouched.

## Reviewer Test Plan

### How to verify

`packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts` is red on `main` and green with this change. The strict-endpoint case starts a local OpenAI-compatible endpoint that accepts `reasoning_content` but 400s on any assistant message carrying a `reasoning` field (returning the same validation payload as `api.fireworks.ai`): on `main` the follow-up turn fails with the reported 400; after the fix both turns succeed and the assistant message on the wire carries `reasoning_content` but no `reasoning`. Unit cases additionally cover subdomain hosts, hostile hostnames (`api.fireworks.ai.evil.example` falls through to the default provider and keeps mirroring), an explicit distinct `reasoning` field being kept, non-mutation of source history, and unchanged mirroring for non-Fireworks qwen3 model names.

Commands: `cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/` (12 files, 324 tests, all pass), `npx tsc --noEmit -p tsconfig.json` (clean), `npx eslint` on the changed files (clean).

### Evidence (Before & After)

Red on `main` (simulated by disabling the router branch, since the file is new): 3 tests fail — both hostname-routing unit cases and the strict-endpoint continuation case (`drops the mirrored reasoning field for api.fireworks.ai…`, `…for Fireworks subdomains`, `continues a qwen3 tool-call conversation without shipping the mirrored reasoning field`).

After (this branch, commit cd7f07ba72):

```text
✓ src/core/openaiContentGenerator/provider/fireworks.test.ts (6 tests)
Test Files  12 passed (12)
     Tests  324 passed (324)
```

Mutation checks: disabling the Fireworks routing turns exactly the 2 hostname unit cases red; no-oping the unmirror turns all 3 suppression-relevant tests red (including the strict-endpoint case) — the suite pins both halves of the change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

vitest unit tests plus a local HTTP stand-in endpoint; Node v22, npm workspaces install on Windows x64.

## Risk & Scope

- Main risk or tradeoff: a user who deliberately sets an explicit `reasoning` field identical to `reasoning_content` on a Fireworks request would have it dropped — indistinguishable from the mirror by construction; empty/null `reasoning` values pass through untouched.
- Not validated / out of scope: live `api.fireworks.ai` traffic (covered by the byte-compatible local stand-in); making mirroring a general per-provider capability registry — this follows the existing hostname-provider precedent instead, keeping the diff minimal.
- Breaking changes / migration notes: none. Non-Fireworks endpoints are byte-identical; Fireworks endpoints change exactly in that the mirrored `reasoning` field no longer leaves the process.

## Linked Issues

Fixes #11657

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增一个 Fireworks provider，按主机名（`api.fireworks.ai` 及其子域）在 provider 路由中识别，并从出站 chat-completion 消息中移除被镜像出来的 `reasoning` 字段 —— 与 #11049 处理 Cerebras 的做法同构。镜像字段按构造特征识别（assistant 消息的 `reasoning` 与 `reasoning_content` 相等，正是默认 provider 对 qwen3 系模型名做镜像的产物）；只删除这个精确副本。调用方自行设置的不同值的 `reasoning` 字段、以及 `reasoning_content` 本身都保留。会话历史从不被修改，非 Fireworks 端点的镜像行为保持不变。

## 为什么需要

Fireworks 的 OpenAI 兼容端点接受非标准的 `messages[].reasoning_content` 输入字段（其文档说明可与 `content`、`tool_calls` 一起回放），但拒绝额外的 `reasoning` 字段并返回 HTTP 400（`Extra inputs are not permitted, field: 'messages[N].reasoning'`）。默认 provider 对任何名字含 `qwen3` 的模型都会把 `reasoning_content` 镜像成 `reasoning` —— 模型族匹配并不能证明端点接受这个额外字段。结果：在 Fireworks 上使用 Qwen3 思考模型时，第一个响应（可能带推理和工具调用）成功，之后每个回放助手思考的请求——包括工具调用续传——都以该 400 失败，正是 #11657 报告的现象。撤销镜像只发生在出站请求边界，需要该字段的 qwen3 端点不受影响。

## 审阅者测试计划

### 如何验证

`packages/core/src/core/openaiContentGenerator/provider/fireworks.test.ts` 在 `main` 上为红、本改动后为绿。严格端点用例启动一个本地 OpenAI 兼容端点：接受 `reasoning_content`，但对任何携带 `reasoning` 字段的 assistant 消息返回 400（回包与 `api.fireworks.ai` 一致）：`main` 上后续轮次以报告中的 400 失败；修复后两轮都成功，且出站的 assistant 消息带 `reasoning_content`、不带 `reasoning`。单元用例另覆盖子域主机名、恶意主机名（`api.fireworks.ai.evil.example` 落回默认 provider 并保持镜像）、显式不同值 `reasoning` 字段被保留、源历史不被修改、非 Fireworks 的 qwen3 模型名镜像行为不变。

命令：`cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/`（12 个文件、324 个测试全部通过）、`npx tsc --noEmit -p tsconfig.json`（干净）、对改动文件跑 `npx eslint`（干净）。

### 证据（改前/改后）

`main` 上为红（通过关闭路由分支模拟，因为该文件是新增的）：3 个测试失败 —— 两个主机名路由单元用例和严格端点续传用例。

改后（本分支，提交 cd7f07ba72）：

```text
✓ src/core/openaiContentGenerator/provider/fireworks.test.ts (6 tests)
Test Files  12 passed (12)
     Tests  324 passed (324)
```

变异验证：关闭 Fireworks 路由恰好使 2 个主机名单元用例变红；将撤销镜像改为空操作恰好使 3 个相关测试全部变红（含严格端点用例）—— 测试套件同时钉住改动的两半。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

vitest 单元测试加本地 HTTP 替身端点；Windows x64、Node v22、npm workspaces 安装。

## 风险与范围

- 主要风险或取舍：若有用户故意在 Fireworks 请求上设置与 `reasoning_content` 完全相同的显式 `reasoning` 字段，会被当作镜像删掉 —— 按构造两者不可区分；空/null 的 `reasoning` 原样通过。
- 未验证 / 范围之外：真实 `api.fireworks.ai` 流量（由字节兼容的本地替身覆盖）；把镜像做成通用按 provider 能力注册表 —— 本 PR 沿用既有的按主机名 provider 先例，保持最小 diff。
- 破坏性变更 / 迁移说明：无。非 Fireworks 端点字节不变；Fireworks 端点唯一的变化是镜像出的 `reasoning` 字段不再离开进程。

## 关联 Issue

Fixes #11657

</details>
