### PR TITLE
fix(core): compute cron next-fire time with epoch arithmetic across DST fall-back

### DIFF
--- a/packages/core/src/utils/cronParser.test.ts
+++ b/packages/core/src/utils/cronParser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { matches, nextFireTime, parseCron } from './cronParser.js';
 
 describe('parseCron', () => {
@@ -225,5 +225,69 @@ describe('nextFireTime', () => {
     expect(nextFireTime('0 0 15 * */3', after)).toEqual(
       new Date(2025, 0, 15, 0, 0),
     );
+  });
+});
+
+describe('nextFireTime across DST transitions', () => {
+  // America/New_York spring forward 2026-03-08 02:00, fall back 2026-11-01 02:00.
+  // The repeated local hour 01:00–01:59 on fall-back day exists twice
+  // (EDT = UTC-4 first, EST = UTC-5 second). Local Date setters resolve the
+  // ambiguous wall-clock to the earlier occurrence, which used to re-project
+  // a live instant into the past (see issue #11720).
+  const originalTz = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York';
+  });
+
+  afterAll(() => {
+    if (originalTz === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTz;
+    }
+  });
+
+  it('returns a strictly-later instant for an anchor inside the repeated hour', () => {
+    // 06:30:15Z is the second 01:30 (EST). The old local-setter scan snapped
+    // back to 05:31Z, 59 minutes before the input.
+    const after = new Date('2026-11-01T06:30:15.000Z');
+    const next = nextFireTime('* * * * *', after);
+    expect(next.toISOString()).toBe('2026-11-01T06:31:00.000Z');
+    expect(next.getTime()).toBeGreaterThan(after.getTime());
+  });
+
+  it('reaches the second occurrence of the repeated hour when scanning forward', () => {
+    // 05:59Z is the first 01:59 (EDT). Local setMinutes(60) built local
+    // 02:00 (EST only) and jumped straight to 07:00Z, skipping 06:00Z.
+    const after = new Date('2026-11-01T05:59:00.000Z');
+    const next = nextFireTime('* * * * *', after);
+    expect(next.toISOString()).toBe('2026-11-01T06:00:00.000Z');
+  });
+
+  it('fires a fixed-hour job in both occurrences of the repeated hour', () => {
+    // Anchored at the first 01:30 (05:30Z), the second 01:30 (06:30Z) must
+    // still be reachable rather than skipped to the next day.
+    const after = new Date('2026-11-01T05:30:00.000Z');
+    const next = nextFireTime('30 1 * * *', after);
+    expect(next.toISOString()).toBe('2026-11-01T06:30:00.000Z');
+  });
+
+  it('advances across the spring-forward gap', () => {
+    // 06:59Z is 01:59 EST; 02:00–02:59 does not exist that morning, so the
+    // next real minute is 03:00 EDT (07:00Z).
+    const after = new Date('2026-03-08T06:59:00.000Z');
+    const next = nextFireTime('* * * * *', after);
+    expect(next.toISOString()).toBe('2026-03-08T07:00:00.000Z');
+    expect(next.getTime()).toBeGreaterThan(after.getTime());
+  });
+
+  it('returns a strictly-later instant when anchored exactly on a repeated-hour match', () => {
+    // 06:00Z is exactly the second 01:00 (EST). The old scan re-materialised
+    // 01:01 as EDT (05:01Z), one minute before the input.
+    const after = new Date('2026-11-01T06:00:00.000Z');
+    const next = nextFireTime('* * * * *', after);
+    expect(next.toISOString()).toBe('2026-11-01T06:01:00.000Z');
+    expect(next.getTime()).toBeGreaterThan(after.getTime());
   });
 });

--- a/packages/core/src/utils/cronParser.ts
+++ b/packages/core/src/utils/cronParser.ts
@@ -170,10 +170,13 @@ export function matches(cronExpr: string, date: Date): boolean {
 export function nextFireTime(cronExpr: string, after: Date): Date {
   const fields = parseCron(cronExpr);
 
-  // Start at the next whole minute after `after`
-  const candidate = new Date(after.getTime());
-  candidate.setSeconds(0, 0);
-  candidate.setMinutes(candidate.getMinutes() + 1);
+  // Start at the next whole minute after `after`. Use epoch arithmetic
+  // rather than local Date setters: a local `setMinutes`/`setSeconds`
+  // resolves an ambiguous fall-back wall-clock to its earlier occurrence,
+  // which would re-project the candidate up to 59 minutes into the past.
+  const candidate = new Date(
+    Math.floor(after.getTime() / 60000) * 60000 + 60000,
+  );
 
   // Scan up to 4 years (~2.1M minutes) to avoid infinite loops
   const maxIterations = 4 * 366 * 24 * 60;
@@ -193,7 +196,7 @@ export function nextFireTime(cronExpr: string, after: Date): Date {
     if (minuteOk && hourOk && monthOk && dayOk) {
       return candidate;
     }
-    candidate.setMinutes(candidate.getMinutes() + 1);
+    candidate.setTime(candidate.getTime() + 60000);
   }
 
   throw new Error(


### PR DESCRIPTION
## What this PR does

`nextFireTime` in `packages/core/src/utils/cronParser.ts` computed the next cron fire time by mutating a local `Date` with `setSeconds`/`setMinutes`. This PR switches the minute-by-minute traversal to elapsed-time (epoch) arithmetic: the starting candidate is `Math.floor(after.getTime()/60000)*60000 + 60000`, and each scan step advances with `candidate.setTime(candidate.getTime() + 60000)`. Cron field matching still uses local getters (`getMinutes`/`getHours`/`getDate`/`getDay`/`getMonth`), so wall-clock cron semantics are unchanged.

## Why it's needed

ECMA-262 `Date` setters resolve an ambiguous fall-back wall-clock (the repeated autumn DST hour) to its earlier occurrence. As a result an anchor inside the second occurrence was re-projected up to 59 minutes into the past, breaking the strictly-after contract, and a forward scan jumped over the entire second occurrence — e.g. `30 1 * * *` anchored in the first 01:30 skipped the second 01:30 and fired the next day. This mis-projects next-run times for `ChannelLoopScheduler` (a loop can become due again immediately after firing), `computeNextFireMs` (healthy tasks look missed), and `nextDurableFireMs` (a negative "next run" countdown). See #11720.

## Reviewer Test Plan

### How to verify

Run the focused suite with `TZ=America/New_York`:

```
npx vitest run src/utils/cronParser.test.ts --root packages/core
```

Five new cases assert: (1) an anchor inside the repeated hour returns a strictly-later instant, (2) forward traversal reaches the second occurrence, (3) a fixed-hour job fires in both occurrences, (4) the spring-forward gap still resolves, (5) an anchor exactly on a repeated-hour match is strictly-later. The existing 31 non-DST cases stay green.

### Evidence (Before & After)

Before (red), `TZ=America/New_York`:

- `nextFireTime('* * * * *', 2026-11-01T06:30:15Z)` → `2026-11-01T05:31:00Z` (59m15s in the past) instead of `06:31:00Z`
- `nextFireTime('* * * * *', 2026-11-01T05:59:00Z)` → `07:00:00Z` instead of `06:00:00Z` (second hour skipped)
- `nextFireTime('30 1 * * *', 2026-11-01T05:30:00Z)` → `2026-11-02T06:30:00Z` instead of `2026-11-01T06:30:00Z`
- `nextFireTime('* * * * *', 2026-11-01T06:00:00Z)` → `05:01:00Z` instead of `06:01:00Z`

After (green): 36/36 pass (31 existing + 5 new), including the spring-forward case.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ |

### Environment (optional)

Unit tests only (vitest), with `TZ=America/New_York` pinned inside the new test block and restored after; `tsc --noEmit` on `packages/core` passes with no errors.

## Risk & Scope

- Main risk or tradeoff: epoch traversal visits both occurrences of the repeated hour, so a fixed-hour job such as `30 1 * * *` now fires twice on fall-back day. This is the correct vixie-cron / systemd behavior and replaces the previous accidental skip.
- Not validated / out of scope: the two other sites carrying the same local-setter pattern (`cronScheduler.ts` `isCronSlotVisibleToTick` and `processJob`) are intentionally left unchanged and will be split into a follow-up. Cron syntax, jitter policy, and unrelated scheduler behavior are untouched.
- Breaking changes / migration notes: none — non-DST and UTC behavior is byte-for-byte identical.

## Linked Issues

Fixes #11720

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`packages/core/src/utils/cronParser.ts` 里的 `nextFireTime` 原先用 `setSeconds`/`setMinutes` 这类本地时间 setter 来逐分钟推进。本 PR 把逐分钟遍历改成基于实际经过时间（epoch）的算术：起始候选值用 `Math.floor(after.getTime()/60000)*60000 + 60000` 计算，每次扫描前进用 `candidate.setTime(candidate.getTime() + 60000)`。cron 字段匹配仍然使用本地 getter（`getMinutes`/`getHours`/`getDate`/`getDay`/`getMonth`），因此墙钟 cron 语义不变。

## 为什么需要

ECMA-262 的 `Date` setter 会把有歧义的回拨墙钟时间（秋季 DST 重复的那一小时）解析到它较早出现的那次。于是落在第二次出现的小时内的锚点会被往回拨最多 59 分钟，破坏「严格晚于入参」的契约；正向扫描则会整个跳过第二次出现的小时——例如 `30 1 * * *` 锚定在第一次 01:30 时会跳过第二次 01:30、直接推到次日触发。这会让 `ChannelLoopScheduler`（循环触发后立刻又到期）、`computeNextFireMs`（健康任务被误判为错过）、`nextDurableFireMs`（倒计时出现负值）拿到的下一次运行时间都失真。见 #11720。

## 评审验证计划

验证方式：以 `TZ=America/New_York` 跑定向测试 `npx vitest run src/utils/cronParser.test.ts --root packages/core`。新增 5 个用例分别断言：(1) 重复小时内的锚点返回严格晚于入参的时刻；(2) 正向遍历能到达第二次出现的小时；(3) 固定小时任务在两次出现的小时内都会触发；(4) 春季拨快缺口仍正确解析；(5) 锚点恰好落在重复小时匹配点上时仍严格晚于入参。原有 31 个非 DST 用例保持通过。

证据（Before/After）：修复前（红态）`06:30:15Z → 05:31:00Z`（早 59 分 15 秒）、`05:59:00Z → 07:00:00Z`（跳过第二次出现的小时）、`30 1 * * *` 从 `05:30:00Z → 2026-11-02T06:30:00Z`、`06:00:00Z → 05:01:00Z`；修复后（绿态）36/36 全部通过（含春季拨快用例）。

本机仅在 Linux 验证（✅），macOS/Windows 未测（⚠️）。环境：仅单测（vitest，新测试块内固定 `TZ=America/New_York` 并在结束后还原）+ `packages/core` 的 `tsc --noEmit`（0 错误）。

## 风险与范围

- 主要风险/取舍：按 epoch 前进会遍历重复小时内的两次出现，因此 `30 1 * * *` 这类固定小时任务在回拨当天会触发两次。这是 vixie-cron / systemd 的正确行为，取代了此前的意外跳过。
- 未验证/范围外：另外两处同类本地 setter 写法（`cronScheduler.ts` 的 `isCronSlotVisibleToTick` 与 `processJob`）有意不动，将拆成 follow-up。cron 语法、jitter 策略及无关调度行为均未改动。
- 破坏性变更：无——非 DST 与 UTC 场景行为完全一致。

## 关联 issue

Fixes #11720

</details>
