### PR TITLE
test(web-shell): give the 200-record history-viewport smoke case its own budget

### DIFF
--- a/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.history-viewport.spec.ts
@@ -192,6 +192,9 @@ for (const pageRecords of [16, 200]) {
     baseURL,
   }) => {
     if (pageRecords === 200) {
+      // 4x CPU throttling over a 2,400-record fixture runs at 75-91% of the
+      // shared 60s budget and has timed out on all 3 attempts on CI (#11736).
+      test.setTimeout(120_000);
       const client = await page.context().newCDPSession(page);
       await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
     }


### PR DESCRIPTION
## What this PR does

The CPU-throttled 200-record case in the history-viewport smoke spec now sets its own timeout budget instead of inheriting the shared 60-second one. Fixture, 4x CPU throttle, assertions and the 16-record sibling are untouched.

## Why it's needed

That variant is the slowest case in the web-shell smoke suite, and it had no margin left: it spends 75-101% of the shared budget, and on one recent run all three attempts timed out and red'd the smoke job of an unrelated PR, which then had to be re-run.

Case duration, read from each job's own `web-shell-e2e-smoke` artifact (unzip → `playwright-report/index.html` → embedded `report.json`), against `timeout: 60_000` and `retries: process.env['CI'] ? 2 : 0`:

| Run | Case duration | Budget used |
| --- | --- | --- |
| 34706670143 (this PR) | 60,525 ms | 101% |
| 34702240187 | 54,697 ms | 91% |
| 34701971638 | 53,985 ms | 90% |
| 34701966100 | 47,209 ms | 79% |
| 34605772996 attempt 2 | 45,172 ms | 75% |
| 34605772996 attempt 1 retry 0 / 1 / 2 | 63,825 / 63,081 / 62,428 ms | timed out 3/3 |

The case is slow by construction: it runs the same assertions as its 16-record sibling under `Emulation.setCPUThrottlingRate { rate: 4 }` over a 2,400-record fixture, and the throttle is the slow-rendering condition the reading-row assertion exists to prove — the assertion loses its point without it. So the case needs room rather than a weaker condition, and `test.setTimeout(120_000)` next to the throttle is the smallest change that gives it. There is in-repo precedent for that shape in the stream-performance spec.

The 16-record sibling finishes in 11,124-12,304 ms locally and on CI, and the suite totals 4.2-6.6 minutes against a 20-minute job, so the higher ceiling only costs wall time when the case actually runs long.

## Reviewer Test Plan

### How to verify

1. Confirm the shared budget is still 60 s and the retry policy is unchanged in `packages/web-shell/playwright.config.ts`, and that only the 200-record branch overrides it.
2. Watch this PR's `web-shell E2E Smoke (ubuntu-latest, Node 22.x)` job and read this case's duration from that job's `web-shell-e2e-smoke` artifact: it should stay in the 45-61 s range, i.e. inside the new 120 s budget, with the 16-record sibling unchanged at ~12 s.
3. Locally: `cd packages/web-shell && CI=1 npx playwright test --config playwright.config.ts --grep "bounded 200-record pages" --retries=0`.

### Evidence (Before & After)

Before (run 34605772996, attempt 1 of commit `b1e4f307`): retry 0 `Test timeout of 60000ms exceeded.`, retry 1 the same, retry 2 `Error: locator.click: Test timeout of 60000ms exceeded. Call log: - waiting for getByRole('button', { name: /Scroll to bottom|回到底部/ })`; the report records 189,334 ms for the case and the job ended `1 failed, 72 passed (6.6m)`.

After, on this PR's own smoke job (run 34706670143, head `c8fd792`): the case took **60,525 ms** and passed on its first attempt (`outcome: expected`), with the 16-record sibling at 12,304 ms and the job green. That run is the first one observed above 60 s, so under the shared budget it would have timed out: raising the ceiling is what made it pass, not a faster runner.

Local runs on macOS (M4 Pro, `--retries=0`), same spec: 200-record **54,311 ms** passed, 16-record **11,124 ms** passed. The local machine also sits at 91% of the old budget on this case, so the pressure is in the case, not in one particular runner.

Mechanism check, on the pre-commit local tree: temporarily setting the override to 1 s fails exactly this variant (`Test timeout of 1000ms exceeded.`) while the 16-record sibling still passes under the shared budget — the override lands on the 200-record branch only, and it is effective.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

macOS: the two local runs above. Linux: this PR's `web-shell E2E Smoke (ubuntu-latest, Node 22.x)` job. Windows has no separate path here — the change is one Playwright per-test timeout on one branch of one spec.

### Environment (optional)

Local: `CI=1 npx playwright test --config playwright.config.ts --grep "bounded" --retries=0` from `packages/web-shell`, Playwright `chromium`, macOS arm64. CI: `Qwen Code CI`, job `web-shell E2E Smoke (ubuntu-latest, Node 22.x)`.

## Risk & Scope

- Main risk: a real history-viewport regression would now be able to burn up to 120 s per attempt before surfacing in CI instead of 60 s. Bounded by the job's 20-minute ceiling and the suite's 4.2-6.6 minute total, so it costs wall time only on the slow case itself.
- Not validated / out of scope: the case's own runtime and the 4x throttle stay as they are, and whether the 200-record variant belongs in `@smoke` at all is a maintainer call. The case now runs at 50% of its new ceiling on CI, so a further climb in its duration is product signal rather than a budget problem, and should be handled separately.
- Breaking changes / migration notes: none. Test-only change, no product behavior.

## Linked Issues

Closes #11736

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

history-viewport smoke spec 中带 CPU 限速的 200 条记录用例，现在自己声明超时预算，不再继承共享的 60 秒。fixture、4 倍 CPU 限速、断言以及 16 条记录的同类用例都未改动。

## 为什么需要

该变体是 web-shell smoke 套件里最慢的用例，且已没有任何余量：它要花掉共享预算的 75–101%，最近一次运行中三次尝试全部超时，把一个无关 PR 的 smoke job 弄红，只能重跑。

用例耗时取自各 job 自己的 `web-shell-e2e-smoke` 产物（解压 → `playwright-report/index.html` → 内嵌 `report.json`），对照 `timeout: 60_000` 与 `retries: process.env['CI'] ? 2 : 0`：

| Run | 用例耗时 | 占用预算 |
| --- | --- | --- |
| 34706670143（本 PR） | 60,525 ms | 101% |
| 34702240187 | 54,697 ms | 91% |
| 34701971638 | 53,985 ms | 90% |
| 34701966100 | 47,209 ms | 79% |
| 34605772996 attempt 2 | 45,172 ms | 75% |
| 34605772996 attempt 1 retry 0 / 1 / 2 | 63,825 / 63,081 / 62,428 ms | 3/3 超时 |

慢是构造出来的：它在 `Emulation.setCPUThrottlingRate { rate: 4 }` 下、对 2,400 条记录的 fixture 跑与 16 条记录变体相同的断言，而该限速正是 "读取行保持" 断言所要验证的慢渲染条件 —— 去掉它断言就失去意义。因此正确做法是给用例留出空间，而不是削弱条件，在限速代码块旁加一行 `test.setTimeout(120_000)` 就是最小改动。这种写法在仓库内已有先例（stream-performance spec）。

16 条记录的同类用例在本地与 CI 上耗时 11,124–12,304 ms；整套 suite 总耗时 4.2–6.6 分钟，job 上限 20 分钟，因此提高上限只在用例真的跑久时才增加墙钟时间。

## Reviewer Test Plan

### 如何验证

1. 确认 `packages/web-shell/playwright.config.ts` 中共享预算仍为 60 秒、重试策略未变，且只有 200 条记录分支覆盖了它。
2. 观察本 PR 的 `web-shell E2E Smoke (ubuntu-latest, Node 22.x)` job，从该 job 的 `web-shell-e2e-smoke` 产物读取本用例耗时：应保持在 45–61 秒区间，即落在新的 120 秒预算内，同时 16 条记录变体保持在约 12 秒不变。
3. 本地：`cd packages/web-shell && CI=1 npx playwright test --config playwright.config.ts --grep "bounded 200-record pages" --retries=0`。

### Evidence（Before & After）

Before（run 34605772996，commit `b1e4f307` 的 attempt 1）：retry 0 `Test timeout of 60000ms exceeded.`，retry 1 相同，retry 2 为 `Error: locator.click: Test timeout of 60000ms exceeded.`；报告记录该用例 189,334 ms，job 结果 `1 failed, 72 passed (6.6m)`。

After（本 PR 自己的 smoke job，run 34706670143，head `c8fd792`）：该用例耗时 **60,525 ms**，首次尝试即通过（`outcome: expected`），16 条记录变体 12,304 ms，job 为绿。这是目前观测到的首个超过 60 秒的运行，也就是说在共享预算下它会超时 —— 是提高上限让它通过，而不是 runner 变快了。

本地 macOS（M4 Pro，`--retries=0`，同一 spec）：200 条记录 **54,311 ms** 通过，16 条记录 **11,124 ms** 通过。本地机器在该用例上也已占到旧预算的 91%，说明压力来自用例本身，而非某个特定 runner。

机制验证（在提交前的本地工作树上）：把覆盖值临时改为 1 秒后，恰好是该变体失败（`Test timeout of 1000ms exceeded.`），而 16 条记录变体仍在共享预算内通过 —— 覆盖只作用于 200 条记录分支，且确实生效。

### Tested on

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

macOS：上述两次本地运行。Linux：本 PR 的 `web-shell E2E Smoke (ubuntu-latest, Node 22.x)` job。Windows 在此没有独立路径 —— 本次改动只是某个 spec 中一个分支上的 Playwright 单用例超时。

### Environment

本地：在 `packages/web-shell` 下执行 `CI=1 npx playwright test --config playwright.config.ts --grep "bounded" --retries=0`，Playwright `chromium`，macOS arm64。CI：`Qwen Code CI`，job `web-shell E2E Smoke (ubuntu-latest, Node 22.x)`。

## Risk & Scope

- 主要风险：若 history-viewport 真的出现回归，在 CI 暴露前单次尝试最多可能消耗 120 秒而非 60 秒。该风险受以下约束：job 上限 20 分钟、suite 总耗时 4.2–6.6 分钟，因此只有在慢用例本身才会增加墙钟时间。
- 未验证 / 不在范围内：用例自身耗时与 4 倍限速保持不变；200 条记录变体是否应留在 `@smoke` 属于维护者决定。该用例目前在 CI 上占新上限的 50%，若耗时继续上升，那是产品信号而非预算问题，需另行处理。
- 破坏性变更 / 迁移说明：无。仅测试改动，不影响产品行为。

## Linked Issues

Closes #11736

</details>
