### PR TITLE
docs(daemon): describe the prompt rate-limit and queue-full responses separately

### DIFF
--- a/docs/developers/daemon-rest-api.openapi.json
+++ b/docs/developers/daemon-rest-api.openapi.json
@@ -1131,7 +1131,7 @@
             }
           },
           "429": {
-            "description": "The session prompt queue or rate limit is full.",
+            "description": "The daemon prompt rate limit was exceeded (`code: rate_limit_exceeded`); honor `Retry-After` before retrying.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1141,7 +1141,7 @@
             }
           },
           "503": {
-            "description": "The owning runtime is unavailable.",
+            "description": "The owning runtime is unavailable, or the session prompt queue is full (`code: prompt_queue_full`, with `Retry-After: 5`).",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/cli/src/serve/rest-integration-docs-contract.test.ts
+++ b/packages/cli/src/serve/rest-integration-docs-contract.test.ts
@@ -502,12 +502,11 @@ describe('REST integration documentation contract', () => {
     ).toEqual([]);
 
     const anchors = protocolAnchors();
-    const broken = [
+    const protocolLinks = [
       ...guide.matchAll(/\]\(\.\/qwen-serve-protocol\.md#([a-z0-9_-]+)\)/g),
-    ]
-      .map((match) => match[1])
-      .filter((anchor) => !anchors.has(anchor));
-    expect(broken).toEqual([]);
+    ].map((match) => match[1]);
+    expect(protocolLinks.length).toBeGreaterThan(0);
+    expect(protocolLinks.filter((anchor) => !anchors.has(anchor))).toEqual([]);
   });
 
   it('points every guide flow command at the published server', () => {
@@ -557,7 +556,7 @@ describe('REST integration documentation contract', () => {
     );
   });
 
-  it('keeps the resume request contract to the fields resume reads', () => {
+  it('publishes the resume request schema without the load-only fields', () => {
     const openApi = JSON.parse(
       readFileSync(OPENAPI, 'utf8'),
     ) as OpenApiDocument;


### PR DESCRIPTION
## What this PR does

Corrects one published response contract and one documentation guard, both raised by the automated review that arrived on #11592 as it merged.

The reference told clients that a prompt submission answers `429` "when the session prompt queue or rate limit is full". The daemon keeps those two apart: the prompt rate limiter is the only producer of `429` on this route, and it reports `code: rate_limit_exceeded` and sets `Retry-After`; a full queue is a `503` carrying `code: prompt_queue_full` with a five-second `Retry-After`. The two descriptions now state what each status actually means, so a client can tell "back off, this is a rate limit" from "wait for the queue to drain".

The same commit renames the resume-schema test to "publishes the resume request schema without the load-only fields", which is what it checks: the design document scopes that guard to method/path pairs and leaves field semantics to ordinary review.

The guard that verifies every protocol link in the integration guide resolves now first asserts that it matched at least one such link. Before, the check passed silently once those links moved to the docs-site URL form — which is the form the guide is expected to move to, and exactly when the assertion matters.

## Why it's needed

The published reference is the contract clients build against, so a response description that merges a server-side queue condition into the rate-limit status hides both the status code and the `code` a client switches on. The guard gap is the same class of problem for the documentation pipeline: a check that cannot fail is not a check.

## Reviewer Test Plan

### How to verify

Run the guard: `cd packages/cli && npx vitest run src/serve/rest-integration-docs-contract.test.ts` — expected `Tests 8 passed (8)`.

Confirm the described behavior against the daemon: the prompt rate limiter is the only producer of `429` on that route and it reports `code: rate_limit_exceeded` with `Retry-After`, while the queue-full error is a `503` reporting `code: prompt_queue_full` with a five-second `Retry-After`.

Confirm the new floor can fail: rewrite the guide's `./qwen-serve-protocol.md#...` links into the docs-site URL form and rerun the guard. It used to pass; it now fails with `expected 0 to be greater than 0`.

### Evidence (Before & After)

Documentation-only change, no screenshots. The published `429` description was "The session prompt queue or rate limit is full." and is now "The daemon prompt rate limit was exceeded (`code: rate_limit_exceeded`); honor `Retry-After` before retrying.". The `503` description became "The owning runtime is unavailable, or the session prompt queue is full (`code: prompt_queue_full`, with `Retry-After: 5`).".

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — unit test only.

## Risk & Scope

- Main risk or tradeoff: the wording is a promise about current behavior; if either response changes shape the published text has to follow, as with any contract.
- Not validated / out of scope: the other documentation-guard gaps the same review round found are deferred to #11728 and are not addressed here.
- Breaking changes / migration notes: none — documentation and test only.

## Linked Issues

Refs #11592 — this lands the two findings from its final review round that the merge did not include. Refs #11728 for the deferred guard work.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修正一处已发布的响应契约和一处文档守护，两者都来自 #11592 合并过程中到达的自动评审。

参考文档此前告诉客户端：提交 prompt 时的 `429` 表示"会话 prompt 队列或速率限制已满"。但守护进程把这两种情况分开：该路由上只有 prompt 速率限制器会产生 `429`，其 `code` 为 `rate_limit_exceeded` 并带有 `Retry-After`；队列满则是 `503`，`code` 为 `prompt_queue_full`，`Retry-After` 为 5 秒。现在两条描述各自说明其真实语义，客户端因此能区分"退避，这是限流"与"等队列排空"。

同一个提交还把 resume schema 测试改名为 “publishes the resume request schema without the load-only fields”，这正是它真正校验的内容：设计文档把该守护的范围限定在 method/path 配对，字段语义交给常规评审。

校验集成指南中所有协议链接可解析的守护，现在会先断言至少匹配到一条此类链接。此前一旦这些链接迁移为文档站 URL 形式，该检查就会静默通过——而这正是指南预期要迁移到的形式，也正是该断言真正起作用的时刻。

## 为什么需要

已发布的参考文档就是客户端据以实现的契约，把服务端队列状况合并进限流状态的描述，会同时隐藏客户端所 switch 的状态码与 `code`。守护的漏洞对文档流水线而言是同一类问题：一个不可能失败的检查不是检查。

## 评审测试方案

### 如何验证

运行守护：`cd packages/cli && npx vitest run src/serve/rest-integration-docs-contract.test.ts`，预期 `Tests 8 passed (8)`。

对照守护进程确认所描述行为：该路由上 `429` 的唯一产生者是 prompt 速率限制器，其 `code` 为 `rate_limit_exceeded` 并带 `Retry-After`；队列满错误是 `503`，`code` 为 `prompt_queue_full`，`Retry-After` 为 5 秒。

确认新增的下限确实会失败：把指南中的 `./qwen-serve-protocol.md#...` 链接改写为文档站 URL 形式后重跑守护。此前通过，现在会以 `expected 0 to be greater than 0` 失败。

### 证据（前后对比）

纯文档改动，无截图。`429` 原描述为 "The session prompt queue or rate limit is full."，现为 "The daemon prompt rate limit was exceeded (`code: rate_limit_exceeded`); honor `Retry-After` before retrying."。`503` 描述变为 "The owning runtime is unavailable, or the session prompt queue is full (`code: prompt_queue_full`, with `Retry-After: 5`)."。

### 测试环境

|     系统   | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境（可选）

不适用——仅单元测试。

## 风险与范围

- 主要风险：该措辞是对当前行为的承诺；若任一响应形态变化，已发布文本需同步更新，与任何契约相同。
- 未验证 / 范围外：同一轮评审发现的其余文档守护缺口已移交 #11728，本 PR 不涉及。
- 破坏性变更 / 迁移说明：无——仅文档与测试。

## 关联 Issue

参见 #11592——本 PR 落地其最后一轮评审中、未被合并包含的两项发现。其余守护工作参见 #11728。

</details>
