### PR TITLE
fix(acp): preserve original filenames in resource-link prompts

### DIFF
--- a/docs/developers/daemon/03-acp-bridge.md
+++ b/docs/developers/daemon/03-acp-bridge.md
@@ -124,6 +124,16 @@ sequenceDiagram
 
 Failures at the queue tail are **swallowed** so that a prior prompt's rejection does not poison subsequent prompts; the original caller still receives the rejection on its own returned promise. The `transportClosedReject` cached on the session races the prompt promise against `channel.exited` so a crashed child surfaces immediately rather than hanging.
 
+### Resource-link prompt metadata
+
+When the ACP child converts a `resource_link` with a non-`file://` URI into model input, it retains the `@URI` reference and includes the client-provided `name` as an original filename. For example, `{ "type": "resource_link", "uri": "https://example.com/objects/7f9a2c", "name": "季度报告.csv" }` becomes:
+
+```text
+@https://example.com/objects/7f9a2c (original filename: "季度报告.csv")
+```
+
+The name is JSON-quoted so quotes and newlines remain unambiguous metadata. Empty names and legacy inputs without a name keep the URI-only text. This conversion does not fetch non-file resources or infer filenames from URI paths; `file://` links continue through the existing file-resolution path.
+
 ### Permission flow (high-level)
 
 ```mermaid

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -14342,6 +14342,64 @@ describe('Session', () => {
       );
     });
 
+    it.each([
+      {
+        label: 'Chinese filename',
+        uri: 'https://example.com/objects/7f9a2c',
+        name: '季度报告.csv',
+        expected:
+          '@https://example.com/objects/7f9a2c (original filename: "季度报告.csv")',
+      },
+      {
+        label: 'ordinary filename with a custom URI scheme',
+        uri: 'resource://objects/7f9a2c',
+        name: 'report.csv',
+        expected:
+          '@resource://objects/7f9a2c (original filename: "report.csv")',
+      },
+      {
+        label: 'quotes and newlines in the filename',
+        uri: 'https://example.com/objects/7f9a2c',
+        name: 'report "final"\n2026.csv',
+        expected:
+          '@https://example.com/objects/7f9a2c (original filename: "report \\"final\\"\\n2026.csv")',
+      },
+      {
+        label: 'missing legacy filename',
+        uri: 'https://example.com/objects/7f9a2c',
+        name: undefined,
+        expected: '@https://example.com/objects/7f9a2c',
+      },
+      {
+        label: 'empty filename',
+        uri: 'https://example.com/objects/7f9a2c',
+        name: '',
+        expected: '@https://example.com/objects/7f9a2c',
+      },
+    ])(
+      'preserves non-file resource links: $label',
+      async ({ uri, name, expected }) => {
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValue(createEmptyStream());
+        const link = {
+          type: 'resource_link',
+          uri,
+          ...(name === undefined ? {} : { name }),
+        } as PromptRequest['prompt'][number];
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [
+            { type: 'text', text: 'Summarize the attached resource.' },
+            link,
+          ],
+        });
+
+        expect(textParts(firstSentMessage())).toContain(expected);
+      },
+    );
+
     it('preserves unsupported image @ files for the vision bridge', async () => {
       const tempDir = await fs.realpath(
         await fs.mkdtemp(path.join(os.tmpdir(), 'qwen-acp-resource-')),

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -14756,7 +14756,11 @@ export class Session implements SessionContext {
               },
             };
           } else {
-            return { text: `@${part.uri}` };
+            return {
+              text: part.name
+                ? `@${part.uri} (original filename: ${JSON.stringify(part.name)})`
+                : `@${part.uri}`,
+            };
           }
         }
         case 'resource': {


### PR DESCRIPTION
## What this PR does

Preserves the client-provided original filename when a non-file ACP resource link becomes model-visible text. The existing `@URI` reference stays intact and a non-empty name is appended as JSON-quoted metadata, for example `@https://example.com/objects/7f9a2c (original filename: "季度报告.csv")`. Adds regression coverage and documents this behavior.

## Why it's needed

ACP clients can attach resources whose URI contains an opaque storage key. Previously the model received only that URI and lost the original filename already supplied by the client. This fixes the prompt-conversion boundary described in #11719; SDK transcript normalization/replay in #11178 / #11194 is separate.

## Reviewer Test Plan

### How to verify

Send a text instruction plus a non-file `resource_link` with an opaque URI and a Chinese or ordinary filename through ACP. Inspect the outgoing model request: both the unchanged URI reference and the exact JSON-quoted filename should be present. Repeat with a custom URI scheme and with quotes/newlines in the name. Legacy missing names and empty names should still produce exactly `@URI`. Existing `file://` resources should continue through file resolution.

### Evidence (Before & After)

No TUI layout changes. An actual ACP subprocess was connected to a loopback OpenAI-compatible mock HTTP endpoint, using only synthetic inputs and a dummy key. Before: global Qwen Code 0.23.3 sent `@https://example.com/objects/test-0` without `季度报告.pdf`. After: this branch's built CLI sent `@https://example.com/objects/test-0 (original filename: "季度报告.pdf")`. The same flow passed for `report.pdf`; both runs issued two model requests. This verifies transport/conversion, not real-model semantic behavior.

The five regression cases were also run against unchanged upstream production code: three named cases failed and the missing/empty cases passed. After the fix, the complete Session suite passed all 938 tests, including existing file-resource tests. Changed-file ESLint, Prettier, and `git diff --check` passed. Build and bundle passed through `npm ci` preparation.

Full-repository `preflight` passed formatting, lint, build, and typecheck, but the test stage did not complete green. The first run was interrupted after local global Git-template hooks rejected fixture commits. Re-running tests with a process-local isolated global Git configuration passed the 2,068 ACP Bridge tests and other initial workspaces, then hit three server-route assertion failures and a review-tool test timeout in the full CLI run; that run was interrupted. All four cases passed individually against unchanged upstream source. A full baseline server-file run instead produced two different `socket hang up` failures (1,275 passed, 2 failed). This does not establish a green full suite; upstream CI remains necessary. Serve fast-path bundle check: passed.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | ✅ arm64, Node.js 22.20.0 |
| 🪟 Windows | ⚠️ not tested locally |
| 🐧 Linux | ⚠️ not tested locally |

### Environment (optional)

Fresh upstream checkout at `8a21551599b7dc15bcc2b8ed0ffb4e151cc75f31`, Node.js 22.20.0. Local built ACP CLI and loopback mock model endpoint; no real model credentials or external model requests.

## Risk & Scope

- Main risk or tradeoff: named non-file links gain a small amount of model-visible text. JSON quoting escapes quotes, newlines, and control characters; names remain client-provided metadata. Names are preserved in full, without introducing an arbitrary truncation policy.
- Not validated / out of scope: real-model filename selection, SDK replay, mid-turn acceptance of resource-link blocks, embedded resources, and remote resource fetching.
- Breaking changes / migration notes: no protocol/schema changes, new URI schemes, or service-specific behavior. Missing/empty names and file-scheme handling keep their current behavior. No client migration is required.

## Linked Issues

Fixes #11719

<details>
<summary>中文说明</summary>

## 此 PR 的改动

当非 file 协议的 ACP 资源链接被转换为模型可见文本时，保留客户端提供的原始文件名。已有 `@URI` 引用保持完整，非空名称以 JSON 字符串形式追加为元数据，例如 `@https://example.com/objects/7f9a2c (original filename: "季度报告.csv")`。同时增加回归测试并补充行为文档。

## 修改原因

ACP 客户端可能上传 URI 中只有不透明存储键的资源。此前模型只收到 URI，丢失了客户端已经提供的原始文件名。本次修复 #11719 描述的 prompt 转换环节；#11178 / #11194 的 SDK transcript 归一化和回放属于另一环节。

## 评审验证计划

### 如何验证

通过 ACP 发送文字指令和非 file 协议的 `resource_link`，URI 使用不透明键，名称分别使用中文和普通文件名。检查发给模型的请求：应同时保留未修改的 URI 引用和准确的 JSON 字符串文件名。再验证自定义 URI 协议、含引号及换行的名称。历史输入缺少名称或名称为空时，仍应准确输出 `@URI`。现有 `file://` 资源继续走文件解析路径。

### 修复前后证据

没有 TUI 布局改动。测试将真实 ACP 子进程连接到本地回环 OpenAI 兼容模拟 HTTP 服务，仅使用合成输入和虚拟密钥。修复前，全局 Qwen Code 0.23.3 发送 `@https://example.com/objects/test-0`，没有 `季度报告.pdf`；修复后，本分支构建的 CLI 发送 `@https://example.com/objects/test-0 (original filename: "季度报告.pdf")`。`report.pdf` 也通过相同流程；前后各产生两次模型请求。该验证证明传输和转换行为，不代表真实模型语义效果。

新增五个回归用例先在未修改的上游生产代码上运行：三个有名称用例失败，缺名和空名用例通过。修复后完整 Session 测试的 938 个用例全部通过，包括现有文件资源测试。改动文件的 ESLint、Prettier 和 `git diff --check` 通过。`npm ci` 的准备步骤完成了构建及 bundle。

全仓 `preflight` 的格式、lint、构建和类型检查通过，但测试阶段未完整通过：第一次运行受到本机全局 Git 模板钩子影响，临时测试仓库的提交被拒绝，因此中止。仅为测试进程隔离 Git 全局配置后重新运行，ACP Bridge 的 2,068 个测试等通过，但 CLI 全量运行出现三个服务端路由断言失败和一个评审工具测试超时，随后中止该全量运行。这四个用例在未修改的上游源码上单独复跑全部通过；完整基线服务端测试则在另外两个测试中出现 `socket hang up`（1,275 通过、2 失败）。这些结果尚不能证明全仓测试通过；需要上游 CI 进一步验证。打包入口检查：通过。

### 测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ✅ arm64，Node.js 22.20.0 |
| 🪟 Windows | ⚠️ 未在本地测试 |
| 🐧 Linux | ⚠️ 未在本地测试 |

### 环境

从上游 `8a21551599b7dc15bcc2b8ed0ffb4e151cc75f31` 建立的干净 checkout，Node.js 22.20.0。使用本地构建的 ACP CLI 和回环模拟模型接口，没有使用真实模型凭据或请求外部模型。

## 风险与范围

- 主要取舍：带名称的非 file 链接会增加少量模型可见文本。JSON 字符串转义引号、换行及控制字符；名称仍是客户端提供的元数据。名称完整保留，不引入任意截断策略。
- 未验证及范围外：真实模型对文件名的选择、SDK 回放、轮次中途接收 resource-link 块、内嵌资源和远程资源抓取。
- 兼容性：不修改协议或 schema，不增加 URI 协议和服务专用逻辑。缺名、空名及 file 协议的行为保持一致，客户端不需要迁移。

## 关联问题

修复 #11719。

</details>
