### PR TITLE
fix(cli): keep history item ids strictly increasing across mixed base timestamps

### DIFF
--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -68,6 +68,63 @@ describe('useHistoryManager', () => {
     expect(result.current.history[0].id).toBeGreaterThanOrEqual(timestamp);
   });
 
+  it('mints strictly increasing ids when callers pass out-of-order base timestamps', () => {
+    const { result } = renderHook(() => useHistory());
+
+    // Notification-turn shape from use-llm-stream.ts: the turn's items reuse
+    // the timestamp captured at submitQuery entry, while the notification
+    // display item is minted mid-turn from onRequestStarted with a fresh
+    // Date.now() base. When the ms gap between the two bases equals the
+    // counter delta between the two mints, base + counter repeats and the
+    // transcript renders two items under one React key.
+    const turnBase = 1_700_000_000_000;
+    const ids: number[] = [];
+    act(() => {
+      // Notification item minted first, 3ms after the turn's base.
+      ids.push(
+        result.current.addItem(
+          { type: 'notification', text: 'background task done' },
+          turnBase + 3,
+        ),
+      );
+      // Then the turn's own items, still on the entry timestamp.
+      ids.push(
+        result.current.addItem({ type: 'user', text: 'turn' }, turnBase),
+      );
+      ids.push(
+        result.current.addItem({ type: 'gemini', text: 'reply' }, turnBase),
+      );
+      ids.push(
+        result.current.addItem(
+          { type: 'gemini_content', text: 'reply continued' },
+          turnBase,
+        ),
+      );
+    });
+
+    expect(result.current.history).toHaveLength(4);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+  });
+
+  it('keeps minting ids above the loaded range after loadHistory', () => {
+    const { result } = renderHook(() => useHistory());
+    const loaded = [
+      { id: 5001, type: 'user', text: 'restored' },
+      { id: 5003, type: 'gemini', text: 'restored reply' },
+    ] as HistoryItem[];
+
+    let minted = 0;
+    act(() => {
+      result.current.loadHistory(loaded);
+    });
+    act(() => {
+      minted = result.current.addItem({ type: 'user', text: 'fresh' }, 1000);
+    });
+
+    expect(minted).toBeGreaterThan(5003);
+  });
+
   it('replaces earlier findings displays when a new report_findings group commits', () => {
     // A delivered findings list REPLACES the session's earlier one: the
     // previous group's display collapses to the marker at commit time, so

--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -125,6 +125,26 @@ describe('useHistoryManager', () => {
     expect(minted).toBeGreaterThan(5003);
   });
 
+  it('resets the id floor in clearItems so post-clear ids restart from the base', () => {
+    const { result } = renderHook(() => useHistory());
+    act(() => {
+      result.current.addItem({ type: 'user', text: 'a' }, 5000);
+      result.current.addItem({ type: 'user', text: 'b' }, 9000);
+    });
+    act(() => {
+      result.current.clearItems();
+    });
+
+    let minted = 0;
+    act(() => {
+      minted = result.current.addItem({ type: 'user', text: 'c' }, 1000);
+    });
+
+    // With a stale floor this would mint 9003 (lastId + 1); after the reset
+    // the id is base + counter again.
+    expect(minted).toBe(1001);
+  });
+
   it('replaces earlier findings displays when a new report_findings group commits', () => {
     // A delivered findings list REPLACES the session's earlier one: the
     // previous group's display collapses to the marker at commit time, so

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -47,11 +47,24 @@ export interface UseHistoryManagerReturn {
 export function useHistory(): UseHistoryManagerReturn {
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const messageIdCounterRef = useRef(0);
+  const lastMessageIdRef = useRef(0);
 
   // Generates a unique message ID based on a timestamp and a counter.
+  // Callers pass bases captured at different wall-clock times: a turn's items
+  // reuse the timestamp taken at submitQuery entry, while notification items
+  // are minted mid-turn from onRequestStarted with a fresh Date.now(). When
+  // the ms gap between two bases equals the counter delta between the two
+  // mints, base + counter repeats — a duplicate React key in the <Static>
+  // transcript. Clamp against the last minted id so ids stay strictly
+  // increasing no matter which base a caller supplies.
   const getNextMessageId = useCallback((baseTimestamp: number): number => {
     messageIdCounterRef.current += 1;
-    return baseTimestamp + messageIdCounterRef.current;
+    const id = Math.max(
+      baseTimestamp + messageIdCounterRef.current,
+      lastMessageIdRef.current + 1,
+    );
+    lastMessageIdRef.current = id;
+    return id;
   }, []);
 
   const loadHistory = useCallback((newHistory: HistoryItem[]) => {
@@ -73,6 +86,7 @@ export function useHistory(): UseHistoryManagerReturn {
       messageIdCounterRef.current,
       maxLoadedId - Date.now(),
     );
+    lastMessageIdRef.current = Math.max(lastMessageIdRef.current, maxLoadedId);
   }, []);
 
   // Adds a new item to the history state with a unique ID.
@@ -167,6 +181,7 @@ export function useHistory(): UseHistoryManagerReturn {
     }
     setHistory([]);
     messageIdCounterRef.current = 0;
+    lastMessageIdRef.current = 0;
   }, []);
 
   // Truncates history to exclude the item with the given ID and everything after it.


### PR DESCRIPTION
## What this PR does

History-item ids are now strictly increasing regardless of the base timestamp a caller passes: `getNextMessageId` clamps each minted id to `lastMintedId + 1`, and `loadHistory`/`clearItems` advance/reset that floor. The base-plus-counter shape is unchanged for the normal case, so id magnitudes stay near wall-clock time.

## Why it's needed

Ids were `baseTimestamp + sharedCounter`, but callers pass bases captured at different wall-clock times: a turn's items reuse the timestamp taken at `submitQuery` entry, while notification display items are minted mid-turn from `onRequestStarted` with a fresh `Date.now()` (`packages/cli/src/ui/hooks/use-llm-stream.ts`). When the millisecond gap between the two bases equals the counter delta between the two mints, `base + counter` repeats — two history items share one React key in the Ink `<Static>` transcript. The tests reproduce this duplicate-id mechanism. Duplicate React keys are a plausible contributor to the React #185 crashes reported in #11500 and #11732, but the downstream render loop and live crash have not been reproduced deterministically.

The duplicate-id investigation and local field test came from @vetaljanos in https://github.com/QwenLM/qwen-code/pull/11565#issuecomment-5640075220, who field-tested the monotonic-id fix locally ("before, it died within a couple of minutes of an agent completing; haven't been able to reproduce since"). I verified the mechanism against the code before implementing: the shared counter plus out-of-order caller bases makes the collision structural, and the codebase already carries a workaround for the same hazard on the resume path (`loadHistory` advances the counter past restored ids "so a subsequent addItem cannot duplicate a React key in the <Static> transcript"). This PR fixes the scheme itself instead of patching each caller.

The relationship to #11565 (the Ink `useBoxMetrics` loop guard): the guard caps any commit-phase cascade per tick — defense in depth that covers drivers we haven't found — while this PR removes the confirmed duplicate-id defect. They are complementary; #11565 has already merged.

## Reviewer Test Plan

### How to verify

- `npx vitest run src/ui/hooks/useHistoryManager.test.ts` in `packages/cli` — the new "out-of-order base timestamps" case mints the exact notification-turn sequence (notification item at base T+3ms first, then three turn items at base T), which produces a duplicate id without the clamp. 33/33 pass; the case fails with the fix reverted.
- Neighboring suite: `npx vitest run src/ui/hooks/use-llm-stream.test.tsx` — 280/280 pass (the notification drain path threads these timestamps).
- Live TUI smoke (macOS, GNU screen): ran a heartbeat monitor session (12s interim events, i.e. the #11732 trigger shape) on this branch's build — see below.

### Evidence (Before & After)

Unit-level red/green from the [sandbox verification](https://github.com/QwenLM/qwen-code/pull/11743#issuecomment-5651572657) at `e5033ebd` (both changed files are byte-identical at `39e2281`):

```
# fix reverted: mixed-base uniqueness and restored-range tests fail
Tests  2 failed | 31 passed (33)
# with the fix:
Tests  33 passed (33)
```

Live TUI (macOS, GNU screen, 12s heartbeat monitor — the #11732 trigger shape): a main-scheme build ran ~100 heartbeat notification turns plus two 6-task completion bursts over ~25 minutes **without** crashing ; that smoke run did not reproduce the reported crash, so it does not establish a before/after crash fix. The deterministic evidence is the red/green above; the field correlation is the reporters' timelines (#11732's two crashes land 77s/350s after a heartbeat-driven turn; #11500's cluster on completion bursts). This branch's build also ran the same soak without incident. The passing smoke runs on both builds do not prove the crash is fixed; the deterministic tests establish the id-uniqueness improvement.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit + neighboring suite + live TUI smoke |
| 🪟 Windows | ⚠️ not tested locally; Windows unit lane skipped in the current CI run |
|  🐧 Linux  | ✅ Linux CI tests passed at `39e2281` |

### Environment (optional)

macOS 15 (darwin), Node v24.19.0; local build of this branch (`npm run build`), `--yolo`, GNU screen capture.

## Risk & Scope

- Main risk or tradeoff: after a clamp, a minted id can exceed `Date.now() + counter`, so ids are no longer guaranteed to stay near wall-clock time. Consumers use ids as React keys, lookup keys, and numeric rewind boundaries (`h.id < userItem.id`). Strictly increasing ids preserve those ordering and identity uses; they are not wall-clock timestamps.
- Not validated / out of scope: the live #185 crash is probabilistic; the duplicate-id mechanism is proven by deterministic tests, but the duplicate-key → render cascade → live crash chain remains unverified end to end. Whether this closes every #185 report is unproven — one reporter saw 2 crashes with no completion notification in flight, which may be a different driver, so the #11565 guard remains valuable. The floor also advances past loaded history ids; the restored-item stamping itself is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #11500 — related notification-turn crash report; this PR does not establish that the reported crash is fully fixed.
Refs #11732 — related heartbeat-driven crash report; the orphaned-monitor lifecycle is out of scope.
Refs #11565 — complementary loop guard; credit for the root-cause analysis to @vetaljanos there.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

无论调用方传入什么时间戳基准，history item 的 id 现在都严格递增：`getNextMessageId` 会把每个新铸 id 钳制为 `上一个 id + 1`，`loadHistory`/`clearItems` 负责推进/重置这个下界。正常情况下 base + counter 的形态不变，id 数量级仍接近当前墙钟时间。

## 为什么需要

原先的 id 是 `基准时间戳 + 共享计数器`，但各调用方的基准取自不同的墙钟时刻：一个 turn 的 item 复用 `submitQuery` 入口捕获的时间戳，而通知展示 item 在 turn 中途从 `onRequestStarted` 以新的 `Date.now()` 为基准铸造（`packages/cli/src/ui/hooks/use-llm-stream.ts`）。当两个基准的毫秒差恰好等于两次铸造之间的计数器增量时，`base + counter` 重复——两条 history item 在 Ink `<Static>`  transcript 里共用同一个 React key。测试已复现这一重复 id 机制。重复 React key 可能是 #11500 和 #11732 所报告 React #185 崩溃的诱因之一，但下游渲染循环与实机崩溃尚未得到确定性的复现。

重复 id 的调查与本地实测来自 @vetaljanos（https://github.com/QwenLM/qwen-code/pull/11565#issuecomment-5640075220），他已在本地实测单调 id 修复（"修复前 agent 完成后几分钟内必崩；修复后再没复现"）。动手前我先对着代码核实了机制：共享计数器加乱序基准让碰撞成为结构性的问题，而且代码库里其实已经带着一个针对同一隐患的局部绕行——`loadHistory` 会把计数器推过已恢复 id 区间，"让后续 addItem 不会在 <Static> transcript 里撞出重复 React key"。本 PR 修复 id 方案本身，而不是逐个修补调用方。

与 #11565（Ink `useBoxMetrics` 环路守卫）的关系：守卫把任意 commit 阶段级联限制在每 tick 预算内——覆盖我们尚未找到的驱动的纵深防御；本 PR 消除的是已确认的重复 id 缺陷。两者互补；#11565 已合并。

## 评审验证计划

### 如何验证

- 在 `packages/cli` 下 `npx vitest run src/ui/hooks/useHistoryManager.test.ts`——新增的"乱序基准时间戳"用例完整复现通知 turn 的铸造序列（通知 item 以 T+3ms 为基准先铸，随后三个 turn item 以 T 为基准），没有钳制时必然产出重复 id。33/33 通过；撤回修复后该用例失败。
- 邻近套件：`npx vitest run src/ui/hooks/use-llm-stream.test.tsx`——280/280 通过（通知 drain 路径正是这些时间戳的流转处）。
- TUI 实测（macOS，GNU screen）：在本分支构建上跑心跳 monitor 会话（12s 间隔的 interim 事件，即 #11732 的触发形态）——结果见下。

### 证据（前后对比）

单元层面的红绿对照来自 [沙箱验证](https://github.com/QwenLM/qwen-code/pull/11743#issuecomment-5651572657)，验证提交为 `e5033ebd`（两个改动文件在 `39e2281` 中字节一致）：

```
# 回滚修复：乱序基准唯一性与恢复区间测试失败
Tests  2 failed | 31 passed (33)
# 应用修复后：
Tests  33 passed (33)
```

TUI 实测（macOS，GNU screen，12s 心跳 monitor——即 #11732 的触发形态）：main 方案的构建在约 25 分钟内跑了 100+ 个心跳通知 turn、外加两轮 6 任务并发完成突发，**没有**崩溃；这次实测未复现报告中的崩溃，因此不能作为崩溃修复的前后对照。确定性证据以上面的红绿对照为准；现场相关性来自报告者的时间线（#11732 两次崩溃分别落在心跳驱动 turn 后 77s/350s；#11500 的崩溃集中在完成突发上）。本分支构建跑了同样的浸泡测试，也未出现异常。两边均未崩溃不能证明崩溃已修复；id 唯一性的改进由确定性测试证明。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 单元 + 邻近套件 + TUI 实测 |
| 🪟 Windows | ⚠️ 本地未测；本轮 Windows 单元测试任务跳过 |
|  🐧 Linux  | ✅ `39e2281` 的 Linux CI 测试通过 |

### 环境（可选）

macOS 15 (darwin)、Node v24.19.0；本分支本地构建（`npm run build`），`--yolo`，GNU screen 截屏。

## 风险与范围

- 主要风险或取舍：钳制之后，新铸 id 可能超过 `Date.now() + counter`，即 id 不再保证贴近墙钟时间。消费方将 id 用作 React key、查找键，以及 rewind 的数值边界（`h.id < userItem.id`）。严格递增保留了这些顺序与身份用途；id 不是墙钟时间戳。
- 未验证 / 超出范围：线上 #185 崩溃是概率性的；确定性测试已证明重复 id 机制，但重复 key → 渲染级联 → 实机崩溃的完整链条仍未得到端到端验证。本 PR 是否覆盖所有 #185 报告尚未证实——有报告者遇到过 2 次没有完成通知在途的崩溃，可能是别的驱动，因此 #11565 的守卫依然有价值。下界也会推进到已加载历史 id 之后；恢复记录本身的 id 生成逻辑未改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #11500——相关的通知 turn 崩溃报告；本 PR 尚不能证明该崩溃已完全解决。
Refs #11732——相关的心跳驱动崩溃报告；孤儿 monitor 生命周期不在本 PR 范围内。
Refs #11565——互补的环路守卫；根因分析credit 归 @vetaljanos。

</details>
